### PR TITLE
feat(dashboard): add chores lite profile

### DIFF
--- a/custom_components/choreops/dashboards/dashboard_registry.json
+++ b/custom_components/choreops/dashboards/dashboard_registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_version": "1.0.1",
+  "release_version": "1.0.2",
   "repo": "ccpk1/ChoreOps-Dashboards",
   "title": "ChoreOps Dashboard Registry",
   "description": "Registry manifest for ChoreOps dashboard templates",
@@ -78,6 +78,33 @@
       },
       "preferences": {
         "doc_asset_path": "preferences/user-chores-essential-v1.md"
+      }
+    },
+    {
+      "template_id": "user-chores-lite-v1",
+      "display_name": "Chores Lite",
+      "description": "Dynamic lightweight user dashboard using native markdown and tile cards with auto-entities only",
+      "audience": "user",
+      "category": "minimal",
+      "lifecycle_state": "active",
+      "min_integration_version": "1.0.0",
+      "maintainer": "ccpk1",
+      "source": {
+        "type": "vendored",
+        "path": "templates/user-chores-lite-v1.yaml"
+      },
+      "dependencies": {
+        "required": [
+          {
+            "id": "ha-card:auto-entities",
+            "name": "Auto-Entities",
+            "url": "https://github.com/thomasloven/lovelace-auto-entities"
+          }
+        ],
+        "recommended": []
+      },
+      "preferences": {
+        "doc_asset_path": "preferences/user-chores-lite-v1.md"
       }
     },
     {

--- a/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
@@ -1,0 +1,103 @@
+# user-chores-lite-v1 preferences
+
+`user-chores-lite-v1` is a dynamic lightweight profile intended for older devices and lower-capability frontend environments. It keeps the ChoreOps dashboard-helper sorting and grouping intelligence while using native Home Assistant cards for the visible UI.
+
+## Quick overview
+
+- Dynamic by design: chores and rewards are still generated from the dashboard helper at runtime.
+- Native-card first: the rendered UI uses native `markdown` and `tile` cards.
+- Lower-risk interaction model: tap triggers one selected workflow button; hold opens more-info for the related status sensor.
+- Focused layout: exactly three top-level cards are rendered for the user view: header, chores, and rewards.
+
+## Dependency policy
+
+- Required custom dependency: `auto-entities`
+- Explicitly not used by this profile:
+  - `button-card`
+  - Mushroom cards
+  - `card-mod`
+
+## Header card behavior
+
+- Shows a welcome summary using translated labels.
+- Includes chore-oriented summary counts such as overdue and due today.
+- Shows points only when gamification is enabled.
+- Does **not** include reward status or reward summary counts.
+
+## Card: Chores
+
+- `pref_use_overdue_grouping` (default: `true`)
+  - Shows a dedicated overdue group.
+
+- `pref_today_grouping_mode` (default: `today_morning`)
+  - Controls whether today chores are grouped into one or two buckets.
+  - Allowed: `off`, `today`, `today_morning`.
+
+- `pref_include_daily_recurring_in_today` (default: `true`)
+  - Keeps recurring daily chores in today groups.
+
+- `pref_use_this_week_grouping` (default: `true`)
+  - Shows a due-this-week group.
+
+- `pref_include_weekly_recurring_in_this_week` (default: `true`)
+  - Keeps recurring weekly chores in the this-week group.
+
+- `pref_exclude_completed` (default: `false`)
+  - Hides completed chores.
+
+- `pref_exclude_blocked` (default: `false`)
+  - Hides blocked-result chores.
+  - Adds `completed_by_other`, `not_my_turn`, and `missed` to the effective exclusion list.
+
+- `pref_exclude_states` (default: `[]`)
+  - Excludes chores by state.
+
+- `pref_use_label_grouping` (default: `false`)
+  - Groups chores by labels instead of time buckets.
+
+- `pref_exclude_label_list` (default: `[]`)
+  - Excludes chores containing any listed labels.
+
+- `pref_label_display_order` (default: `[]`)
+  - Optional explicit label-group order.
+
+- `pref_sort_within_groups` (default: `by_state_and_date`)
+  - Sorting mode inside each rendered group.
+  - Allowed: `default`, `name_asc`, `name_desc`, `date_asc`, `date_desc`, `by_state_and_date`.
+
+## Chore action selection
+
+The lite profile uses one tap action per chore tile.
+
+- Default priority:
+  - `claim_button_eid`
+  - then `approve_button_eid`
+- Claimed/in-progress priority:
+  - `disapprove_button_eid`
+  - then `approve_button_eid`
+- Hold action opens more-info on the chore status sensor.
+
+## Rewards card behavior
+
+- Reward state is shown on the reward tile itself rather than repeated in the header.
+- Rewards are grouped into `Available`, `Requested`, `Approved`, and `Locked` sections.
+- Empty reward state uses the translated `no_rewards` copy.
+
+## Reward action selection
+
+The lite profile uses one tap action per reward tile.
+
+- Default priority:
+  - `claim_button_eid`
+  - then `approve_button_eid`
+- Requested priority:
+  - `disapprove_button_eid`
+  - then `approve_button_eid`
+- Hold action opens more-info on the reward status sensor.
+
+## Practical tuning examples
+
+- Keep the light default behavior: change nothing and let the helper-provided sorting do the work.
+- Hide completed chores: set `pref_exclude_completed: true`.
+- Hide blocked-result chores on shared/rotation heavy installs: set `pref_exclude_blocked: true`.
+- Prefer label buckets over time buckets: set `pref_use_label_grouping: true` and provide `pref_label_display_order`.

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -1,0 +1,567 @@
+<#-- ============================================= --#>
+<#-- ChoreOps Dashboard Template - CHORES LITE   --#>
+<#-- Template Schema Version: 1                  --#>
+<#-- Integration: 1.0.0 (Schema 100)             --#>
+<#-- ============================================= --#>
+<#--                                             --#>
+<#-- Chores Lite dashboard: dynamic lightweight --#>
+<#-- native-card profile for older devices      --#>
+<#-- OUTPUT: Full dashboard document with root keys --#>
+<#--                                             --#>
+<#-- Injection variables (Python << >>):         --#>
+<#--   << user.name >> - User's display name      --#>
+<#--   << user.slug >> - URL-safe slug            --#>
+<#--   << user.user_id >> - User identity UUID    --#>
+<#--   << integration.entry_id >> - Instance scope ID --#>
+<#--                                             --#>
+<#-- Snippet tokens: template_snippets.user_setup,                       --#>
+<#-- template_snippets.user_validation,                                  --#>
+<#-- template_snippets.user_override_helper, template_snippets.meta_stamp --#>
+<#-- Stamp format (canonical): META STAMP: {template_id} • {release} • {generated_at} --#>
+<#-- Stamp placement: first line inside each card template block after card header comment --#>
+<#--                                             --#>
+<#-- All HA Jinja2 {{ }} syntax preserved       --#>
+<#-- ============================================= --#>
+
+views:
+  - max_columns: 4
+    title: << user.name >>
+    path: << user.slug >>
+    type: sections
+    sections:
+      - type: grid
+        column_span: 1
+        cards:
+          - square: false
+            type: grid
+            columns: 1
+            grid_options:
+              columns: full
+            cards:
+              - type: custom:auto-entities
+                card:
+                  square: false
+                  type: grid
+                  columns: 1
+                card_param: cards
+                filter:
+                  template: |-
+                    {#-- ===== HEADER CARD ===== --#}
+
+                    << template_snippets.meta_stamp >>
+
+
+                    {#-- 1. User Configuration --#}
+
+                    << template_snippets.user_override_helper | indent(width=20, first=true) >>
+
+
+                    {#-- 2. Dynamic Lookups & Validations --#}
+
+                    << template_snippets.user_setup | indent(width=20, first=true) >>
+
+                    << template_snippets.user_validation | indent(width=20, first=true) >>
+
+                    {%- if not skip_render -%}
+
+                      {#-- 3. Collect Data --#}
+                      {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                      {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
+                      {%- set points_sensor = core_sensors.get('points_eid') -%}
+                      {%- set total_sensor = core_sensors.get('chores_eid') -%}
+                      {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                      {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
+                      {%- set points = (states(points_sensor) | int(default=0)) if points_sensor else 0 -%}
+                      {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or ui.get('points_details', 'Points') -%}
+                      {%- set overdue_now = (state_attr(total_sensor, 'chore_stat_current_overdue') | int(default=0)) if total_sensor else 0 -%}
+                      {%- set due_today_open = (state_attr(total_sensor, 'chore_stat_current_due_today') | int(default=0)) if total_sensor else 0 -%}
+                      {%- set todays_completed = (state_attr(total_sensor, 'chore_stat_approved_today') | int(default=0)) if total_sensor else 0 -%}
+                      {%- set weekly_completed = (state_attr(total_sensor, 'chore_stat_approved_week') | int(default=0)) if total_sensor else 0 -%}
+
+                      {#-- 4. Build Display --#}
+                      {%- set content =
+                        "## 👋 " ~ ui.get('welcome', 'err-welcome') ~ ", " ~ name ~ "\n"
+                        ~ ("**⭐ " ~ points_label ~ ":** " ~ points|string ~ "  \n" if gamification_enabled else "")
+                        ~ "**🧹 " ~ ui.get('overdue', 'err-overdue') ~ ":** " ~ overdue_now|string ~ ""
+                        ~ "  •  **📅 " ~ ui.get('due_today', 'err-due_today') ~ ":** " ~ due_today_open|string ~ "  \n"
+                        ~ "**☀️ " ~ ui.get('todays_completed', 'err-todays_completed') ~ ":** " ~ todays_completed|string
+                        ~ "  •  **🗓️ " ~ ui.get('weekly_completed', 'err-weekly_completed') ~ ":** " ~ weekly_completed|string
+                      -%}
+
+                      {#-- 5. Render --#}
+                      {{
+                        {
+                          'type': 'markdown',
+                          'content': content
+                        }
+                      }},
+
+                    {%- endif -%}
+
+          - square: false
+            type: grid
+            columns: 1
+            grid_options:
+              columns: full
+            cards:
+              - type: custom:auto-entities
+                card:
+                  square: false
+                  type: grid
+                  columns: 1
+                card_param: cards
+                filter:
+                  template: |-
+                    {#-- ===== CHORES CARD ===== --#}
+
+                    << template_snippets.meta_stamp >>
+
+
+                    {#-- 1. User Configuration --#}
+
+                    << template_snippets.user_override_helper | indent(width=20, first=true) >>
+
+                    {%- set pref_use_overdue_grouping = true -%}
+
+                    {%- set pref_today_grouping_mode = 'today_morning' -%}
+
+                    {%- set pref_include_daily_recurring_in_today = true -%}
+
+                    {%- set pref_use_this_week_grouping = true -%}
+
+                    {%- set pref_include_weekly_recurring_in_this_week = true -%}
+
+                    {%- set pref_exclude_completed = false -%}
+
+                    {%- set pref_exclude_blocked = false -%}
+
+                    {%- set pref_exclude_states = [] -%}
+
+                    {%- set pref_use_label_grouping = false -%}
+
+                    {%- set pref_exclude_label_list = [] -%}
+
+                    {%- set pref_label_display_order = [] -%}
+
+                    {%- set pref_sort_within_groups = 'by_state_and_date' -%}
+
+
+                    {#-- Type coercion for preferences --#}
+                    {%- set pref_use_overdue_grouping = pref_use_overdue_grouping | default(true, true) -%}
+                    {%- set pref_today_grouping_mode = pref_today_grouping_mode | default('today_morning', true) -%}
+                    {%- set pref_include_daily_recurring_in_today = pref_include_daily_recurring_in_today | default(true, true) -%}
+                    {%- set pref_use_this_week_grouping = pref_use_this_week_grouping | default(true, true) -%}
+                    {%- set pref_include_weekly_recurring_in_this_week = pref_include_weekly_recurring_in_this_week | default(true, true) -%}
+                    {%- set pref_exclude_completed = pref_exclude_completed | default(false, true) -%}
+                    {%- set pref_exclude_blocked = pref_exclude_blocked | default(false, true) -%}
+                    {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable else [] -%}
+                    {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
+                    {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
+                      {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
+                    {%- endif -%}
+                    {%- if pref_exclude_blocked -%}
+                      {%- for blocked_state in ['completed_by_other', 'not_my_turn', 'missed'] -%}
+                        {%- if blocked_state not in pref_exclude_states -%}
+                          {%- set pref_exclude_states = pref_exclude_states + [blocked_state] -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+                    {%- endif -%}
+                    {%- set pref_use_label_grouping = pref_use_label_grouping | default(false, true) -%}
+                    {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable else [] -%}
+                    {%- set pref_label_display_order = pref_label_display_order if pref_label_display_order is iterable else [] -%}
+
+
+                    {#-- 2. Dynamic Lookups & Validations --#}
+
+                    << template_snippets.user_setup | indent(width=20, first=true) >>
+
+                    << template_snippets.user_validation | indent(width=20, first=true) >>
+
+                    {%- if not skip_render -%}
+
+                      {#-- 3. Initialize Variables --#}
+                      {%- set ns = namespace(
+                        overdue_buttons=[],
+                        am_buttons=[],
+                        today_buttons=[],
+                        this_week_buttons=[],
+                        other_buttons=[],
+                        label_button_groups=[],
+                        label_order=[],
+                        visible_count=0
+                      ) -%}
+
+                      {#-- 4. Collect Data --#}
+                      {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                      {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
+                      {%- set chore_list = state_attr(dashboard_helper, 'chores') | default([], true) -%}
+                      {%- set chores_by_label_raw = state_attr(dashboard_helper, 'chores_by_label') | default({}, true) -%}
+
+                      {#-- 5. Build Display --#}
+                      {%- for chore in chore_list -%}
+                        {%- set chore_sensor_id = chore.eid if chore is mapping else chore -%}
+                        {%- set chore_status = chore.state if chore is mapping else states(chore_sensor_id) -%}
+                        {%- set chore_labels = chore.labels if chore is mapping else state_attr(chore_sensor_id, 'labels') | default([], true) -%}
+                        {%- set chore_primary_group = chore.primary_group if chore is mapping else state_attr(chore_sensor_id, 'primary_group') | default('other') -%}
+                        {%- set chore_is_today_am = chore.is_today_am if chore is mapping else state_attr(chore_sensor_id, 'is_today_am') -%}
+
+                        {%- if not (chore_labels | select('in', pref_exclude_label_list) | list | count > 0) -%}
+                          {%- if chore_status in pref_exclude_states -%}
+                          {%- elif chore_status == 'overdue' and pref_use_overdue_grouping -%}
+                            {%- set ns.overdue_buttons = ns.overdue_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- elif pref_use_label_grouping and (chore_labels | default([], true) | list | length > 0) -%}
+                          {%- elif chore_primary_group == 'today' and not pref_include_daily_recurring_in_today -%}
+                            {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- elif chore_primary_group == 'this_week' and not pref_include_weekly_recurring_in_this_week -%}
+                            {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- elif chore_primary_group == 'today' and pref_today_grouping_mode == 'today_morning' and chore_is_today_am == true -%}
+                            {%- set ns.am_buttons = ns.am_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- elif chore_primary_group == 'today' and pref_today_grouping_mode in ['today', 'today_morning'] -%}
+                            {%- set ns.today_buttons = ns.today_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- elif chore_primary_group == 'this_week' and pref_use_this_week_grouping -%}
+                            {%- set ns.this_week_buttons = ns.this_week_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- else -%}
+                            {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
+                            {%- set ns.visible_count = ns.visible_count + 1 -%}
+                          {%- endif -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+
+                      {%- if pref_use_label_grouping -%}
+                        {%- if pref_label_display_order | length > 0 -%}
+                          {%- set ns.label_order = pref_label_display_order -%}
+                        {%- else -%}
+                          {%- set ns.label_order = chores_by_label_raw.keys() | list | sort -%}
+                        {%- endif -%}
+                        {%- for label in ns.label_order -%}
+                          {%- if label not in pref_exclude_label_list and label in chores_by_label_raw -%}
+                            {%- set label_eids = chores_by_label_raw[label] | default([], true) -%}
+                            {%- set ns.temp_label_buttons = [] -%}
+                            {%- for eid in label_eids -%}
+                              {%- if eid not in (ns.overdue_buttons | list) -%}
+                                {%- set ns.temp_label_buttons = ns.temp_label_buttons + [eid] -%}
+                              {%- endif -%}
+                            {%- endfor -%}
+                            {%- if ns.temp_label_buttons | length > 0 -%}
+                              {%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons}] -%}
+                            {%- endif -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                      {%- endif -%}
+
+                      {%- set button_groups = [
+                        {'name': ui.get('overdue', 'err-overdue'), 'buttons': ns.overdue_buttons},
+                        {'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons},
+                        {'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons},
+                        {'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons}
+                      ] -%}
+                      {%- set button_groups = button_groups + ns.label_button_groups -%}
+                      {%- set button_groups = button_groups + [{'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons}] -%}
+
+                      {%- if pref_sort_within_groups != 'default' -%}
+                        {%- set ns.sorted_groups = [] -%}
+                        {%- for group in button_groups -%}
+                          {%- if group.buttons | length > 0 -%}
+                            {%- if pref_sort_within_groups in ['name_asc', 'name_desc'] -%}
+                              {%- set ns.temp_list = [] -%}
+                              {%- for eid in group.buttons -%}
+                                {%- set chore_name = state_attr(eid, 'chore_name') | default('zzz', true) | lower -%}
+                                {%- set ns.temp_list = ns.temp_list + [[chore_name, eid]] -%}
+                              {%- endfor -%}
+                              {%- set sorted_list = ns.temp_list | sort -%}
+                              {%- if pref_sort_within_groups == 'name_desc' -%}
+                                {%- set sorted_list = sorted_list | reverse | list -%}
+                              {%- endif -%}
+                              {%- set sorted_buttons = sorted_list | map('last') | list -%}
+                              {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons}] -%}
+                            {%- elif pref_sort_within_groups in ['date_asc', 'date_desc'] -%}
+                              {%- set ns.temp_list = [] -%}
+                              {%- for eid in group.buttons -%}
+                                {%- set due_date_value = state_attr(eid, 'due_date') -%}
+                                {%- if due_date_value is not none and due_date_value not in ['unknown', 'unavailable'] -%}
+                                  {%- set due_timestamp = as_timestamp(due_date_value) | default(9999999999, true) -%}
+                                {%- else -%}
+                                  {%- set due_timestamp = 9999999999 -%}
+                                {%- endif -%}
+                                {%- set ns.temp_list = ns.temp_list + [[due_timestamp, eid]] -%}
+                              {%- endfor -%}
+                              {%- set sorted_list = ns.temp_list | sort -%}
+                              {%- if pref_sort_within_groups == 'date_desc' -%}
+                                {%- set sorted_list = sorted_list | reverse | list -%}
+                              {%- endif -%}
+                              {%- set sorted_buttons = sorted_list | map('last') | list -%}
+                              {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons}] -%}
+                            {%- else -%}
+                              {%- set ns.temp_list = [] -%}
+                              {%- for eid in group.buttons -%}
+                                {%- set chore_state = states(eid) | lower -%}
+                                {%- if chore_state == 'overdue' -%}
+                                  {%- set state_priority = 0 -%}
+                                {%- elif chore_state == 'due' -%}
+                                  {%- set state_priority = 1 -%}
+                                {%- elif chore_state == 'pending' -%}
+                                  {%- set state_priority = 2 -%}
+                                {%- elif chore_state == 'waiting' -%}
+                                  {%- set state_priority = 3 -%}
+                                {%- elif chore_state == 'claimed' -%}
+                                  {%- set state_priority = 4 -%}
+                                {%- elif chore_state == 'completed' -%}
+                                  {%- set state_priority = 5 -%}
+                                {%- elif chore_state == 'completed_by_other' -%}
+                                  {%- set state_priority = 6 -%}
+                                {%- elif chore_state == 'not_my_turn' -%}
+                                  {%- set state_priority = 7 -%}
+                                {%- elif chore_state == 'missed' -%}
+                                  {%- set state_priority = 8 -%}
+                                {%- else -%}
+                                  {%- set state_priority = 50 -%}
+                                {%- endif -%}
+                                {%- set due_date_value = state_attr(eid, 'due_date') -%}
+                                {%- if due_date_value is not none and due_date_value not in ['unknown', 'unavailable'] -%}
+                                  {%- set due_timestamp = as_timestamp(due_date_value) | default(9999999999, true) -%}
+                                {%- else -%}
+                                  {%- set due_timestamp = 9999999999 -%}
+                                {%- endif -%}
+                                {%- set chore_name = state_attr(eid, 'chore_name') | default('zzz', true) | lower -%}
+                                {%- set ns.temp_list = ns.temp_list + [[state_priority, due_timestamp, chore_name, eid]] -%}
+                              {%- endfor -%}
+                              {%- set sorted_list = ns.temp_list | sort -%}
+                              {%- set sorted_buttons = sorted_list | map('last') | list -%}
+                              {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons}] -%}
+                            {%- endif -%}
+                          {%- else -%}
+                            {%- set ns.sorted_groups = ns.sorted_groups + [group] -%}
+                          {%- endif -%}
+                        {%- endfor -%}
+                        {%- set button_groups = ns.sorted_groups -%}
+                      {%- endif -%}
+
+                      {#-- 6. Render --#}
+                      {{
+                        {
+                          'type': 'heading',
+                          'heading': ui.get('chores', 'err-chores'),
+                          'icon': 'mdi:broom',
+                          'heading_style': 'title'
+                        }
+                      }},
+
+                      {%- if ns.visible_count == 0 -%}
+                        {{
+                          {
+                            'type': 'markdown',
+                            'content': ui.get('all_caught_up', 'All Caught Up!')
+                          }
+                        }},
+                      {%- endif -%}
+
+                      {%- for group in button_groups -%}
+                        {%- if group.buttons | length > 0 -%}
+                          {{
+                            {
+                              'type': 'heading',
+                              'heading': group.name,
+                              'heading_style': 'subtitle'
+                            }
+                          }},
+
+                          {%- for chore_sensor_id in group.buttons -%}
+                            {%- set chore_name = state_attr(chore_sensor_id, 'chore_name') | default(state_attr(chore_sensor_id, 'friendly_name') or chore_sensor_id, true) -%}
+                            {%- set chore_icon = state_attr(chore_sensor_id, 'icon') | default('mdi:broom', true) -%}
+                            {%- set claim_button_eid = state_attr(chore_sensor_id, 'claim_button_eid') | default('', true) -%}
+                            {%- set approve_button_eid = state_attr(chore_sensor_id, 'approve_button_eid') | default('', true) -%}
+                            {%- set disapprove_button_eid = state_attr(chore_sensor_id, 'disapprove_button_eid') | default('', true) -%}
+                            {%- set raw_state = states(chore_sensor_id) -%}
+                            {%- if raw_state == 'claimed' -%}
+                              {%- set active_button_eid = disapprove_button_eid or approve_button_eid -%}
+                            {%- else -%}
+                              {%- set active_button_eid = claim_button_eid or approve_button_eid -%}
+                            {%- endif -%}
+                            {%- set tile_color = (
+                              'red' if raw_state in ['overdue', 'missed'] else
+                              'orange' if raw_state == 'due' else
+                              'purple' if raw_state == 'claimed' else
+                              'green' if raw_state == 'completed' else
+                              'disabled' if raw_state in ['waiting', 'completed_by_other', 'not_my_turn'] else
+                              'primary'
+                            ) -%}
+                            {{
+                              {
+                                'type': 'tile',
+                                'entity': chore_sensor_id,
+                                'name': chore_name,
+                                'icon': chore_icon,
+                                'color': tile_color,
+                                'vertical': false,
+                                'state_content': ['state', 'due_date'],
+                                'tap_action': (
+                                  {
+                                    'action': 'perform-action',
+                                    'perform_action': 'button.press',
+                                    'target': {'entity_id': active_button_eid}
+                                  }
+                                  if active_button_eid not in ['', None, 'None']
+                                  else {'action': 'none'}
+                                ),
+                                'hold_action': {
+                                  'action': 'more-info',
+                                  'entity': chore_sensor_id
+                                }
+                              }
+                            }},
+                          {%- endfor -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+
+                    {%- endif -%}
+
+          - square: false
+            type: grid
+            columns: 1
+            grid_options:
+              columns: full
+            cards:
+              - type: custom:auto-entities
+                card:
+                  square: false
+                  type: grid
+                  columns: 1
+                card_param: cards
+                filter:
+                  template: |-
+                    {#-- ===== REWARDS CARD ===== --#}
+
+                    << template_snippets.meta_stamp >>
+
+
+                    {#-- 1. User Configuration --#}
+
+                    << template_snippets.user_override_helper | indent(width=20, first=true) >>
+
+
+                    {#-- 2. Dynamic Lookups & Validations --#}
+
+                    << template_snippets.user_setup | indent(width=20, first=true) >>
+
+                    << template_snippets.user_validation | indent(width=20, first=true) >>
+
+                    {%- if not skip_render -%}
+
+                      {#-- 3. Initialize Variables --#}
+                      {%- set ns = namespace(
+                        available_rewards=[],
+                        requested_rewards=[],
+                        approved_rewards=[],
+                        locked_rewards=[]
+                      ) -%}
+
+                      {#-- 4. Collect Data --#}
+                      {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
+                      {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                      {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
+                      {%- set rewards = state_attr(dashboard_helper, 'rewards') | default([], true) -%}
+
+                      {#-- 5. Build Display --#}
+                      {%- for reward in rewards -%}
+                        {%- set reward_state = states(reward.eid) if reward is mapping and reward.eid else 'unknown' -%}
+                        {%- if reward_state == 'available' -%}
+                          {%- set ns.available_rewards = ns.available_rewards + [reward] -%}
+                        {%- elif reward_state == 'requested' -%}
+                          {%- set ns.requested_rewards = ns.requested_rewards + [reward] -%}
+                        {%- elif reward_state == 'approved' -%}
+                          {%- set ns.approved_rewards = ns.approved_rewards + [reward] -%}
+                        {%- else -%}
+                          {%- set ns.locked_rewards = ns.locked_rewards + [reward] -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+
+                      {%- set reward_groups = [
+                        {'name': ui.get('available', 'err-available'), 'rewards': ns.available_rewards},
+                        {'name': ui.get('requested', 'err-requested'), 'rewards': ns.requested_rewards},
+                        {'name': ui.get('approved', 'err-approved'), 'rewards': ns.approved_rewards},
+                        {'name': ui.get('locked', 'err-locked'), 'rewards': ns.locked_rewards}
+                      ] -%}
+
+                      {#-- 6. Render --#}
+                      {{
+                        {
+                          'type': 'heading',
+                          'heading': ui.get('rewards', 'err-rewards'),
+                          'icon': 'mdi:gift',
+                          'heading_style': 'title'
+                        }
+                      }},
+
+                      {%- if not gamification_enabled or rewards | length == 0 -%}
+                        {{
+                          {
+                            'type': 'markdown',
+                            'content': ui.get('no_rewards', 'No rewards available.')
+                          }
+                        }},
+                      {%- endif -%}
+
+                      {%- for group in reward_groups -%}
+                        {%- if group.rewards | length > 0 -%}
+                          {{
+                            {
+                              'type': 'heading',
+                              'heading': group.name,
+                              'heading_style': 'subtitle'
+                            }
+                          }},
+
+                          {%- for reward in group.rewards | sort(attribute='name') -%}
+                            {%- set reward_name = reward.name if reward is mapping else 'Unknown' -%}
+                            {%- set reward_sensor_eid = reward.eid if reward is mapping else '' -%}
+                            {%- set reward_icon = state_attr(reward_sensor_eid, 'icon') | default('mdi:gift', true) -%}
+                            {%- set reward_state = states(reward_sensor_eid) -%}
+                            {%- set claim_button_eid = state_attr(reward_sensor_eid, 'claim_button_eid') | default('', true) -%}
+                            {%- set approve_button_eid = state_attr(reward_sensor_eid, 'approve_button_eid') | default('', true) -%}
+                            {%- set disapprove_button_eid = state_attr(reward_sensor_eid, 'disapprove_button_eid') | default('', true) -%}
+                            {%- if reward_state == 'requested' -%}
+                              {%- set active_button_eid = disapprove_button_eid or approve_button_eid -%}
+                            {%- else -%}
+                              {%- set active_button_eid = claim_button_eid or approve_button_eid -%}
+                            {%- endif -%}
+                            {%- set tile_color = (
+                              'green' if reward_state == 'available' else
+                              'purple' if reward_state == 'requested' else
+                              'blue' if reward_state == 'approved' else
+                              'disabled'
+                            ) -%}
+                            {{
+                              {
+                                'type': 'tile',
+                                'entity': reward_sensor_eid,
+                                'name': reward_name,
+                                'icon': reward_icon,
+                                'color': tile_color,
+                                'vertical': false,
+                                'state_content': ['state'],
+                                'tap_action': (
+                                  {
+                                    'action': 'perform-action',
+                                    'perform_action': 'button.press',
+                                    'target': {'entity_id': active_button_eid}
+                                  }
+                                  if active_button_eid not in ['', None, 'None']
+                                  else {'action': 'none'}
+                                ),
+                                'hold_action': {
+                                  'action': 'more-info',
+                                  'entity': reward_sensor_eid
+                                }
+                              }
+                            }},
+                          {%- endfor -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+
+                    {%- endif -%}

--- a/docs/in-process/DASHBOARD_USER_CHORES_LITE_V1_IN-PROCESS.md
+++ b/docs/in-process/DASHBOARD_USER_CHORES_LITE_V1_IN-PROCESS.md
@@ -1,0 +1,151 @@
+# Initiative snapshot
+
+- **Name / Code**: User chores lite dashboard profile / `DASHBOARD_USER_CHORES_LITE_V1`
+- **Target release / milestone**: Next 1.0.x feature release
+- **Owner / driver(s)**: TBD
+- **Status**: In progress
+
+## Summary & immediate steps
+
+| Phase / Step                        | Description                                                             | % complete | Quick notes                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------- | ---------- | ----------------------------------------------------------- |
+| Phase 1 - Spec and contract         | Capture the approved lightweight profile behavior and constraints       | 100%       | Phase 2 profile uses native cards plus `auto-entities` only |
+| Phase 2 - Canonical assets          | Add template, preferences, and registry record in `choreops-dashboards` | 0%         | New user profile: `user-chores-lite-v1`                     |
+| Phase 3 - Vendored mirror and tests | Sync assets into integration and add focused contract/render coverage   | 0%         | No Python runtime logic changes expected                    |
+| Phase 4 - Validation                | Run dashboard sync and targeted tests                                   | 0%         | Focus on render, contract, and dependency coverage          |
+
+1. **Key objective** - Add a dynamic, lower-risk user dashboard profile for older devices that preserves ChoreOps dashboard-helper intelligence while avoiding JavaScript-heavy custom row cards.
+2. **Summary of recent work** -
+   - Reframed issues 57 and 58 as enhancement requests for legacy-device compatibility.
+   - Reviewed current template constraints and confirmed native Lovelace alone cannot build a fully dynamic chore list without a generator layer.
+   - Confirmed `tile` supports `tap_action` and `hold_action`, which enables a native interaction path.
+3. **Next steps (short term)** -
+   - Implement the canonical dashboard assets for `user-chores-lite-v1`.
+   - Mirror assets into the vendored integration dashboard directory.
+   - Add focused tests for render, dependency, and template contract coverage.
+4. **Risks / blockers** -
+   - Native tile cards have a much smaller presentation surface than `button-card`, so some state nuance will be intentionally reduced.
+   - Action selection must remain deterministic and gracefully degrade when a button entity is absent.
+   - The profile must keep the same snippet, validation, and translation discipline as the existing reviewed user templates.
+5. **References** -
+   - [docs/DASHBOARD_TEMPLATE_GUIDE.md](../DASHBOARD_TEMPLATE_GUIDE.md)
+   - [docs/DASHBOARD_UI_DESIGN_GUIDELINE.md](../DASHBOARD_UI_DESIGN_GUIDELINE.md)
+   - [docs/DEVELOPMENT_STANDARDS.md](../DEVELOPMENT_STANDARDS.md)
+   - [choreops-dashboards/dashboard_registry.json](../../choreops-dashboards/dashboard_registry.json)
+   - [choreops-dashboards/templates/user-chores-essential-v1.yaml](../../choreops-dashboards/templates/user-chores-essential-v1.yaml)
+6. **Decisions & completion check**
+   - **Decisions captured**:
+     - Use `user-chores-lite-v1` as the new profile identifier.
+     - Keep `auto-entities` as the only custom dependency.
+     - Use native `markdown` and `tile` cards for the visible UI.
+     - Keep exactly three top-level cards: header, chores, rewards.
+     - Remove reward summaries from the header.
+     - Use a single-action rule for taps:
+       - default: `claim_button_eid` then `approve_button_eid`
+       - claimed/requested state: `disapprove_button_eid` first, then `approve_button_eid` fallback
+     - Use hold-to-open `more-info` on the status sensor when supported.
+   - **Completion confirmation**: `[ ]` All follow-up items completed before requesting owner approval to mark initiative done.
+
+> **Important:** Keep the Summary section current with every meaningful update so the initiative can be understood quickly without reading the implementation details below.
+
+## Functional contract
+
+### Profile identity
+
+- `template_id`: `user-chores-lite-v1`
+- `display_name`: `Chores Lite`
+- `audience`: `user`
+- `category`: `minimal`
+- `dependencies.required`: `ha-card:auto-entities`
+
+### Top-level card model
+
+The profile renders exactly three top-level cards inside one user view:
+
+1. Header card
+2. Chores card
+3. Rewards card
+
+### Header card
+
+- Card type: native `markdown`
+- Purpose:
+  - welcome copy
+  - points total when gamification is enabled
+  - chore-only summary counts
+- Required data:
+  - `core_sensors.points_eid` when available
+  - `core_sensors.chores_eid`
+  - translated UI labels from `dashboard_helpers.translation_sensor_eid`
+- Explicitly excluded:
+  - reward summary counts
+  - reward state overview
+
+### Chores card
+
+- Outer generator: `custom:auto-entities`
+- Visible cards: native `markdown` section headers plus native `tile` cards
+- Dynamic source: `dashboard_helper.chores` and `dashboard_helper.chores_by_label`
+- Required behavior:
+  - preserve the established grouping/sorting preferences from the lightweight chores path where practical
+  - reuse the backend/helper sort order and smart-grouping logic rather than inventing a new frontend heuristic
+  - keep validation, snippets, and translation behavior aligned with reviewed user templates
+
+#### Chore tap action resolution
+
+For each chore tile:
+
+1. Normalize state:
+   - `approved` and `already_approved` map to `completed`
+   - `approved_in_part` maps to `completed_in_part`
+2. If normalized state is `claimed` or `claimed_in_part`:
+   - use `disapprove_button_eid` first
+   - if missing, fall back to `approve_button_eid`
+3. Otherwise:
+   - use `claim_button_eid` first
+   - if missing, fall back to `approve_button_eid`
+4. If no action entity is available:
+   - set `tap_action` to `none`
+5. Set `hold_action` to `more-info` on the chore status sensor
+
+### Rewards card
+
+- Outer generator: `custom:auto-entities`
+- Visible cards: native `markdown` section headers plus native `tile` cards
+- Dynamic source: `dashboard_helper.rewards`
+- Required behavior:
+  - keep reward interaction local to the rewards card
+  - do not duplicate reward status in the header card
+
+#### Reward tap action resolution
+
+For each reward tile:
+
+1. If reward state is `requested`:
+   - use `disapprove_button_eid` first
+   - if missing, fall back to `approve_button_eid`
+2. Otherwise:
+   - use `claim_button_eid` first
+   - if missing, fall back to `approve_button_eid`
+3. If no action entity is available:
+   - set `tap_action` to `none`
+4. Set `hold_action` to `more-info` on the reward status sensor
+
+## Authoring constraints
+
+- Keep the full reviewed template structure:
+  - card header comments
+  - numbered configuration/validation/render sections
+  - canonical snippet markers
+  - graceful fallback validation
+- Use the translation sensor and existing dashboard UI keys wherever possible.
+- Avoid hardcoded user-facing English when an existing translation key already exists.
+- Do not use `custom:button-card`, Mushroom cards, or `card-mod` for this profile.
+- Keep colors theme-first and minimal; ordering and icon/state text should do most of the work.
+
+## Testing requirements
+
+- Add one render smoke test for `user-chores-lite-v1`.
+- Add one template contract test covering required snippet markers.
+- Add one template contract test confirming the lite template uses `auto-entities` and native `tile`, and does not use `button-card`.
+- Ensure manifest dependency tests pass with only `ha-card:auto-entities` declared for the new profile.

--- a/tests/test_dashboard_template_contract.py
+++ b/tests/test_dashboard_template_contract.py
@@ -23,6 +23,7 @@ def test_user_templates_include_required_snippet_markers() -> None:
 
     for template_name in (
         "user-chores-essential-v1.yaml",
+        "user-chores-lite-v1.yaml",
         "user-chores-standard-v1.yaml",
         "user-gamification-premier-v1.yaml",
         "user-kidschores-classic-v1.yaml",
@@ -77,6 +78,7 @@ def test_templates_keep_card_header_and_section_markers() -> None:
     """Templates preserve required card-header and numbered-section comments."""
     for template_name in (
         "user-chores-essential-v1.yaml",
+        "user-chores-lite-v1.yaml",
         "user-chores-standard-v1.yaml",
         "user-gamification-premier-v1.yaml",
         "user-kidschores-classic-v1.yaml",
@@ -104,3 +106,14 @@ def test_user_chores_template_uses_button_card_template_contract() -> None:
 
     legacy_row_helper = TEMPLATES_ROOT / "shared" / "chore_row_user_chores_v1.yaml"
     assert not legacy_row_helper.exists()
+
+
+def test_user_chores_lite_template_uses_native_tile_contract() -> None:
+    """Chores Lite template keeps the native-card-only visible UI contract."""
+    content = _read_template("user-chores-lite-v1.yaml")
+
+    assert "custom:auto-entities" in content
+    assert "'type': 'tile'" in content
+    assert "perform_action': 'button.press'" in content
+    assert "'action': 'more-info'" in content
+    assert "custom:button-card" not in content

--- a/tests/test_dashboard_template_render_smoke.py
+++ b/tests/test_dashboard_template_render_smoke.py
@@ -44,6 +44,27 @@ def test_user_template_renders_without_parse_errors() -> None:
     assert isinstance(rendered["views"][0].get("sections"), list)
 
 
+def test_user_chores_lite_template_renders_without_parse_errors() -> None:
+    """Chores Lite template renders and parses into a dashboard dict."""
+    template_str = _read_template("user-chores-lite-v1.yaml")
+    context = dh.build_dashboard_context(
+        "Zoe",
+        assignee_id="user-123",
+        integration_entry_id="entry-123",
+        template_profile="user-chores-lite-v1",
+        release_ref="0.0.1-beta.3",
+        generated_at="2026-03-18T00:00:00+00:00",
+    )
+
+    rendered = builder.render_dashboard_template(template_str, dict(context))
+
+    assert isinstance(rendered.get("views"), list)
+    assert len(rendered["views"]) == 1
+    assert rendered["views"][0]["title"] == "Zoe"
+    assert rendered["views"][0]["path"] == "zoe"
+    assert isinstance(rendered["views"][0].get("sections"), list)
+
+
 def test_admin_template_renders_without_parse_errors() -> None:
     """Admin template renders and parses into a dashboard dict."""
     template_str = _read_template("admin-shared-v1.yaml")


### PR DESCRIPTION
## Summary
- add the new user-chores-lite-v1 dashboard profile
- vendor the synced dashboard assets and focused validation coverage
- ship the 1.0.2 dashboard registry release update for tester validation

## Testing
- python utils/sync_dashboard_assets.py
- python utils/sync_dashboard_assets.py --check
- python -m pytest tests/test_dashboard_template_render_smoke.py tests/test_dashboard_template_contract.py tests/test_dashboard_manifest_runtime_policy.py tests/test_dashboard_manifest_dependencies_contract.py -v --tb=line

Closes #58
