### PR TITLE
Preserve deleted dashboards across restart

### DIFF
--- a/custom_components/choreops/helpers/dashboard_builder.py
+++ b/custom_components/choreops/helpers/dashboard_builder.py
@@ -801,6 +801,34 @@ def get_multi_view_url_path(dashboard_name: str) -> str:
     return f"{const.DASHBOARD_URL_PATH_PREFIX}{slug}"
 
 
+def _canonical_dashboard_url_path(url_path: str) -> str:
+    """Return the canonical ChoreOps dashboard URL path.
+
+    Legacy dashboards used the ``kcd-`` prefix. Treat those as aliases of the
+    current ``cod-`` path so existence, dedupe, and delete flows operate on the
+    logical dashboard rather than a single historical URL variant.
+    """
+    if url_path.startswith(const.DASHBOARD_LEGACY_URL_PATH_PREFIX):
+        suffix = url_path.removeprefix(const.DASHBOARD_LEGACY_URL_PATH_PREFIX)
+        return f"{const.DASHBOARD_URL_PATH_PREFIX}{suffix}"
+    return url_path
+
+
+def _get_dashboard_url_aliases(url_path: str) -> tuple[str, ...]:
+    """Return all known URL path aliases for a ChoreOps dashboard."""
+    if not _is_choreops_dashboard_url_path(url_path):
+        return (url_path,)
+
+    canonical_url_path = _canonical_dashboard_url_path(url_path)
+    suffix = canonical_url_path.removeprefix(const.DASHBOARD_URL_PATH_PREFIX)
+    legacy_url_path = f"{const.DASHBOARD_LEGACY_URL_PATH_PREFIX}{suffix}"
+
+    if legacy_url_path == canonical_url_path:
+        return (canonical_url_path,)
+
+    return (canonical_url_path, legacy_url_path)
+
+
 def _is_choreops_dashboard_url_path(url_path: str) -> bool:
     """Return True for current or legacy ChoreOps dashboard URL paths."""
     return url_path.startswith(
@@ -837,14 +865,18 @@ def check_dashboard_exists(hass: HomeAssistant, url_path: str) -> bool:
     Returns:
         True if dashboard exists, False otherwise.
     """
+    aliases = _get_dashboard_url_aliases(url_path)
+
     # Check frontend panels
-    if DATA_PANELS in hass.data and url_path in hass.data[DATA_PANELS]:
+    if DATA_PANELS in hass.data and any(
+        alias in hass.data[DATA_PANELS] for alias in aliases
+    ):
         return True
 
     # Check lovelace dashboards
     if LOVELACE_DATA in hass.data:
         lovelace_data = hass.data[LOVELACE_DATA]
-        if url_path in lovelace_data.dashboards:
+        if any(alias in lovelace_data.dashboards for alias in aliases):
             return True
 
     return False
@@ -862,6 +894,8 @@ async def async_check_dashboard_exists(hass: HomeAssistant, url_path: str) -> bo
     Returns:
         True if dashboard exists, False otherwise.
     """
+    aliases = _get_dashboard_url_aliases(url_path)
+
     if check_dashboard_exists(hass, url_path):
         return True
 
@@ -869,7 +903,8 @@ async def async_check_dashboard_exists(hass: HomeAssistant, url_path: str) -> bo
     await dashboards_collection.async_load()
 
     for item in _get_collection_items(dashboards_collection):
-        if item.get(CONF_URL_PATH) == url_path:
+        item_url_path = item.get(CONF_URL_PATH)
+        if isinstance(item_url_path, str) and item_url_path in aliases:
             return True
 
     return False
@@ -919,6 +954,10 @@ async def async_dedupe_choreops_dashboards(
     dashboards_collection = DashboardsCollection(hass)
     await dashboards_collection.async_load()
 
+    target_canonical_url_path = (
+        _canonical_dashboard_url_path(url_path) if isinstance(url_path, str) else None
+    )
+
     matching_items: dict[str, list[dict[str, Any]]] = {}
     for item in _get_collection_items(dashboards_collection):
         item_url_path = item.get(CONF_URL_PATH)
@@ -926,9 +965,13 @@ async def async_dedupe_choreops_dashboards(
             continue
         if not _is_choreops_dashboard_url_path(item_url_path):
             continue
-        if url_path and item_url_path != url_path:
+        canonical_item_url_path = _canonical_dashboard_url_path(item_url_path)
+        if (
+            target_canonical_url_path is not None
+            and canonical_item_url_path != target_canonical_url_path
+        ):
             continue
-        matching_items.setdefault(item_url_path, []).append(item)
+        matching_items.setdefault(canonical_item_url_path, []).append(item)
 
     removed_by_path: dict[str, int] = {}
 
@@ -936,8 +979,11 @@ async def async_dedupe_choreops_dashboards(
         if len(items) <= 1:
             continue
 
-        # Keep newest item (last in collection order), remove older duplicates
-        to_remove = items[:-1]
+        preferred_items = [
+            item for item in items if item.get(CONF_URL_PATH) == target_url_path
+        ]
+        keep_item = preferred_items[-1] if preferred_items else items[-1]
+        to_remove = [item for item in items if item is not keep_item]
         removed_count = 0
         for duplicate_item in to_remove:
             duplicate_id = duplicate_item.get("id")
@@ -1788,16 +1834,17 @@ async def _delete_dashboard(hass: HomeAssistant, url_path: str) -> None:
         url_path: Dashboard URL path to delete.
     """
     const.LOGGER.debug("Deleting dashboard: %s", url_path)
+    aliases = _get_dashboard_url_aliases(url_path)
 
     # Step 1: Remove from DashboardsCollection (storage)
-    # Delete ALL items with matching url_path (handle duplicates)
+    # Delete ALL items with matching url_path aliases (handle legacy/current pairs)
     dashboards_collection = DashboardsCollection(hass)
     await dashboards_collection.async_load()
 
     items_to_delete = [
         item_id
         for item in _get_collection_items(dashboards_collection)
-        if item.get(CONF_URL_PATH) == url_path
+        if item.get(CONF_URL_PATH) in aliases
         if isinstance(item_id := item.get("id"), str)
     ]
 
@@ -1805,9 +1852,9 @@ async def _delete_dashboard(hass: HomeAssistant, url_path: str) -> None:
         try:
             await dashboards_collection.async_delete_item(item_id)
             const.LOGGER.debug(
-                "Removed dashboard entry from collection: id=%s, url_path=%s",
+                "Removed dashboard entry from collection: id=%s, url_paths=%s",
                 item_id,
-                url_path,
+                aliases,
             )
         except Exception as err:
             const.LOGGER.warning(
@@ -1817,20 +1864,24 @@ async def _delete_dashboard(hass: HomeAssistant, url_path: str) -> None:
     # Step 2: Remove from lovelace_data.dashboards (runtime)
     if LOVELACE_DATA in hass.data:
         lovelace_data = hass.data[LOVELACE_DATA]
-        if url_path in lovelace_data.dashboards:
-            dashboard = lovelace_data.dashboards.pop(url_path)
+        for alias in aliases:
+            if alias not in lovelace_data.dashboards:
+                continue
+
+            dashboard = lovelace_data.dashboards.pop(alias)
             # Delete the storage file
             try:
                 await dashboard.async_delete()
             except Exception as err:
                 const.LOGGER.warning(
-                    "Failed to delete dashboard storage for %s: %s", url_path, err
+                    "Failed to delete dashboard storage for %s: %s", alias, err
                 )
-            const.LOGGER.debug("Removed dashboard from lovelace_data: %s", url_path)
+            const.LOGGER.debug("Removed dashboard from lovelace_data: %s", alias)
 
     # Step 3: Remove the frontend panel
-    async_remove_panel(hass, url_path, warn_if_unknown=False)
-    const.LOGGER.debug("Removed dashboard panel: %s", url_path)
+    for alias in aliases:
+        async_remove_panel(hass, alias, warn_if_unknown=False)
+        const.LOGGER.debug("Removed dashboard panel: %s", alias)
 
 
 async def delete_choreops_dashboard(

--- a/custom_components/choreops/helpers/dashboard_helpers.py
+++ b/custom_components/choreops/helpers/dashboard_helpers.py
@@ -2138,10 +2138,16 @@ def get_existing_choreops_dashboards(
     """
     from homeassistant.components.lovelace.const import LOVELACE_DATA
 
-    discovered_dashboards: list[dict[str, str]] = []
+    discovered_dashboards: dict[str, dict[str, str]] = {}
+
+    def _canonical_dashboard_url_path(url_path: str) -> str:
+        if url_path.startswith(const.DASHBOARD_LEGACY_URL_PATH_PREFIX):
+            suffix = url_path.removeprefix(const.DASHBOARD_LEGACY_URL_PATH_PREFIX)
+            return f"{const.DASHBOARD_URL_PATH_PREFIX}{suffix}"
+        return url_path
 
     if LOVELACE_DATA not in hass.data:
-        return discovered_dashboards
+        return []
 
     lovelace_data = hass.data[LOVELACE_DATA]
 
@@ -2174,29 +2180,26 @@ def get_existing_choreops_dashboards(
                                 if isinstance(view_title, str) and view_title.strip():
                                     title = view_title.strip()
 
-            discovered_dashboards.append(
-                {
-                    "value": url_path,
-                    "title": str(title).strip() or url_path,
-                }
-            )
+            canonical_url_path = _canonical_dashboard_url_path(url_path)
+            entry = {
+                "value": url_path,
+                "title": str(title).strip() or url_path,
+                "display_path": canonical_url_path,
+            }
+            current_entry = discovered_dashboards.get(canonical_url_path)
+            if current_entry is None or url_path == canonical_url_path:
+                discovered_dashboards[canonical_url_path] = entry
 
     if not discovered_dashboards:
         return []
 
     dashboards: list[dict[str, str]] = []
     for dashboard in sorted(
-        discovered_dashboards, key=lambda item: item["title"].casefold()
+        discovered_dashboards.values(), key=lambda item: item["title"].casefold()
     ):
         url_path = dashboard["value"]
         title = dashboard["title"]
-        display_path = url_path
-        if display_path.startswith(const.DASHBOARD_LEGACY_URL_PATH_PREFIX):
-            display_path = display_path.replace(
-                const.DASHBOARD_LEGACY_URL_PATH_PREFIX,
-                const.DASHBOARD_URL_PATH_PREFIX,
-                1,
-            )
+        display_path = dashboard["display_path"]
         label = f"{title} ({display_path})"
         dashboards.append({"value": url_path, "label": label})
 

--- a/tests/test_dashboard_builder_single_path.py
+++ b/tests/test_dashboard_builder_single_path.py
@@ -252,3 +252,136 @@ async def test_update_dashboard_prepared_assets_match_release_applied_template_o
     )
 
     assert prepared_output == release_applied_output
+
+
+@pytest.mark.asyncio
+async def test_async_check_dashboard_exists_treats_legacy_alias_as_existing() -> None:
+    """Canonical dashboard existence checks must honor legacy kcd aliases."""
+
+    class _FakeDashboardsCollection:
+        def __init__(self, _hass: Any) -> None:
+            self.data = {
+                "items": [
+                    {
+                        "id": "legacy-1",
+                        "url_path": "kcd-chores",
+                    }
+                ]
+            }
+
+        async def async_load(self) -> None:
+            return None
+
+    fake_hass = SimpleNamespace(data={})
+
+    with patch.object(builder, "DashboardsCollection", _FakeDashboardsCollection):
+        exists = await builder.async_check_dashboard_exists(fake_hass, "cod-chores")
+
+    assert exists is True
+
+
+@pytest.mark.asyncio
+async def test_delete_dashboard_removes_legacy_and_current_aliases() -> None:
+    """Deleting one dashboard variant must remove both cod and kcd aliases."""
+
+    class _FakeDashboard:
+        def __init__(self) -> None:
+            self.deleted = False
+
+        async def async_delete(self) -> None:
+            self.deleted = True
+
+    class _FakeDashboardsCollection:
+        def __init__(self, _hass: Any) -> None:
+            self.data = {
+                "items": [
+                    {"id": "legacy-1", "url_path": "kcd-chores"},
+                    {"id": "current-1", "url_path": "cod-chores"},
+                ]
+            }
+            self.deleted_ids: list[str] = []
+
+        async def async_load(self) -> None:
+            return None
+
+        async def async_delete_item(self, item_id: str) -> None:
+            self.deleted_ids.append(item_id)
+            self.data["items"] = [
+                item for item in self.data["items"] if item.get("id") != item_id
+            ]
+
+    fake_legacy_dashboard = _FakeDashboard()
+    fake_current_dashboard = _FakeDashboard()
+    fake_collection = _FakeDashboardsCollection(None)
+    removed_panels: list[str] = []
+    fake_hass = SimpleNamespace(
+        config=SimpleNamespace(recovery_mode=False),
+        data={
+            builder.LOVELACE_DATA: SimpleNamespace(
+                dashboards={
+                    "kcd-chores": fake_legacy_dashboard,
+                    "cod-chores": fake_current_dashboard,
+                }
+            )
+        },
+    )
+
+    with (
+        patch.object(
+            builder,
+            "DashboardsCollection",
+            side_effect=lambda _hass: fake_collection,
+        ),
+        patch.object(
+            builder,
+            "async_remove_panel",
+            side_effect=lambda _hass, url_path, warn_if_unknown=False: (
+                removed_panels.append(url_path)
+            ),
+        ),
+    ):
+        await builder.delete_choreops_dashboard(fake_hass, "cod-chores")
+
+    assert sorted(fake_collection.deleted_ids) == ["current-1", "legacy-1"]
+    assert fake_legacy_dashboard.deleted is True
+    assert fake_current_dashboard.deleted is True
+    assert fake_hass.data[builder.LOVELACE_DATA].dashboards == {}
+    assert sorted(removed_panels) == ["cod-chores", "kcd-chores"]
+
+
+@pytest.mark.asyncio
+async def test_async_dedupe_choreops_dashboards_removes_legacy_alias_duplicate() -> (
+    None
+):
+    """Startup dedupe must collapse legacy/current alias pairs to one entry."""
+
+    class _FakeDashboardsCollection:
+        def __init__(self, _hass: Any) -> None:
+            self.data = {
+                "items": [
+                    {"id": "legacy-1", "url_path": "kcd-chores"},
+                    {"id": "current-1", "url_path": "cod-chores"},
+                ]
+            }
+            self.deleted_ids: list[str] = []
+
+        async def async_load(self) -> None:
+            return None
+
+        async def async_delete_item(self, item_id: str) -> None:
+            self.deleted_ids.append(item_id)
+            self.data["items"] = [
+                item for item in self.data["items"] if item.get("id") != item_id
+            ]
+
+    fake_collection = _FakeDashboardsCollection(None)
+
+    with patch.object(
+        builder,
+        "DashboardsCollection",
+        side_effect=lambda _hass: fake_collection,
+    ):
+        removed = await builder.async_dedupe_choreops_dashboards(object())
+
+    assert removed == {"cod-chores": 1}
+    assert fake_collection.deleted_ids == ["legacy-1"]

--- a/tests/test_options_flow_dashboard_release_selection.py
+++ b/tests/test_options_flow_dashboard_release_selection.py
@@ -500,6 +500,31 @@ def test_get_existing_dashboards_prefers_config_title_over_url_path() -> None:
     assert options == [{"value": "cod-chores", "label": "Chores (cod-chores)"}]
 
 
+def test_get_existing_dashboards_collapses_legacy_and_current_aliases() -> None:
+    """Dashboard discovery should surface one logical option per dashboard."""
+
+    class _FakeDashboard:
+        def __init__(self, config: dict[str, Any]) -> None:
+            self.config = config
+
+    class _FakeLovelaceData:
+        def __init__(self) -> None:
+            self.dashboards = {
+                "kcd-chores": _FakeDashboard({"title": "Chores (legacy)"}),
+                "cod-chores": _FakeDashboard({"title": "Chores"}),
+            }
+
+    class _FakeHass:
+        def __init__(self) -> None:
+            self.data: dict[str, Any] = {
+                "lovelace": _FakeLovelaceData(),
+            }
+
+    options = dh.get_existing_choreops_dashboards(_FakeHass())
+
+    assert options == [{"value": "cod-chores", "label": "Chores (cod-chores)"}]
+
+
 @pytest.mark.asyncio
 async def test_dashboard_update_step_shows_release_controls(
     hass: HomeAssistant,


### PR DESCRIPTION
## Summary
- treat legacy `kcd-...` and current `cod-...` dashboard URL paths as aliases for existence, dedupe, and delete flows
- remove both alias variants when a dashboard is deleted so pre-fix dashboards cannot reappear after restart
- collapse legacy/current alias pairs in the dashboard selector and add regression coverage for legacy dashboard behavior

## Validation
- ./utils/quick_lint.sh --fix
- python -m pytest tests/test_dashboard_builder_single_path.py tests/test_dashboard_builder_frontend_compat.py tests/test_dashboard_builder_release_fetch.py tests/test_dashboard_release_asset_apply.py tests/test_dashboard_context_contract.py tests/test_dashboard_template_contract.py tests/test_dashboard_template_release_resolution.py tests/test_dashboard_provenance_contract.py tests/test_dashboard_manifest_runtime_policy.py tests/test_dashboard_manifest_dependencies_contract.py tests/test_dashboard_custom_card_detection.py tests/test_options_flow_dashboard_release_selection.py -v --tb=line

Closes #62
