### PR TITLE
fix(chores): clear stale due dates on reset (#28)

### DIFF
--- a/custom_components/choreops/engines/chore_engine.py
+++ b/custom_components/choreops/engines/chore_engine.py
@@ -1440,10 +1440,12 @@ class ChoreEngine:
         Returns:
             Action string:
             - "reset_and_reschedule": Reset state + calculate next due date
-            - "reset_only": Reset state without rescheduling (no due date)
+            - "reset_only": Reset state without rescheduling
             - "hold": Skip processing, preserve current state
             - "skip": No action needed (already PENDING or non-recurring approved)
         """
+        should_reschedule = has_due_date and recurring_frequency != const.FREQUENCY_NONE
+
         # PENDING state = nothing to do
         if current_state == const.CHORE_STATE_PENDING:
             return "skip"
@@ -1452,7 +1454,7 @@ class ChoreEngine:
         # Note: Non-recurring chores with AT_MIDNIGHT_* still reset at midnight.
         # The approval_reset_type determines WHEN resets happen, not frequency.
         if current_state == const.CHORE_STATE_APPROVED:
-            return "reset_and_reschedule" if has_due_date else "reset_only"
+            return "reset_and_reschedule" if should_reschedule else "reset_only"
 
         # CLAIMED state = check pending_claims_handling
         if current_state == const.CHORE_STATE_CLAIMED:
@@ -1460,7 +1462,7 @@ class ChoreEngine:
                 return "hold"
             # CLEAR and AUTO_APPROVE both proceed with reset
             # (AUTO_APPROVE approval is handled by the manager, not engine)
-            return "reset_and_reschedule" if has_due_date else "reset_only"
+            return "reset_and_reschedule" if should_reschedule else "reset_only"
 
         # OVERDUE state = check overdue_handling
         if current_state == const.CHORE_STATE_OVERDUE:
@@ -1472,13 +1474,13 @@ class ChoreEngine:
                 overdue_handling
                 == const.OVERDUE_HANDLING_AT_DUE_DATE_CLEAR_AT_APPROVAL_RESET
             ):
-                return "reset_and_reschedule" if has_due_date else "reset_only"
+                return "reset_and_reschedule" if should_reschedule else "reset_only"
             # CLEAR_AND_MARK_MISSED = record miss then reset
             if (
                 overdue_handling
                 == const.OVERDUE_HANDLING_AT_DUE_DATE_CLEAR_AND_MARK_MISSED
             ):
-                return "reset_and_reschedule" if has_due_date else "reset_only"
+                return "reset_and_reschedule" if should_reschedule else "reset_only"
             # CLEAR_IMMEDIATE_ON_LATE = already handled when due passed, skip
             if (
                 overdue_handling
@@ -1497,7 +1499,7 @@ class ChoreEngine:
                 overdue_handling
                 == const.OVERDUE_HANDLING_AT_DUE_DATE_MARK_MISSED_AND_LOCK
             ):
-                return "reset_and_reschedule" if has_due_date else "reset_only"
+                return "reset_and_reschedule" if should_reschedule else "reset_only"
             return "skip"
 
         # Default: skip unknown states

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -1577,6 +1577,7 @@ class ChoreManager(BaseManager):
         decision = context["decision"]
         reschedule_assignee_id = context["reschedule_assignee_id"]
         allow_reschedule = context.get("allow_reschedule", True)
+        clear_due_date = context.get("clear_due_date", False)
 
         self._transition_chore_state(
             assignee_id,
@@ -1586,11 +1587,59 @@ class ChoreManager(BaseManager):
             clear_ownership=True,
         )
 
+        if clear_due_date:
+            self._clear_due_date_after_reset(
+                chore_id,
+                assignee_id if allow_reschedule else None,
+            )
+
         if (
-            allow_reschedule
+            not clear_due_date
+            and allow_reschedule
             and decision == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
         ):
             self._reschedule_chore_due(chore_id, reschedule_assignee_id)
+
+    def _clear_due_date_after_reset(
+        self,
+        chore_id: str,
+        assignee_id: str | None = None,
+    ) -> None:
+        """Clear stale due date data after a fresh-cycle reset."""
+        chore_info = self._coordinator.chores_data.get(chore_id)
+        if not chore_info:
+            return
+
+        if (
+            chore_info.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+            != const.FREQUENCY_NONE
+        ):
+            return
+
+        completion_criteria = chore_info.get(
+            const.DATA_CHORE_COMPLETION_CRITERIA,
+            const.COMPLETION_CRITERIA_SHARED,
+        )
+        if completion_criteria == const.COMPLETION_CRITERIA_INDEPENDENT:
+            per_assignee_due_dates = chore_info.get(
+                const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
+                {},
+            )
+            if assignee_id is None:
+                per_assignee_due_dates.clear()
+            else:
+                per_assignee_due_dates.pop(assignee_id, None)
+            chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = per_assignee_due_dates
+        else:
+            chore_info.pop(const.DATA_CHORE_DUE_DATE, None)
+
+        const.LOGGER.debug(
+            "Cleared stale due date for non-recurring chore %s after fresh-cycle reset",
+            chore_id,
+        )
 
     def _finalize_reset_batch(
         self,
@@ -2359,6 +2408,29 @@ class ChoreManager(BaseManager):
             else:
                 effective_decision = const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
 
+        completion_criteria = chore_info.get(
+            const.DATA_CHORE_COMPLETION_CRITERIA,
+            const.COMPLETION_CRITERIA_SHARED,
+        )
+        due_assignee_id = (
+            assignee_id
+            if completion_criteria == const.COMPLETION_CRITERIA_INDEPENDENT
+            else None
+        )
+        should_clear_due_date = (
+            chore_info.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+            == const.FREQUENCY_NONE
+            and self.get_due_date(chore_id, due_assignee_id) is not None
+            and effective_decision
+            in (
+                const.CHORE_RESET_DECISION_RESET_ONLY,
+                const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE,
+            )
+        )
+
         overdue_handling = chore_info.get(
             const.DATA_CHORE_OVERDUE_HANDLING_TYPE,
             const.DEFAULT_OVERDUE_HANDLING_TYPE,
@@ -2413,11 +2485,13 @@ class ChoreManager(BaseManager):
                 "decision": effective_decision,
                 "reschedule_assignee_id": reschedule_assignee_id,
                 "allow_reschedule": allow_reschedule,
+                "clear_due_date": should_clear_due_date,
             }
         )
 
         should_reschedule_shared = (
-            not allow_reschedule
+            not should_clear_due_date
+            and not allow_reschedule
             and effective_decision == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
         )
         return True, should_reschedule_shared

--- a/custom_components/choreops/type_defs.py
+++ b/custom_components/choreops/type_defs.py
@@ -309,6 +309,7 @@ class ResetApplyContext(TypedDict, total=False):
     decision: ResetDecision
     reschedule_assignee_id: str | None
     allow_reschedule: bool
+    clear_due_date: bool
 
 
 # =============================================================================

--- a/tests/test_chore_engine.py
+++ b/tests/test_chore_engine.py
@@ -1112,13 +1112,8 @@ class TestCalculateBoundaryAction:
         )
         assert result == "reset_only"
 
-    def test_approved_non_recurring_with_due_date_resets_and_reschedules(self) -> None:
-        """Non-recurring APPROVED chore resets based on approval_reset_type.
-
-        Even for non-recurring chores, APPROVED state resets at the boundary.
-        The approval_reset_type (AT_MIDNIGHT_*, AT_DUE_DATE_*) determines
-        WHEN resets happen, not recurring_frequency.
-        """
+    def test_approved_non_recurring_with_due_date_resets_only(self) -> None:
+        """Non-recurring APPROVED chore resets without rescheduling."""
         result = ChoreEngine.calculate_boundary_action(
             current_state=const.CHORE_STATE_APPROVED,
             overdue_handling=const.OVERDUE_HANDLING_AT_DUE_DATE,
@@ -1126,7 +1121,18 @@ class TestCalculateBoundaryAction:
             recurring_frequency=const.FREQUENCY_NONE,
             has_due_date=True,
         )
-        assert result == "reset_and_reschedule"
+        assert result == "reset_only"
+
+    def test_claimed_non_recurring_with_due_date_resets_only(self) -> None:
+        """Non-recurring CLAIMED chore resets without rescheduling."""
+        result = ChoreEngine.calculate_boundary_action(
+            current_state=const.CHORE_STATE_CLAIMED,
+            overdue_handling=const.OVERDUE_HANDLING_AT_DUE_DATE,
+            pending_claims_handling=const.APPROVAL_RESET_PENDING_CLAIM_CLEAR,
+            recurring_frequency=const.FREQUENCY_NONE,
+            has_due_date=True,
+        )
+        assert result == "reset_only"
 
     def test_approved_non_recurring_without_due_date_resets_only(self) -> None:
         """Non-recurring APPROVED chore without due date → reset_only."""
@@ -1221,6 +1227,19 @@ class TestCalculateBoundaryAction:
             pending_claims_handling=const.APPROVAL_RESET_PENDING_CLAIM_CLEAR,
             recurring_frequency=const.FREQUENCY_DAILY,
             has_due_date=False,
+        )
+        assert result == "reset_only"
+
+    def test_overdue_non_recurring_clear_at_reset_with_due_date_resets_only(
+        self,
+    ) -> None:
+        """Non-recurring OVERDUE chore clears at boundary without rescheduling."""
+        result = ChoreEngine.calculate_boundary_action(
+            current_state=const.CHORE_STATE_OVERDUE,
+            overdue_handling=const.OVERDUE_HANDLING_AT_DUE_DATE_CLEAR_AT_APPROVAL_RESET,
+            pending_claims_handling=const.APPROVAL_RESET_PENDING_CLAIM_CLEAR,
+            recurring_frequency=const.FREQUENCY_NONE,
+            has_due_date=True,
         )
         assert result == "reset_only"
 
@@ -1380,6 +1399,34 @@ class TestGetBoundaryCategory:
             chore_data, const.CHORE_STATE_APPROVED, "midnight"
         )
         assert result == "reset_and_reschedule"
+
+    def test_non_recurring_shared_due_date_returns_reset_only(self) -> None:
+        """Non-recurring shared chore with due date resets without rescheduling."""
+        chore_data = {
+            const.DATA_CHORE_APPROVAL_RESET_TYPE: const.APPROVAL_RESET_AT_MIDNIGHT_ONCE,
+            const.DATA_CHORE_RECURRING_FREQUENCY: const.FREQUENCY_NONE,
+            const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_SHARED,
+            const.DATA_CHORE_DUE_DATE: "2025-01-31T10:00:00",
+        }
+        result = ChoreEngine.get_boundary_category(
+            chore_data, const.CHORE_STATE_APPROVED, "midnight"
+        )
+        assert result == "reset_only"
+
+    def test_non_recurring_independent_due_date_returns_reset_only(self) -> None:
+        """Non-recurring independent chore with due date resets without rescheduling."""
+        chore_data = {
+            const.DATA_CHORE_APPROVAL_RESET_TYPE: const.APPROVAL_RESET_AT_MIDNIGHT_ONCE,
+            const.DATA_CHORE_RECURRING_FREQUENCY: const.FREQUENCY_NONE,
+            const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_INDEPENDENT,
+            const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES: {
+                "assignee-1": "2025-01-31T10:00:00"
+            },
+        }
+        result = ChoreEngine.get_boundary_category(
+            chore_data, const.CHORE_STATE_APPROVED, "midnight"
+        )
+        assert result == "reset_only"
 
     def test_shared_chore_without_due_date_resets_only(self) -> None:
         """SHARED chore without due_date → reset_only."""

--- a/tests/test_chore_manager.py
+++ b/tests/test_chore_manager.py
@@ -275,6 +275,76 @@ class TestTimeScanCache:
         assert len(scan[const.CHORE_SCAN_RESULT_APPROVAL_RESET_SHARED]) == 1
         assert len(scan[const.CHORE_SCAN_RESULT_APPROVAL_RESET_INDEPENDENT]) == 0
 
+    @pytest.mark.asyncio
+    async def test_midnight_rollover_resets_daily_shared_without_due_date(
+        self,
+        chore_manager: ChoreManager,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Daily shared chores without due dates should reset at midnight."""
+        chore = mock_coordinator.chores_data["chore-1"]
+        chore[const.DATA_CHORE_COMPLETION_CRITERIA] = const.COMPLETION_CRITERIA_SHARED
+        chore[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+            const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+        )
+        chore[const.DATA_CHORE_RECURRING_FREQUENCY] = const.FREQUENCY_DAILY
+        chore.pop(const.DATA_CHORE_DUE_DATE, None)
+        mock_coordinator._data[const.DATA_CHORES]["chore-1"] = chore
+
+        for assignee_id in ("assignee-1", "assignee-2"):
+            mock_coordinator.assignees_data[assignee_id][const.DATA_USER_CHORE_DATA][
+                "chore-1"
+            ] = {const.DATA_USER_CHORE_DATA_STATE: const.CHORE_STATE_APPROVED}
+
+        reset_count = await chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+
+        assert reset_count == 2
+        for assignee_id in ("assignee-1", "assignee-2"):
+            assignee_chore_data = mock_coordinator.assignees_data[assignee_id][
+                const.DATA_USER_CHORE_DATA
+            ]["chore-1"]
+            assert (
+                assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE]
+                == const.CHORE_STATE_PENDING
+            )
+
+    @pytest.mark.asyncio
+    async def test_midnight_rollover_resets_daily_independent_without_due_date(
+        self,
+        chore_manager: ChoreManager,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Daily independent chores without due dates should reset at midnight."""
+        chore = mock_coordinator.chores_data["chore-1"]
+        chore[const.DATA_CHORE_COMPLETION_CRITERIA] = (
+            const.COMPLETION_CRITERIA_INDEPENDENT
+        )
+        chore[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+            const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+        )
+        chore[const.DATA_CHORE_RECURRING_FREQUENCY] = const.FREQUENCY_DAILY
+        chore.pop(const.DATA_CHORE_DUE_DATE, None)
+        chore[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {}
+        mock_coordinator._data[const.DATA_CHORES]["chore-1"] = chore
+
+        mock_coordinator.assignees_data["assignee-1"][const.DATA_USER_CHORE_DATA][
+            "chore-1"
+        ] = {const.DATA_USER_CHORE_DATA_STATE: const.CHORE_STATE_APPROVED}
+        mock_coordinator.assignees_data["assignee-2"][const.DATA_USER_CHORE_DATA][
+            "chore-1"
+        ] = {const.DATA_USER_CHORE_DATA_STATE: const.CHORE_STATE_PENDING}
+
+        reset_count = await chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+
+        assert reset_count == 1
+        assignee_one_chore_data = mock_coordinator.assignees_data["assignee-1"][
+            const.DATA_USER_CHORE_DATA
+        ]["chore-1"]
+        assert (
+            assignee_one_chore_data[const.DATA_USER_CHORE_DATA_STATE]
+            == const.CHORE_STATE_PENDING
+        )
+
 
 class TestResetPolicyDecision:
     """Table-driven tests for reset policy decision helper."""
@@ -538,6 +608,35 @@ class TestResetExecutor:
         chore_manager._transition_chore_state.assert_called_once()
         chore_manager._reschedule_chore_due.assert_not_called()
 
+    def test_apply_reset_action_clears_due_date_for_non_recurring_reset(
+        self,
+        chore_manager: ChoreManager,
+    ) -> None:
+        """Executor clears stale due date instead of rescheduling non-recurring chore."""
+        chore_info = chore_manager._coordinator.chores_data["chore-1"]
+        chore_info[const.DATA_CHORE_COMPLETION_CRITERIA] = (
+            const.COMPLETION_CRITERIA_SHARED
+        )
+        chore_info[const.DATA_CHORE_RECURRING_FREQUENCY] = const.FREQUENCY_NONE
+        chore_info[const.DATA_CHORE_DUE_DATE] = "2025-01-31T10:00:00+00:00"
+
+        chore_manager._transition_chore_state = MagicMock()
+        chore_manager._reschedule_chore_due = MagicMock()
+
+        chore_manager._apply_reset_action(
+            {
+                "assignee_id": "assignee-1",
+                "chore_id": "chore-1",
+                "decision": const.CHORE_RESET_DECISION_RESET_ONLY,
+                "reschedule_assignee_id": None,
+                "allow_reschedule": False,
+                "clear_due_date": True,
+            }
+        )
+
+        assert const.DATA_CHORE_DUE_DATE not in chore_info
+        chore_manager._reschedule_chore_due.assert_not_called()
+
     def test_finalize_reset_batch_persist_then_emit(
         self,
         chore_manager: ChoreManager,
@@ -743,8 +842,72 @@ class TestResetExecutor:
                 "decision": const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE,
                 "reschedule_assignee_id": "assignee-1",
                 "allow_reschedule": True,
+                "clear_due_date": False,
             }
         )
+
+    @pytest.mark.asyncio
+    async def test_process_approval_reset_entries_non_recurring_shared_clears_due_date(
+        self,
+        chore_manager: ChoreManager,
+        mock_coordinator: MagicMock,
+    ) -> None:
+        """Boundary reset clears stale due date for non-recurring shared chore."""
+        chore_info = {
+            const.DATA_CHORE_ASSIGNED_USER_IDS: ["assignee-1", "assignee-2"],
+            const.DATA_CHORE_STATE: const.CHORE_STATE_APPROVED,
+            const.DATA_CHORE_APPROVAL_RESET_PENDING_CLAIM_ACTION: (
+                const.APPROVAL_RESET_PENDING_CLAIM_CLEAR
+            ),
+            const.DATA_CHORE_APPROVAL_RESET_TYPE: const.APPROVAL_RESET_AT_DUE_DATE_ONCE,
+            const.DATA_CHORE_OVERDUE_HANDLING_TYPE: const.DEFAULT_OVERDUE_HANDLING_TYPE,
+            const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_SHARED,
+            const.DATA_CHORE_RECURRING_FREQUENCY: const.FREQUENCY_NONE,
+            const.DATA_CHORE_DUE_DATE: "2025-01-31T10:00:00+00:00",
+        }
+        mock_coordinator.chores_data["chore-1"] = chore_info
+        mock_coordinator._data[const.DATA_CHORES]["chore-1"] = chore_info
+
+        for assignee_id in ("assignee-1", "assignee-2"):
+            mock_coordinator.assignees_data[assignee_id][const.DATA_USER_CHORE_DATA][
+                "chore-1"
+            ] = {const.DATA_USER_CHORE_DATA_STATE: const.CHORE_STATE_APPROVED}
+
+        chore_manager._reschedule_chore_due = MagicMock()
+        chore_manager._coordinator._persist = MagicMock()
+        chore_manager._coordinator.async_set_updated_data = MagicMock()
+
+        scan: dict[str, list[dict[str, Any]]] = {
+            const.CHORE_SCAN_RESULT_APPROVAL_RESET_SHARED: [
+                {
+                    const.CHORE_SCAN_ENTRY_CHORE_ID: "chore-1",
+                    const.CHORE_SCAN_ENTRY_CHORE_INFO: chore_info,
+                }
+            ],
+            const.CHORE_SCAN_RESULT_APPROVAL_RESET_INDEPENDENT: [],
+        }
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            monkeypatch.setattr(
+                "custom_components.choreops.managers.chore_manager.ChoreEngine.get_boundary_category",
+                lambda **_kwargs: const.CHORE_RESET_BOUNDARY_CATEGORY_CLEAR_ONLY,
+            )
+
+            (
+                reset_count,
+                reset_pairs,
+            ) = await chore_manager._process_approval_reset_entries(
+                scan,
+                dt_now_utc(),
+                trigger=const.CHORE_SCAN_TRIGGER_DUE_DATE,
+                persist=True,
+            )
+
+        assert reset_count == 2
+        assert ("assignee-1", "chore-1") in reset_pairs
+        assert ("assignee-2", "chore-1") in reset_pairs
+        assert const.DATA_CHORE_DUE_DATE not in chore_info
+        chore_manager._reschedule_chore_due.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_rotation_boundary_advances_once_for_missed_turn_holder(
@@ -1055,6 +1218,8 @@ class TestApprovalResetExecutorLane:
         periodic_payload = chore_manager._apply_reset_action.call_args.args[0]
         periodic_payload.setdefault("allow_reschedule", True)
         approval_payload.setdefault("allow_reschedule", True)
+        periodic_payload.setdefault("clear_due_date", False)
+        approval_payload.setdefault("clear_due_date", False)
         assert periodic_payload == approval_payload
 
     @pytest.mark.asyncio
@@ -1130,6 +1295,12 @@ class TestApprovalResetExecutorLane:
         periodic_payloads = [
             call.args[0] for call in chore_manager._apply_reset_action.call_args_list
         ]
+        for periodic_payload in periodic_payloads:
+            periodic_payload.setdefault("allow_reschedule", False)
+            periodic_payload.setdefault("clear_due_date", False)
+        for approval_payload in approval_payloads:
+            approval_payload.setdefault("allow_reschedule", False)
+            approval_payload.setdefault("clear_due_date", False)
         assert periodic_payloads == approval_payloads
 
 


### PR DESCRIPTION
## Summary
- clear stale due dates after fresh-cycle resets for non-recurring chores
- stop approval boundary resets from rescheduling `FREQUENCY_NONE` chores
- add regression coverage for issue #28 and daily no-due-date midnight resets

## Testing
- `python -m pytest tests/test_chore_engine.py tests/test_chore_manager.py -q`
- `./utils/quick_lint.sh --fix`

Closes #28
