### PR TITLE
Release ChoreOps 1.0.3

### DIFF
--- a/custom_components/choreops/manifest.json
+++ b/custom_components/choreops/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ccpk1/choreops/issues",
   "quality_scale": "platinum",
   "requirements": ["python-dateutil>=2.9.0"],
-  "version": "1.0.2"
+  "version": "1.0.3"
 }


### PR DESCRIPTION
## Summary
- bump the ChoreOps integration manifest version from `1.0.2` to `1.0.3`
- keep the vendored dashboard registry release version at `1.0.1` by design
- prepare the repository metadata needed to publish the `1.0.3` integration release

## Release notes
- publishes ChoreOps integration version `1.0.3`
- ships the overdue reset fix merged in #54 as the next stable integration release
- does not change dashboard registry versioning

## Validation
- did not rerun validation in this PR by request
- relied on the previously completed release validation for the shipped code in #54:
  - `./utils/quick_lint.sh --fix`
  - `mypy custom_components/choreops/`
  - `python -m pytest tests/ -v --tb=line`
