### PR TITLE
docs(process): codify main merge automation rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@
 
 - Closes #
 
+## Main merge automation checks
+
+- [ ] PR body uses a closing keyword when applicable (`Closes #...`)
+- [ ] Correct release-note label is applied for `.github/release.yml` categorization
+- [ ] Excluded triage or status labels have been removed before merge
+- [ ] PR title is suitable for generated release notes
+
 ## Change type
 
 - [ ] Bug fix
@@ -46,6 +53,8 @@
 
 - [ ] No release notes needed
 - [ ] Release notes needed (summarize user-visible changes below)
+
+- Release note summary:
 
 ## Breaking changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,19 @@ python -m pytest tests/ -v --tb=line  # All tests pass
 
 **Error Recovery**: If `mypy` fails more than twice on the same error, STOP and ask for clarification. Do NOT suppress with `# type: ignore`.
 
+## 🔀 Main Merge Readiness
+
+Before declaring work ready for merge to `main`, verify the workflow metadata required by release automation:
+
+- The change is going through a PR to `main`, not a direct push
+- The PR body includes `Closes #...` when the work resolves an issue
+- The PR has the correct release-note category label from `.github/release.yml`
+- Excluded labels such as `needs-triage`, `needs-info`, or blocked/in-progress status labels are removed
+- The PR title is release-note friendly
+- Validation run is recorded in the PR
+
+Use `docs/DEVELOPMENT_STANDARDS.md` as the canonical policy. Do not invent alternate merge rules in agent responses.
+
 ## ⚡ Core Principles (Follow These First)
 
 ### 1. No Hardcoded Strings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,18 @@ If your change only affects a narrow area, you may run a targeted test suite, bu
 - Note documentation impact (README/wiki/docs)
 - Call out breaking changes and migration impact when relevant
 
+## Before merging to main
+
+Use a pull request to `main` so automation can close issues and categorize release notes.
+
+- Include a closing keyword in the PR body when applicable (`Closes #...`)
+- Apply the correct release-note label for the change type
+- Remove excluded triage or status labels before merge
+- Use a release-note-friendly PR title
+- Complete the PR template sections for validation and release notes
+
+See `docs/DEVELOPMENT_STANDARDS.md` for the canonical main-merge and release automation contract.
+
 ## Dashboard source of truth policy
 
 - Do not submit dashboard template source changes to this repository.

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -25,6 +25,22 @@ To maintain a clean history and stable environment use a **Traffic Controller** 
 - **Sync Protocol**: Use the workflow dispatch input to target a specific branch when needed, and regularly merge translation PR updates from `main` into active feature branches.
 - **Commit Style**: Use **Conventional Commits** (e.g., `feat:`, `fix:`, `refactor:`, `chore(l10n):`) to ensure a readable, professional history.
 
+#### Main branch merge and release automation contract
+
+Changes intended for `main` MUST preserve automated issue linking and generated release notes.
+
+- **Merge path**: Use a pull request into `main`; do not rely on direct pushes if release-note categorization is required.
+- **Issue closure keyword**: The PR body MUST include a closing keyword such as `Closes #123` when the change resolves an issue. `Refs #123` is informational only and does not close the issue.
+- **Release-note categorization**: The PR MUST carry the correct release-note label defined in `.github/release.yml` (for example `bug`, `enhancement`, `enh: feature`, `documentation`).
+- **Excluded labels**: Remove labels excluded by `.github/release.yml` before merge (for example `needs-triage`, `needs-info`, `status: blocked`, `status: in-progress`, `status: ready`).
+- **PR title quality**: Use a clear, user-facing PR title because generated release notes surface PR titles.
+- **Release-note summary**: If the change is user-visible, summarize it in the PR description under the release-notes section.
+- **Validation before merge**: Before merging to `main`, pass the required validation gates and document what was run in the PR.
+
+Operational rule:
+
+- If a change bypasses PR metadata, automated release-note grouping cannot reliably classify it.
+
 ### 1.0 Release tag versioning standard (all repos)
 
 Use SemVer-style release versions without a `v` prefix for all ChoreOps repositories.


### PR DESCRIPTION
## Summary
- document the PR metadata required for automated issue closure and generated release notes
- add the canonical main-merge policy to the development standards and reinforce it in contributor and agent guidance

## Linked issue
- None

## Main merge automation checks
- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [x] Correct release-note label is applied for `.github/release.yml` categorization
- [x] Excluded triage or status labels have been removed before merge
- [x] PR title is suitable for generated release notes

## Change type
- [ ] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [x] Documentation

## Scope
- [ ] Integration logic/state
- [ ] Dashboard/template behavior
- [ ] Services/automations
- [x] Documentation/wiki

## Dashboard source boundary
- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Validation
- [x] `./utils/quick_lint.sh --fix`
- [ ] `python -m pytest tests/ -v --tb=line` (docs-only change; not run)

## Documentation impact
- [ ] No documentation updates needed
- [x] Documentation updated (README / wiki / inline docs)

## Release notes
- [x] No release notes needed
- [ ] Release notes needed (summarize user-visible changes below)

- Release note summary:

## Breaking changes
- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)
