### PR TITLE
fix(dashboard): restore admin UI toggles (#31)

### DIFF
--- a/custom_components/choreops/managers/user_manager.py
+++ b/custom_components/choreops/managers/user_manager.py
@@ -485,28 +485,14 @@ class UserManager(BaseManager):
         for segment in segments[:-1]:
             child = current.get(segment)
             if not isinstance(child, dict):
-                raise HomeAssistantError(
-                    translation_domain=const.DOMAIN,
-                    translation_key=const.TRANS_KEY_ERROR_UI_CONTROL_KEY_NOT_FOUND,
-                    translation_placeholders={
-                        "key": key_path,
-                        "user_name": target_label,
-                    },
-                )
+                return
 
             parents.append((current, segment))
             current = child
 
         leaf_key = segments[-1]
         if leaf_key not in current:
-            raise HomeAssistantError(
-                translation_domain=const.DOMAIN,
-                translation_key=const.TRANS_KEY_ERROR_UI_CONTROL_KEY_NOT_FOUND,
-                translation_placeholders={
-                    "key": key_path,
-                    "user_name": target_label,
-                },
-            )
+            return
 
         del current[leaf_key]
 

--- a/tests/test_ui_control_services.py
+++ b/tests/test_ui_control_services.py
@@ -294,6 +294,44 @@ class TestManageUiControlService:
         assert _get_helper_ui_control(hass, "zoe") == {}
 
     @pytest.mark.asyncio
+    async def test_remove_missing_key_is_noop(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Remove should treat a missing key as a no-op for dashboard resets."""
+        user_id = scenario_full.assignee_ids["Zoë"]
+
+        response = await hass.services.async_call(
+            const.DOMAIN,
+            const.SERVICE_MANAGE_UI_CONTROL,
+            {
+                const.SERVICE_FIELD_USER_ID: user_id,
+                const.SERVICE_FIELD_UI_CONTROL_ACTION: const.UI_CONTROL_ACTION_REMOVE,
+                const.SERVICE_FIELD_UI_CONTROL_KEY: REWARDS_HEADER_COLLAPSE_KEY,
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+        await hass.async_block_till_done()
+
+        assert response["cleared_all"] is False
+        assert response[const.SERVICE_FIELD_UI_CONTROL_TARGET] == (
+            const.UI_CONTROL_TARGET_USER
+        )
+        assert response[const.SERVICE_FIELD_UI_CONTROL_KEY] == (
+            REWARDS_HEADER_COLLAPSE_KEY
+        )
+        assert (
+            scenario_full.coordinator.assignees_data[user_id][
+                const.DATA_USER_UI_PREFERENCES
+            ]
+            == {}
+        )
+        assert _get_helper_ui_control(hass, "zoe") == {}
+
+    @pytest.mark.asyncio
     async def test_requires_user_target(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary
- make dashboard UI-control removals idempotent when no stored key exists yet
- add regression coverage for the first-use reset path that was breaking admin dashboard interactions

## Validation
- ./utils/quick_lint.sh --fix custom_components/choreops/managers/user_manager.py tests/test_ui_control_services.py
- python -m pytest tests/test_ui_control_services.py -v --tb=line

Fixes #31
