### PR TITLE
Fix same-day badge progress inflation on re-evaluation

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -216,6 +216,7 @@ DASHBOARD_RELEASE_INCLUDE_PRERELEASES_DEFAULT: Final = True
 SIGNAL_SUFFIX_DATA_READY: Final = "data_ready"  # Data migrated, registry clean
 SIGNAL_SUFFIX_CHORES_READY: Final = "chores_ready"  # ChoreManager init complete
 SIGNAL_SUFFIX_STATS_READY: Final = "stats_ready"  # StatisticsManager hydration complete
+SIGNAL_SUFFIX_STATS_UPDATED: Final = "stats_updated"  # Statistics buckets updated
 SIGNAL_SUFFIX_GAMIFICATION_READY: Final = (
     "gamification_ready"  # GamificationManager complete
 )

--- a/custom_components/choreops/engines/gamification_engine.py
+++ b/custom_components/choreops/engines/gamification_engine.py
@@ -716,18 +716,20 @@ class GamificationEngine:
         """
         threshold = target.get(const.DATA_BADGE_TARGET_THRESHOLD_VALUE, 0)
 
-        # Use per-badge cycle count
-        badge_progress = context.get("current_badge_progress") or {}
-        cycle_count = badge_progress.get(
-            const.DATA_USER_BADGE_PROGRESS_POINTS_CYCLE_COUNT, 0
-        )
-
-        # Get today's point progress from pre-computed stats in context
         today_stats = context.get("today_stats") or {}
-        today_points = today_stats.get("today_points", 0)
+        window_points = today_stats.get("window_points")
 
-        # Total is cycle_count (previously accumulated) + today's points
-        current_value = cycle_count + today_points
+        if window_points is not None:
+            current_value = float(window_points)
+        else:
+            # Backward-compatible fallback for contexts that still provide
+            # incremental cycle state plus today's points.
+            badge_progress = context.get("current_badge_progress") or {}
+            cycle_count = badge_progress.get(
+                const.DATA_USER_BADGE_PROGRESS_POINTS_CYCLE_COUNT, 0
+            )
+            today_points = today_stats.get("today_points", 0)
+            current_value = cycle_count + today_points
 
         progress = min(1.0, current_value / threshold) if threshold > 0 else 0.0
         criteria_met = current_value >= threshold
@@ -843,17 +845,21 @@ class GamificationEngine:
         """
         threshold = target.get(const.DATA_BADGE_TARGET_THRESHOLD_VALUE, 0)
 
-        # Get cycle count from badge progress
-        badge_progress = context.get("current_badge_progress") or {}
-        cycle_count = badge_progress.get(
-            const.DATA_USER_BADGE_PROGRESS_CHORES_CYCLE_COUNT, 0
-        )
-
-        # Get today's chore completion count from pre-computed stats
         today_stats = context.get("today_stats") or {}
-        today_approved = today_stats.get("today_approved", 0)
+        window_approved = today_stats.get("window_approved")
 
-        current_value = cycle_count + today_approved
+        if window_approved is not None:
+            current_value = int(window_approved)
+        else:
+            # Backward-compatible fallback for contexts that still provide
+            # incremental cycle state plus today's approvals.
+            badge_progress = context.get("current_badge_progress") or {}
+            cycle_count = badge_progress.get(
+                const.DATA_USER_BADGE_PROGRESS_CHORES_CYCLE_COUNT, 0
+            )
+            today_approved = today_stats.get("today_approved", 0)
+            current_value = cycle_count + today_approved
+
         progress = min(1.0, current_value / threshold) if threshold > 0 else 0.0
         criteria_met = current_value >= threshold
 

--- a/custom_components/choreops/managers/gamification_manager.py
+++ b/custom_components/choreops/managers/gamification_manager.py
@@ -114,6 +114,7 @@ class GamificationManager(BaseManager):
         """
         # Startup cascade - wait for stats to be ready before initializing badges
         self.listen(const.SIGNAL_SUFFIX_STATS_READY, self._on_stats_ready)
+        self.listen(const.SIGNAL_SUFFIX_STATS_UPDATED, self._on_stats_updated)
 
         # Point changes affect point-based badges
         self.listen(const.SIGNAL_SUFFIX_POINTS_CHANGED, self._on_points_changed)
@@ -174,6 +175,21 @@ class GamificationManager(BaseManager):
         # Signal cascade complete
         self.emit(const.SIGNAL_SUFFIX_GAMIFICATION_READY)
         const.LOGGER.info("ChoreOps initialization cascade complete")
+
+    def _on_stats_updated(self, payload: dict[str, Any]) -> None:
+        """Handle post-statistics updates.
+
+        Statistics writes can complete after earlier lifecycle signals such as
+        `chore_approved` or `points_changed` have already queued an evaluation.
+        Re-queueing on the post-stats signal ensures badge evaluation sees the
+        authoritative period buckets.
+
+        Args:
+            payload: Event data with assignee/user identifier.
+        """
+        assignee_id = payload.get("user_id")
+        if assignee_id:
+            self._mark_pending(assignee_id)
 
     # =========================================================================
     # EVENT HANDLERS
@@ -1357,15 +1373,26 @@ class GamificationManager(BaseManager):
         end_date_iso = str(
             reset_schedule.get(const.DATA_BADGE_RESET_SCHEDULE_END_DATE, "")
         )
-        if (
-            canonical_target.get("source_raw_type")
-            == const.BADGE_TARGET_THRESHOLD_TYPE_POINTS_CHORES
-        ):
+        window_start_iso = start_date_iso or today_iso
+        window_end_iso = end_date_iso or today_iso
+        target_type = canonical_target.get("source_raw_type")
+
+        if target_type in {
+            const.BADGE_TARGET_THRESHOLD_TYPE_POINTS,
+            const.BADGE_TARGET_THRESHOLD_TYPE_POINTS_CHORES,
+        }:
             today_stats["window_points"] = self._get_tracked_window_points_total(
                 assignee_id,
                 tracked_chores,
-                start_date_iso or today_iso,
-                end_date_iso or today_iso,
+                window_start_iso,
+                window_end_iso,
+            )
+        if target_type == const.BADGE_TARGET_THRESHOLD_TYPE_CHORE_COUNT:
+            today_stats["window_approved"] = self._get_tracked_window_completion_total(
+                assignee_id,
+                tracked_chores,
+                window_start_iso,
+                window_end_iso,
             )
         today_completion = (
             self.coordinator.statistics_manager.get_badge_scoped_today_completion(
@@ -1455,7 +1482,6 @@ class GamificationManager(BaseManager):
             const.DATA_USER_BADGE_PROGRESS_STATUS,
             const.BADGE_STATE_IN_PROGRESS,
         )
-
         entry.setdefault(const.DATA_USER_BADGE_PROGRESS_POINTS_CYCLE_COUNT, 0.0)
         entry.setdefault(const.DATA_USER_BADGE_PROGRESS_CHORES_CYCLE_COUNT, 0)
         entry.setdefault(const.DATA_USER_BADGE_PROGRESS_DAYS_CYCLE_COUNT, 0)
@@ -3508,10 +3534,8 @@ class GamificationManager(BaseManager):
         today_local_iso = dt_today_iso()
 
         badges_earned = assignee_info.setdefault(const.DATA_USER_BADGES_EARNED, {})
-
         # Phase 4: GamificationManager (Landlord) creates/updates structure only
         # StatisticsManager (Tenant) handles period updates via _on_badge_earned listener
-
         if badge_id not in badges_earned:
             # Create new badge tracking entry with empty periods (Landlord creates structure only)
             # StatisticsEngine creates daily/weekly/monthly/yearly keys on-demand
@@ -3538,7 +3562,6 @@ class GamificationManager(BaseManager):
                 const.DATA_BADGE_NAME, ""
             )
             tracking_entry[const.DATA_USER_BADGES_EARNED_LAST_AWARDED] = today_local_iso
-
             # Ensure periods structure exists (Landlord ensures container)
             # StatisticsEngine creates daily/weekly/monthly/yearly keys on-demand
             tracking_entry.setdefault(

--- a/custom_components/choreops/managers/statistics_manager.py
+++ b/custom_components/choreops/managers/statistics_manager.py
@@ -102,6 +102,10 @@ class StatisticsManager(BaseManager):
         """Get the StatisticsEngine from coordinator."""
         return self._coordinator.stats
 
+    def _emit_stats_updated(self, assignee_id: str) -> None:
+        """Emit a post-statistics update signal for an assignee."""
+        self.emit(const.SIGNAL_SUFFIX_STATS_UPDATED, user_id=assignee_id)
+
     async def async_setup(self) -> None:
         """Set up event subscriptions for statistics tracking.
 
@@ -377,6 +381,7 @@ class StatisticsManager(BaseManager):
 
         # === 7) Notify Home Assistant of data update ===
         self._coordinator.async_set_updated_data(self._coordinator._data)
+        self._emit_stats_updated(assignee_id)
 
         const.LOGGER.debug(
             "StatisticsManager._on_points_changed: assignee=%s, delta=%.2f, source=%s",
@@ -595,6 +600,9 @@ class StatisticsManager(BaseManager):
 
         # Transactional Flush: notify sensors that all batch updates are complete
         self._coordinator.async_set_updated_data(self._coordinator._data)
+        for assignee_id in assignee_ids:
+            if assignee_id:
+                self._emit_stats_updated(assignee_id)
 
         const.LOGGER.debug(
             "StatisticsManager._on_chore_completed: chore=%s, assignees=%s",
@@ -1478,6 +1486,7 @@ class StatisticsManager(BaseManager):
         if persist:
             self._coordinator._persist()
             self._refresh_chore_cache(assignee_id)
+            self._emit_stats_updated(assignee_id)
 
         return True
 
@@ -1604,6 +1613,7 @@ class StatisticsManager(BaseManager):
         if persist:
             self._coordinator._persist()
             self._refresh_reward_cache(assignee_id)
+            self._emit_stats_updated(assignee_id)
 
         return True
 

--- a/custom_components/choreops/manifest.json
+++ b/custom_components/choreops/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ccpk1/choreops/issues",
   "quality_scale": "platinum",
   "requirements": ["python-dateutil>=2.9.0"],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/tests/test_badge_target_types.py
+++ b/tests/test_badge_target_types.py
@@ -17,12 +17,13 @@ Note: Section 1.1 (Cumulative) and Section 1.3 (Weekly - actually handled
 by periodic with weekly reset) are covered in test_badge_cumulative.py.
 """
 
+import asyncio
 import logging
 from typing import Any
 from zoneinfo import ZoneInfo
 
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 import pytest
 
@@ -57,6 +58,9 @@ from tests.helpers import (
     OPTIONS_FLOW_INPUT_MANAGE_ACTION,
     OPTIONS_FLOW_INPUT_MENU_SELECTION,
     OPTIONS_FLOW_STEP_INIT,
+    approve_chore,
+    claim_chore,
+    get_dashboard_helper,
 )
 from tests.helpers.setup import SetupResult, setup_from_yaml
 
@@ -155,6 +159,171 @@ def get_badge_by_name(coordinator: Any, badge_name: str) -> tuple[str, dict[str,
         if badge_data.get(const.DATA_BADGE_NAME) == badge_name:
             return badge_id, badge_data
     raise ValueError(f"Badge not found: {badge_name}")
+
+
+async def _wait_for_badge_progress_state(
+    hass: HomeAssistant,
+    assignee_slug: str,
+    badge_name: str,
+    *,
+    expected_progress: float,
+) -> None:
+    """Wait until badge progress reaches an expected settled state.
+
+    The badge pipeline is event-driven. This helper waits for the badge's
+    persisted progress to reflect the approved chore before the regression test
+    checks that unrelated events do not inflate it further.
+    """
+    for _ in range(100):
+        await hass.async_block_till_done()
+        dashboard = get_dashboard_helper(hass, assignee_slug)
+        badge_entry = next(
+            (
+                badge
+                for badge in dashboard.get("badges", [])
+                if badge.get("name") == badge_name
+            ),
+            None,
+        )
+        if badge_entry and (badge_eid := badge_entry.get("eid")):
+            badge_state = hass.states.get(str(badge_eid))
+            if badge_state is not None:
+                try:
+                    state_progress = float(badge_state.state)
+                except (TypeError, ValueError):
+                    state_progress = 0.0
+                overall_progress = float(
+                    badge_state.attributes.get(
+                        const.DATA_USER_BADGE_PROGRESS_OVERALL_PROGRESS,
+                        0.0,
+                    )
+                    or 0.0
+                )
+                criteria_met = bool(
+                    badge_state.attributes.get(
+                        const.DATA_USER_BADGE_PROGRESS_CRITERIA_MET,
+                        False,
+                    )
+                )
+
+                if (
+                    abs(state_progress - (expected_progress * 100)) <= 0.1
+                    and abs(overall_progress - expected_progress) <= 0.001
+                    and criteria_met is False
+                ):
+                    return
+
+        await asyncio.sleep(0.05)
+
+    raise AssertionError(
+        f"Timed out waiting for badge progress for {badge_name}: "
+        f"overall_progress={expected_progress}"
+    )
+
+
+async def _add_daily_badge_and_seed_single_chore_progress(
+    hass: HomeAssistant,
+    setup_result: SetupResult,
+    mock_hass_users: dict[str, Any],
+    *,
+    badge_name: str,
+    target_type: str,
+    threshold: int,
+) -> tuple[str, str]:
+    """Create a daily badge and seed one approved chore for Zoë.
+
+    Returns:
+        Tuple of (assignee_id, badge_id)
+    """
+    config_entry = setup_result.config_entry
+    coordinator = setup_result.coordinator
+    assignee_id = setup_result.assignee_ids["Zoë"]
+
+    badge_data = {
+        CFOF_BADGES_INPUT_NAME: badge_name,
+        CFOF_BADGES_INPUT_ICON: "mdi:test-tube",
+        CFOF_BADGES_INPUT_TARGET_TYPE: target_type,
+        CFOF_BADGES_INPUT_TARGET_THRESHOLD_VALUE: threshold,
+        CFOF_BADGES_INPUT_ASSIGNED_USER_IDS: [assignee_id],
+        CFOF_BADGES_INPUT_SELECTED_CHORES: [],
+        CFOF_BADGES_INPUT_AWARD_POINTS: 5.0,
+        CFOF_BADGES_INPUT_AWARD_ITEMS: ["points"],
+    }
+
+    await add_badge_via_options_flow(
+        hass,
+        config_entry.entry_id,
+        BADGE_TYPE_DAILY,
+        badge_data,
+    )
+
+    badge_id, _ = get_badge_by_name(coordinator, badge_name)
+
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    approver_context = Context(user_id=mock_hass_users["approver1"].id)
+
+    claim_result = await claim_chore(hass, "zoe", "Make bed", assignee_context)
+    assert claim_result.success, f"Failed to claim chore: {claim_result.error}"
+
+    approve_result = await approve_chore(hass, "zoe", "Make bed", approver_context)
+    assert approve_result.success, f"Failed to approve chore: {approve_result.error}"
+
+    await hass.async_block_till_done()
+
+    return assignee_id, badge_id
+
+
+async def _trigger_unrelated_gamification_event(
+    setup_result: SetupResult,
+    assignee_id: str,
+    trigger_type: str,
+) -> None:
+    """Trigger one non-chore gamification event and drain evaluation."""
+    gamification_manager = setup_result.coordinator.gamification_manager
+    payload = {"user_id": assignee_id}
+
+    if trigger_type == "reward_approved":
+        gamification_manager._on_reward_approved(payload)
+    elif trigger_type == "bonus_applied":
+        gamification_manager._on_bonus_applied(payload)
+    elif trigger_type == "penalty_applied":
+        gamification_manager._on_penalty_applied(payload)
+    else:
+        raise ValueError(f"Unsupported trigger type: {trigger_type}")
+
+    await gamification_manager._drain_pending_evaluations_now()
+
+
+def _get_badge_progress_sensor_snapshot(
+    hass: HomeAssistant,
+    assignee_slug: str,
+    badge_name: str,
+) -> tuple[float, dict[str, Any]]:
+    """Return badge progress sensor state and attributes for the named badge."""
+    dashboard = get_dashboard_helper(hass, assignee_slug)
+    badge_entry = next(
+        (
+            badge
+            for badge in dashboard.get("badges", [])
+            if badge.get("name") == badge_name
+        ),
+        None,
+    )
+    if badge_entry is None or not badge_entry.get("eid"):
+        raise AssertionError(f"Badge progress entity not found for {badge_name}")
+
+    badge_state = hass.states.get(str(badge_entry["eid"]))
+    if badge_state is None:
+        raise AssertionError(f"Badge progress state missing for {badge_name}")
+
+    try:
+        state_value = float(badge_state.state)
+    except (TypeError, ValueError) as err:
+        raise AssertionError(
+            f"Badge progress state is not numeric for {badge_name}: {badge_state.state}"
+        ) from err
+
+    return state_value, dict(badge_state.attributes)
 
 
 # ============================================================================
@@ -258,6 +427,82 @@ class TestDailyBadgeTargetTypes:
             DATA_USER_BADGE_PROGRESS, {}
         )
         assert badge_id in assignee_progress, "Badge progress should be initialized"
+
+    @pytest.mark.parametrize(
+        ("target_type", "threshold", "expected_progress"),
+        [
+            ("chore_count", 3, 0.33),
+            ("points", 50, 0.1),
+        ],
+        ids=["chore-count", "points"],
+    )
+    @pytest.mark.parametrize(
+        "trigger_type",
+        ["reward_approved", "bonus_applied", "penalty_applied"],
+        ids=["reward", "bonus", "penalty"],
+    )
+    async def test_unrelated_same_day_events_do_not_inflate_daily_badge_progress(
+        self,
+        hass: HomeAssistant,
+        setup_minimal: SetupResult,
+        mock_hass_users: dict[str, Any],
+        target_type: str,
+        threshold: int,
+        expected_progress: float,
+        trigger_type: str,
+    ) -> None:
+        """Reward, bonus, and penalty re-evaluations must not double count progress."""
+        assignee_id, badge_id = await _add_daily_badge_and_seed_single_chore_progress(
+            hass,
+            setup_minimal,
+            mock_hass_users,
+            badge_name=f"Re-eval Guard {target_type} {trigger_type}",
+            target_type=target_type,
+            threshold=threshold,
+        )
+        badge_name = f"Re-eval Guard {target_type} {trigger_type}"
+
+        await _wait_for_badge_progress_state(
+            hass,
+            "zoe",
+            badge_name,
+            expected_progress=expected_progress,
+        )
+
+        before_state, before_attrs = _get_badge_progress_sensor_snapshot(
+            hass,
+            "zoe",
+            badge_name,
+        )
+        assert before_state == pytest.approx(expected_progress * 100, abs=0.1)
+        assert before_attrs[
+            const.DATA_USER_BADGE_PROGRESS_OVERALL_PROGRESS
+        ] == pytest.approx(
+            expected_progress,
+            abs=0.001,
+        )
+        assert before_attrs[const.DATA_USER_BADGE_PROGRESS_CRITERIA_MET] is False
+
+        await _trigger_unrelated_gamification_event(
+            setup_minimal,
+            assignee_id,
+            trigger_type,
+        )
+        await hass.async_block_till_done()
+
+        after_state, after_attrs = _get_badge_progress_sensor_snapshot(
+            hass,
+            "zoe",
+            badge_name,
+        )
+        assert after_state == pytest.approx(before_state, abs=0.1)
+        assert after_attrs[
+            const.DATA_USER_BADGE_PROGRESS_OVERALL_PROGRESS
+        ] == pytest.approx(
+            expected_progress,
+            abs=0.001,
+        )
+        assert after_attrs[const.DATA_USER_BADGE_PROGRESS_CRITERIA_MET] is False
 
 
 # ============================================================================

--- a/tests/test_gamification_engine.py
+++ b/tests/test_gamification_engine.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
+import pytest
+
 from custom_components.choreops import const
 from custom_components.choreops.engines.gamification_engine import GamificationEngine
 
@@ -247,6 +249,19 @@ class TestEvaluatePoints:
         assert result["progress"] == 0.25
         assert result["current_value"] == 25
 
+    def test_window_points_prevents_same_day_double_count(self) -> None:
+        """Canonical window points take precedence over additive cycle math."""
+        context = make_context(points_cycle_count=5, today_points=5)
+        context["today_stats"]["window_points"] = 5.0
+        badge_data = make_badge(threshold=50)
+        target = badge_data[const.DATA_BADGE_TARGET]
+
+        result = GamificationEngine._evaluate_points(context, target)
+
+        assert result["met"] is False
+        assert result["current_value"] == 5.0
+        assert result["progress"] == 0.1
+
 
 # =============================================================================
 # TEST: _evaluate_chore_count
@@ -301,6 +316,22 @@ class TestEvaluateChoreCount:
         assert result["met"] is False
         assert result["current_value"] == 0
         assert result["progress"] == 0.0
+
+    def test_window_approved_prevents_same_day_double_count(self) -> None:
+        """Canonical window approvals take precedence over additive cycle math."""
+        context = make_context(chores_cycle_count=1, today_approved=1)
+        context["today_stats"]["window_approved"] = 1
+        badge_data = make_badge(
+            target_type=const.BADGE_TARGET_THRESHOLD_TYPE_CHORE_COUNT,
+            threshold=3,
+        )
+        target = badge_data[const.DATA_BADGE_TARGET]
+
+        result = GamificationEngine._evaluate_chore_count(context, target)
+
+        assert result["met"] is False
+        assert result["current_value"] == 1
+        assert result["progress"] == pytest.approx(1 / 3)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- use canonical active-window totals for badge points and chore-count evaluation
- requeue gamification after post-statistics writes so badge checks see settled period buckets
- add engine and integration regressions to prove unrelated same-day events do not inflate badge progress

## Validation
- ./utils/quick_lint.sh --fix
- python -m pytest tests/test_gamification_engine.py tests/test_badge_target_types.py -v --tb=line
- python -m pytest tests/test_badge_target_types.py tests/test_badge_periods_initialization.py tests/test_badge_helpers.py tests/test_badge_cumulative.py tests/test_gamification_engine.py tests/test_gamification_shadow_comparison.py tests/test_workflow_gamification_pending_queue.py -v --tb=line

Closes #60