### PR TITLE
fix(chores): restore daily multi edit flow (#37)

### DIFF
--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -2740,7 +2740,10 @@ class ChoreManager(BaseManager):
                     return  # No due date to skip
 
                 self._reschedule_chore_next_due_date_for_assignee(
-                    chore_info, chore_id, assignee_id
+                    chore_info,
+                    chore_id,
+                    assignee_id,
+                    use_current_due_as_reference=True,
                 )
                 self._transition_chore_state(
                     assignee_id,
@@ -2753,7 +2756,10 @@ class ChoreManager(BaseManager):
                 reset_events.add((assignee_id, chore_id, chore_name))
             else:
                 # Skip all assigned assignees
-                self._reschedule_chore_next_due(chore_info)
+                self._reschedule_chore_next_due(
+                    chore_info,
+                    use_current_due_as_reference=True,
+                )
                 for assigned_assignee_id in chore_info.get(
                     const.DATA_CHORE_ASSIGNED_USER_IDS, []
                 ):
@@ -2762,7 +2768,10 @@ class ChoreManager(BaseManager):
                         and assigned_assignee_id in self._coordinator.assignees_data
                     ):
                         self._reschedule_chore_next_due_date_for_assignee(
-                            chore_info, chore_id, assigned_assignee_id
+                            chore_info,
+                            chore_id,
+                            assigned_assignee_id,
+                            use_current_due_as_reference=True,
                         )
                         self._transition_chore_state(
                             assigned_assignee_id,
@@ -2784,7 +2793,10 @@ class ChoreManager(BaseManager):
                         "entity": f"chore '{chore_info.get(const.DATA_CHORE_NAME, chore_id)}'",
                     },
                 )
-            self._reschedule_chore_next_due(chore_info)
+            self._reschedule_chore_next_due(
+                chore_info,
+                use_current_due_as_reference=True,
+            )
             for assigned_assignee_id in chore_info.get(
                 const.DATA_CHORE_ASSIGNED_USER_IDS, []
             ):
@@ -5554,7 +5566,12 @@ class ChoreManager(BaseManager):
             # SHARED/SHARED_FIRST: chore-level
             self._reschedule_chore_next_due(chore_info)
 
-    def _reschedule_chore_next_due(self, chore_info: ChoreData) -> None:
+    def _reschedule_chore_next_due(
+        self,
+        chore_info: ChoreData,
+        *,
+        use_current_due_as_reference: bool = False,
+    ) -> None:
         """Reschedule chore's next due date (chore-level for SHARED chores)."""
         due_date_str = chore_info.get(const.DATA_CHORE_DUE_DATE)
         if not due_date_str:
@@ -5579,12 +5596,23 @@ class ChoreManager(BaseManager):
         if last_completed_str:
             completion_utc = dt_to_utc(last_completed_str)
 
+        reference_time = dt_util.utcnow()
+        if (
+            use_current_due_as_reference
+            and chore_info.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+            == const.FREQUENCY_DAILY_MULTI
+        ):
+            reference_time = original_due_utc
+
         # Use schedule engine for calculation
         next_due_utc = calculate_next_due_date_from_chore_info(
             original_due_utc,
             chore_info,
             completion_timestamp=completion_utc,
-            reference_time=dt_util.utcnow(),
+            reference_time=reference_time,
         )
         if not next_due_utc:
             const.LOGGER.warning(
@@ -5616,7 +5644,12 @@ class ChoreManager(BaseManager):
         )
 
     def _reschedule_chore_next_due_date_for_assignee(
-        self, chore_info: ChoreData, chore_id: str, assignee_id: str
+        self,
+        chore_info: ChoreData,
+        chore_id: str,
+        assignee_id: str,
+        *,
+        use_current_due_as_reference: bool = False,
     ) -> None:
         """Reschedule per-assignee due date (INDEPENDENT mode).
 
@@ -5694,12 +5727,23 @@ class ChoreManager(BaseManager):
                 per_assignee_times[assignee_id]
             )
 
+        reference_time = dt_util.utcnow()
+        if (
+            use_current_due_as_reference
+            and chore_info_for_calc.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+            == const.FREQUENCY_DAILY_MULTI
+        ):
+            reference_time = original_due_utc
+
         # Use schedule engine
         next_due_utc = calculate_next_due_date_from_chore_info(
             original_due_utc,
             cast("ChoreData", chore_info_for_calc),
             completion_timestamp=completion_utc,
-            reference_time=dt_util.utcnow(),
+            reference_time=reference_time,
         )
         if not next_due_utc:
             const.LOGGER.warning(

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -27,7 +27,7 @@ from .utils.math_utils import parse_points_adjust_values
 
 if TYPE_CHECKING:
     from .helpers.dashboard_helpers import DashboardReleaseAssets
-    from .type_defs import BadgeData
+    from .type_defs import BadgeData, ChoreData
 
 # ----------------------------------------------------------------------------------
 # INITIALIZATION & HELPERS
@@ -249,6 +249,24 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             )
             for dependency_id in dependency_ids
         )
+
+    async def _async_route_to_daily_multi_helper(
+        self,
+        chore_data: "ChoreData | dict[str, Any]",
+        internal_id: str,
+        log_message: str,
+        *log_args: Any,
+        update_listeners: bool = False,
+    ) -> ConfigFlowResult:
+        """Store chore state and open the DAILY_MULTI times helper."""
+        self._chore_being_edited = dict(chore_data)
+        self._chore_being_edited[const.DATA_INTERNAL_ID] = internal_id
+
+        if update_listeners:
+            self._get_coordinator().async_update_listeners()
+
+        const.LOGGER.debug(log_message, *log_args)
+        return await self.async_step_chores_daily_multi()
 
     def _build_dashboard_template_preferences_markdown_lines(
         self,
@@ -683,14 +701,12 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
 
         # Retrieve HA users and existing assignees for linking
         users = await self.hass.auth.async_get_users()
-        # Build sorted assignment-participant dict for association dropdown.
         assignees_dict = {
             assignee_data[const.DATA_USER_NAME]: assignee_id
             for assignee_id, assignee_data in coordinator.assignees_data.items()
             if eh.is_user_assignment_participant(coordinator, assignee_id)
         }
-
-        user_schema = await fh.build_user_schema(
+        user_schema = fh.build_user_schema(
             self.hass, users=users, assignees_dict=assignees_dict
         )
 
@@ -1075,18 +1091,14 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
 
                     # CFE-2026-001 FIX: Single-assignee DAILY_MULTI without times
                     # needs to route to times helper (main form doesn't have times field)
-                    if (
-                        recurring_frequency == const.FREQUENCY_DAILY_MULTI
-                        and not template_daily_multi_times
-                    ):
-                        self._chore_being_edited = dict(final_chore)
-                        self._chore_being_edited[const.DATA_INTERNAL_ID] = internal_id
-                        const.LOGGER.debug(
+                    if recurring_frequency == const.FREQUENCY_DAILY_MULTI:
+                        return await self._async_route_to_daily_multi_helper(
+                            final_chore,
+                            internal_id,
                             "Added single-assignee INDEPENDENT DAILY_MULTI Chore '%s' "
                             "- routing to times helper",
                             chore_name,
                         )
-                        return await self.async_step_chores_daily_multi()
 
                     const.LOGGER.debug(
                         "Added single-assignee INDEPENDENT Chore '%s' with ID: %s",
@@ -1129,15 +1141,12 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                     immediate_persist=True,
                 )
 
-                # Store chore data for helper step
-                self._chore_being_edited = dict(new_chore_data)
-                self._chore_being_edited[const.DATA_INTERNAL_ID] = internal_id
-
-                const.LOGGER.debug(
+                return await self._async_route_to_daily_multi_helper(
+                    new_chore_data,
+                    internal_id,
                     "Added DAILY_MULTI Chore '%s' - routing to times helper",
                     chore_name,
                 )
-                return await self.async_step_chores_daily_multi()
 
             # Standard chore creation (SHARED/SHARED_FIRST or no special handling)
             # Use Manager-owned CRUD (prebuilt=True since new_chore_data is ready)
@@ -1402,25 +1411,14 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                         immediate_persist=True,
                     )
 
-                    # CFE-2026-001 FIX: Single-assignee DAILY_MULTI without times
-                    # needs to route to times helper (check per-assignee times too)
-                    existing_per_assignee_times = final_chore.get(
-                        const.DATA_CHORE_PER_ASSIGNEE_DAILY_MULTI_TIMES, {}
-                    )
-                    assignee_has_times = existing_per_assignee_times.get(assignee_id)
-                    if (
-                        recurring_freq == const.FREQUENCY_DAILY_MULTI
-                        and not template_daily_multi_times
-                        and not assignee_has_times
-                    ):
-                        # Store chore data with internal_id for times helper
-                        self._chore_being_edited = dict(final_chore)
-                        self._chore_being_edited[const.DATA_INTERNAL_ID] = internal_id
-                        const.LOGGER.debug(
-                            "Edited single-assignee INDEPENDENT chore to DAILY_MULTI "
-                            "- routing to times helper"
+                    if recurring_freq == const.FREQUENCY_DAILY_MULTI:
+                        return await self._async_route_to_daily_multi_helper(
+                            final_chore,
+                            str(internal_id),
+                            "Edited single-assignee INDEPENDENT DAILY_MULTI chore '%s' "
+                            "- routing to times helper",
+                            new_name,
                         )
-                        return await self.async_step_chores_daily_multi()
 
                     self._mark_reload_needed()
                     return await self.async_step_init()
@@ -1435,25 +1433,15 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 self._chore_template_daily_multi_times = template_daily_multi_times
                 return await self.async_step_edit_chore_per_user_details()
 
-            # CFE-2026-001: Check if DAILY_MULTI needs times collection/update
             recurring_frequency = merged_chore.get(const.DATA_CHORE_RECURRING_FREQUENCY)
-            existing_times = merged_chore.get(const.DATA_CHORE_DAILY_MULTI_TIMES, "")
-            if (
-                recurring_frequency == const.FREQUENCY_DAILY_MULTI
-                and not existing_times
-            ):
-                # DAILY_MULTI selected but no times yet - route to helper
-                # (already persisted above, just need to set up helper state)
-                self._chore_being_edited = dict(merged_chore)
-                coordinator.async_update_listeners()
-                # Orphan cleanup handled by ChoreManager CRUD methods (Phase 7.3)
-
-                self._chore_being_edited[const.DATA_INTERNAL_ID] = internal_id
-
-                const.LOGGER.debug(
-                    "Edited chore to DAILY_MULTI - routing to times helper"
+            if recurring_frequency == const.FREQUENCY_DAILY_MULTI:
+                return await self._async_route_to_daily_multi_helper(
+                    merged_chore,
+                    str(internal_id),
+                    "Edited DAILY_MULTI chore '%s' - routing to times helper",
+                    new_name,
+                    update_listeners=True,
                 )
-                return await self.async_step_chores_daily_multi()
 
             return await self.async_step_init()
 

--- a/tests/test_due_date_services_enhanced_frequencies.py
+++ b/tests/test_due_date_services_enhanced_frequencies.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from homeassistant.util import dt as dt_util
 import pytest
 
 from tests.helpers import (
@@ -208,6 +209,40 @@ class TestDailyMultiDueDateServices:
         )
 
     @pytest.mark.asyncio
+    async def test_dm_ind_repeated_skip_advances_between_slots(
+        self,
+        hass: HomeAssistant,
+        setup_enhanced_frequencies: SetupResult,
+    ) -> None:
+        """Repeated DAILY_MULTI skips should continue advancing slot by slot."""
+        coordinator = setup_enhanced_frequencies.coordinator
+        zoe_id = setup_enhanced_frequencies.assignee_ids["Zoë"]
+        chore_id = setup_enhanced_frequencies.chore_ids["Daily Multi Single Assignee"]
+
+        local_now = dt_util.as_local(dt_util.utcnow())
+        first_slot_local = local_now.replace(hour=9, minute=0, second=0, microsecond=0)
+        second_slot_local = local_now.replace(
+            hour=21, minute=0, second=0, microsecond=0
+        )
+        tomorrow_first_slot_local = first_slot_local + timedelta(days=1)
+
+        await coordinator.chore_manager.set_due_date(
+            chore_id,
+            first_slot_local.astimezone(UTC),
+            assignee_id=zoe_id,
+        )
+
+        await coordinator.chore_manager.skip_due_date(chore_id, assignee_id=zoe_id)
+        second_due = get_assignee_due_date_for_chore(coordinator, chore_id, zoe_id)
+        second_due_dt = parse_iso_datetime(second_due)
+        assert second_due_dt == second_slot_local.astimezone(UTC)
+
+        await coordinator.chore_manager.skip_due_date(chore_id, assignee_id=zoe_id)
+        third_due = get_assignee_due_date_for_chore(coordinator, chore_id, zoe_id)
+        third_due_dt = parse_iso_datetime(third_due)
+        assert third_due_dt == tomorrow_first_slot_local.astimezone(UTC)
+
+    @pytest.mark.asyncio
     async def test_dm_shared_set_daily_multi(
         self,
         hass: HomeAssistant,
@@ -290,6 +325,38 @@ class TestDailyMultiDueDateServices:
         assert new_dt != initial_dt, (
             f"Due date should have changed from {initial_dt} to something else"
         )
+
+    @pytest.mark.asyncio
+    async def test_dm_shared_repeated_skip_advances_between_slots(
+        self,
+        hass: HomeAssistant,
+        setup_enhanced_frequencies: SetupResult,
+    ) -> None:
+        """Repeated DAILY_MULTI skips should continue advancing shared slots."""
+        coordinator = setup_enhanced_frequencies.coordinator
+        chore_id = setup_enhanced_frequencies.chore_ids["Daily Multi Morning Evening"]
+
+        local_now = dt_util.as_local(dt_util.utcnow())
+        first_slot_local = local_now.replace(hour=7, minute=0, second=0, microsecond=0)
+        second_slot_local = local_now.replace(
+            hour=18, minute=0, second=0, microsecond=0
+        )
+        tomorrow_first_slot_local = first_slot_local + timedelta(days=1)
+
+        await coordinator.chore_manager.set_due_date(
+            chore_id,
+            first_slot_local.astimezone(UTC),
+        )
+
+        await coordinator.chore_manager.skip_due_date(chore_id)
+        second_due = get_chore_due_date(coordinator, chore_id)
+        second_due_dt = parse_iso_datetime(second_due)
+        assert second_due_dt == second_slot_local.astimezone(UTC)
+
+        await coordinator.chore_manager.skip_due_date(chore_id)
+        third_due = get_chore_due_date(coordinator, chore_id)
+        third_due_dt = parse_iso_datetime(third_due)
+        assert third_due_dt == tomorrow_first_slot_local.astimezone(UTC)
 
     @pytest.mark.asyncio
     async def test_dm_sf_set_daily_multi(

--- a/tests/test_options_flow_daily_multi.py
+++ b/tests/test_options_flow_daily_multi.py
@@ -414,6 +414,104 @@ class TestDailyMultiOptionsFlow:
         assert chore.get(const.DATA_CHORE_AUTO_APPROVE) is True
 
     @pytest.mark.asyncio
+    async def test_of_08_edit_existing_daily_multi_reopens_helper(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+    ) -> None:
+        """Editing an existing DAILY_MULTI chore should reopen the times helper."""
+        config_entry = scenario_minimal.config_entry
+        coordinator = scenario_minimal.coordinator
+        assignee_names = [k["name"] for k in coordinator.assignees_data.values()]
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        flow_id = result.get("flow_id")
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={OPTIONS_FLOW_INPUT_MENU_SELECTION: OPTIONS_FLOW_CHORES},
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={OPTIONS_FLOW_INPUT_MANAGE_ACTION: OPTIONS_FLOW_ACTIONS_ADD},
+        )
+
+        due_date = datetime.now(UTC) + timedelta(hours=3)
+        with patch.object(
+            coordinator.notification_manager, "notify_assignee", new=AsyncMock()
+        ):
+            result = await hass.config_entries.options.async_configure(
+                flow_id,  # type: ignore[arg-type]
+                user_input={
+                    CFOF_CHORES_INPUT_NAME: "OF08 Existing DailyMulti Edit",
+                    CFOF_CHORES_INPUT_DEFAULT_POINTS: 11,
+                    CFOF_CHORES_INPUT_ICON: "mdi:calendar-clock",
+                    CFOF_CHORES_INPUT_DESCRIPTION: "",
+                    CFOF_CHORES_INPUT_ASSIGNED_USER_IDS: assignee_names[:1],
+                    CFOF_CHORES_INPUT_RECURRING_FREQUENCY: FREQUENCY_DAILY_MULTI,
+                    CFOF_CHORES_INPUT_COMPLETION_CRITERIA: COMPLETION_CRITERIA_SHARED,
+                    CFOF_CHORES_INPUT_APPROVAL_RESET_TYPE: APPROVAL_RESET_UPON_COMPLETION,
+                    CFOF_CHORES_INPUT_DUE_DATE: due_date,
+                },
+            )
+
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_CHORES_DAILY_MULTI
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={CFOF_CHORES_INPUT_DAILY_MULTI_TIMES: "08:00|17:00"},
+        )
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_INIT
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        flow_id = result.get("flow_id")
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={OPTIONS_FLOW_INPUT_MENU_SELECTION: OPTIONS_FLOW_CHORES},
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={OPTIONS_FLOW_INPUT_MANAGE_ACTION: OPTIONS_FLOW_ACTIONS_EDIT},
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={
+                OPTIONS_FLOW_INPUT_ENTITY_NAME: "OF08 Existing DailyMulti Edit"
+            },
+        )
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_EDIT_CHORE
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={
+                CFOF_CHORES_INPUT_NAME: "OF08 Existing DailyMulti Edit",
+                CFOF_CHORES_INPUT_DESCRIPTION: "Updated via edit",
+                CFOF_CHORES_INPUT_RECURRING_FREQUENCY: FREQUENCY_DAILY_MULTI,
+            },
+        )
+
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_CHORES_DAILY_MULTI
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,  # type: ignore[arg-type]
+            user_input={CFOF_CHORES_INPUT_DAILY_MULTI_TIMES: "09:00|18:00"},
+        )
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_INIT
+
+        await hass.async_block_till_done()
+        coordinator = config_entry.runtime_data
+        chore = next(
+            (
+                c
+                for c in coordinator.chores_data.values()
+                if c["name"] == "OF08 Existing DailyMulti Edit"
+            ),
+            None,
+        )
+        assert chore is not None
+        assert chore.get(DATA_CHORE_DAILY_MULTI_TIMES) == "09:00|18:00"
+
+    @pytest.mark.asyncio
     async def test_of_04c_helper_form_validates_too_many_times(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary
- fix issue #37 by routing existing DAILY_MULTI chore edits back through the helper step
- add regression coverage for re-editing DAILY_MULTI chores through the options flow
- fix DAILY_MULTI `skip_due_date` repeated advancement after finding the regression during issue #37 testing
- add repeated-skip regression coverage for shared and independent DAILY_MULTI chores

## Validation
- `./utils/quick_lint.sh --fix`
- `pytest tests/test_workflow_chores.py tests/test_chore_crud_services.py tests/test_chore_scheduling.py tests/test_chore_state_matrix.py tests/test_chore_services.py tests/test_shared_chore_features.py tests/test_chore_manager.py tests/test_chore_engine.py tests/test_chore_missed_tracking.py tests/test_daily_multi_approval_reset.py tests/test_options_flow_daily_multi.py tests/test_due_date_services_enhanced_frequencies.py -v --tb=line`

Closes #37
