### PR TITLE
fix(calendar): align rendering and descriptions (#45)

### DIFF
--- a/custom_components/choreops/calendar.py
+++ b/custom_components/choreops/calendar.py
@@ -29,6 +29,7 @@ from .helpers.entity_helpers import (
     get_event_signal,
     should_create_entity_for_user_assignee,
 )
+from .helpers.translation_helpers import load_dashboard_translation
 from .type_defs import ChoreData
 from .utils.dt_utils import dt_now_local, dt_parse
 
@@ -121,6 +122,7 @@ class AssigneeScheduleCalendar(CalendarEntity):
             tuple[str, int, str, tuple[int, ...], str], RecurrenceEngine
         ] = {}
         self._rrule_cache: dict[tuple[str, int, str, tuple[int, ...], str], str] = {}
+        self._dashboard_translations: dict[str, str] = {}
 
     def _get_timed_event_bounds(
         self,
@@ -136,6 +138,16 @@ class AssigneeScheduleCalendar(CalendarEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to mutation signals that invalidate calendar caches."""
         await super().async_added_to_hass()
+
+        assignee_info = self.coordinator.assignees_data.get(self._assignee_id, {})
+        dashboard_language = assignee_info.get(
+            const.DATA_USER_DASHBOARD_LANGUAGE,
+            const.DEFAULT_DASHBOARD_LANGUAGE,
+        )
+        self._dashboard_translations = await load_dashboard_translation(
+            self.hass,
+            dashboard_language,
+        )
 
         invalidation_signals = (
             const.SIGNAL_SUFFIX_CHORE_CREATED,
@@ -361,6 +373,83 @@ class AssigneeScheduleCalendar(CalendarEntity):
 
         # SHARED chores: use chore-level
         return chore.get(const.DATA_CHORE_APPLICABLE_DAYS, [])
+
+    def _translate_dashboard_value(self, key: str, fallback: str) -> str:
+        """Translate a dashboard key with fallback text."""
+        return self._dashboard_translations.get(key, fallback)
+
+    def _get_assignee_names_for_chore(self, chore: dict) -> str:
+        """Return a user-facing assignee label for the chore."""
+        assigned_user_ids = chore.get(const.DATA_CHORE_ASSIGNED_USER_IDS, [])
+        if not assigned_user_ids:
+            return self._assignee_name
+
+        assignee_names: list[str] = []
+        for assignee_id in assigned_user_ids:
+            assignee_info = self.coordinator.assignees_data.get(assignee_id, {})
+            assignee_names.append(
+                assignee_info.get(
+                    const.DATA_USER_NAME,
+                    f"{const.TRANS_KEY_LABEL_ASSIGNEE} {assignee_id}",
+                )
+            )
+
+        return ", ".join(assignee_names)
+
+    def _build_chore_description(self, chore: dict) -> str:
+        """Build a localized calendar description for a chore event."""
+        description = str(
+            chore.get(const.DATA_CHORE_DESCRIPTION, const.SENTINEL_EMPTY)
+        ).strip()
+        assigned_to_label = self._translate_dashboard_value(
+            "assigned_to",
+            const.LABEL_ASSIGNEE,
+        )
+        recurrence_label = self._translate_dashboard_value(
+            "recurrence",
+            "Recurrence",
+        )
+        completion_label = self._translate_dashboard_value(
+            "completion_criteria",
+            "Completion Type",
+        )
+
+        recurring = str(
+            chore.get(const.DATA_CHORE_RECURRING_FREQUENCY, const.FREQUENCY_NONE)
+        )
+        recurring_display = self._translate_dashboard_value(recurring, recurring)
+
+        completion_criteria = str(
+            chore.get(
+                const.DATA_CHORE_COMPLETION_CRITERIA,
+                const.COMPLETION_CRITERIA_SHARED,
+            )
+        )
+        completion_display = self._translate_dashboard_value(
+            completion_criteria,
+            completion_criteria,
+        )
+
+        points_label = str(
+            self._config_entry.options.get(
+                const.CONF_POINTS_LABEL,
+                const.DEFAULT_POINTS_LABEL,
+            )
+        )
+        points_value = chore.get(const.DATA_CHORE_DEFAULT_POINTS)
+
+        detail_lines = [
+            f"{assigned_to_label}: {self._get_assignee_names_for_chore(chore)}",
+            f"{recurrence_label}: {recurring_display}",
+            f"{completion_label}: {completion_display}",
+        ]
+        if points_value is not None:
+            detail_lines.append(f"{points_label}: {points_value}")
+
+        detail_summary = " | ".join(detail_lines)
+        if description:
+            return f"{description} | {detail_summary}"
+        return detail_summary
 
     def _generate_non_recurring_with_due_date(
         self,
@@ -889,7 +978,7 @@ class AssigneeScheduleCalendar(CalendarEntity):
         summary = chore.get(
             const.DATA_CHORE_NAME, const.TRANS_KEY_DISPLAY_UNKNOWN_CHORE
         )
-        description = chore.get(const.DATA_CHORE_DESCRIPTION, const.SENTINEL_EMPTY)
+        description = self._build_chore_description(chore)
         recurring = chore.get(
             const.DATA_CHORE_RECURRING_FREQUENCY, const.FREQUENCY_NONE
         )

--- a/tests/test_calendar_daily_limiter.py
+++ b/tests/test_calendar_daily_limiter.py
@@ -16,10 +16,21 @@ def _build_calendar(duration_days: int) -> AssigneeScheduleCalendar:
     calendar = object.__new__(AssigneeScheduleCalendar)
     calendar._calendar_duration = datetime.timedelta(days=duration_days)
     calendar._assignee_id = "assignee-1"
+    calendar._assignee_name = "Leo"
     calendar._events_cache = {}
     calendar._max_cache_entries = 8
     calendar._recurrence_engine_cache = {}
     calendar._rrule_cache = {}
+    calendar._dashboard_translations = {}
+    calendar._config_entry = type(
+        "FakeConfigEntry",
+        (),
+        {
+            "options": {
+                const.CONF_POINTS_LABEL: "Stars",
+            }
+        },
+    )()
     return calendar
 
 
@@ -44,8 +55,49 @@ def _attach_fake_coordinator(calendar: AssigneeScheduleCalendar) -> None:
             "chores_data": {},
             "challenges_data": {},
             "chore_manager": fake_manager,
+            "assignees_data": {
+                "assignee-1": {
+                    const.DATA_USER_NAME: "Leo",
+                    const.DATA_USER_DASHBOARD_LANGUAGE: "en",
+                },
+                "assignee-2": {
+                    const.DATA_USER_NAME: "Mia",
+                    const.DATA_USER_DASHBOARD_LANGUAGE: "en",
+                },
+            },
         },
     )()
+
+
+def test_build_chore_description_enriches_existing_text() -> None:
+    """Calendar descriptions use a compact localized single-line format."""
+    calendar = _build_calendar(30)
+    _attach_fake_coordinator(calendar)
+    calendar._dashboard_translations = {
+        "assigned_to": "Assigned To",
+        "recurrence": "Recurrence",
+        "completion_criteria": "Completion Type",
+        const.FREQUENCY_WEEKLY: "Weekly",
+        const.COMPLETION_CRITERIA_SHARED: "Shared (All)",
+    }
+
+    chore = {
+        const.DATA_CHORE_DESCRIPTION: "Roll the bins to the curb.",
+        const.DATA_CHORE_ASSIGNED_USER_IDS: ["assignee-1", "assignee-2"],
+        const.DATA_CHORE_RECURRING_FREQUENCY: const.FREQUENCY_WEEKLY,
+        const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_SHARED,
+        const.DATA_CHORE_DEFAULT_POINTS: 5,
+    }
+
+    description = calendar._build_chore_description(chore)
+
+    assert description == (
+        "Roll the bins to the curb. | "
+        "Assigned To: Leo, Mia | "
+        "Recurrence: Weekly | "
+        "Completion Type: Shared (All) | "
+        "Stars: 5"
+    )
 
 
 def test_daily_window_end_uses_one_third_horizon() -> None:


### PR DESCRIPTION
## Summary

- Fixes #45 by making calendar recurrence rendering use the schedule source of truth
- Adds localized compact calendar descriptions using the assignee dashboard language
- Preserves existing event titles while improving event detail text for popup rendering

## Validation

- python -m pytest tests/test_calendar_daily_limiter.py -v --tb=line
- ./utils/quick_lint.sh --fix custom_components/choreops/calendar.py tests/test_calendar_daily_limiter.py
