### PR TITLE
Surface action errors and add earlier kiosk warnings

### DIFF
--- a/.github/workflows/translation-sync-manual.yaml
+++ b/.github/workflows/translation-sync-manual.yaml
@@ -68,8 +68,8 @@ jobs:
               echo "::notice::Dedicated PR automation token detected. Translation PR automation will run."
             elif [ -n "$EFFECTIVE_PR_TOKEN" ]; then
               echo "run_pr_automation=true" >> "$GITHUB_OUTPUT"
-              echo "::warning::TRANSLATION_PR_TOKEN is not configured. Falling back to the default GitHub Actions token for translation PR automation."
-              echo "::notice::Translation PR creation and labeling will still run, but downstream workflows triggered by the automation branch or PR may be limited."
+              echo "::notice::Using the default GitHub Actions token for translation PR automation."
+              echo "::notice::Set TRANSLATION_PR_TOKEN to enable a dedicated PR automation token when needed."
             else
               echo "run_pr_automation=false" >> "$GITHUB_OUTPUT"
               echo "::warning::No GitHub token is available for translation PR automation. Crowdin sync will run, but the downloaded translations will not be committed automatically."
@@ -127,14 +127,14 @@ jobs:
           PR_TITLE: "chore(l10n): sync translations from Crowdin"
         run: |
           if ! git ls-remote --exit-code --heads origin "$L10N_BRANCH" >/dev/null 2>&1; then
-            echo "No translation branch found to open a PR from"
+            echo "Translation branch '$L10N_BRANCH' was not found; skipping translation PR creation"
             exit 0
           fi
 
           if git diff --quiet "origin/$TARGET_BRANCH" "origin/$L10N_BRANCH" -- \
             custom_components/choreops/translations \
             custom_components/choreops/translations_custom; then
-            echo "No translation changes to open a PR for"
+            echo "Translation PR is already up to date for '$TARGET_BRANCH'"
             exit 0
           fi
 
@@ -198,4 +198,4 @@ jobs:
       - name: Translation PR automation skipped
         if: steps.crowdin_preflight.outputs.run_crowdin == 'true' && steps.crowdin_preflight.outputs.run_pr_automation != 'true'
         run: |
-          echo "Translation PR automation skipped: TRANSLATION_PR_TOKEN is not configured yet."
+          echo "Translation PR automation skipped: no GitHub token is available."

--- a/.github/workflows/translation-sync-manual.yaml
+++ b/.github/workflows/translation-sync-manual.yaml
@@ -126,28 +126,17 @@ jobs:
           L10N_BRANCH: l10n_crowdin_action
           PR_TITLE: "chore(l10n): sync translations from Crowdin"
         run: |
-          # The Docker-based Crowdin action can leave git metadata owned by root.
-          # Restore ownership before local branch operations and pushes.
-          sudo chown -R "$(id -u):$(id -g)" .git
-
-          git config user.name "Crowdin Bot"
-          git config user.email "support+bot@crowdin.com"
-
-          git fetch origin "$TARGET_BRANCH"
-          if git ls-remote --exit-code --heads origin "$L10N_BRANCH" >/dev/null 2>&1; then
-            git fetch origin "$L10N_BRANCH"
-          fi
-
-          git checkout -B "$L10N_BRANCH" "origin/$TARGET_BRANCH"
-          git add custom_components/choreops/translations custom_components/choreops/translations_custom
-
-          if git diff --cached --quiet; then
-            echo "No translation changes to commit"
+          if ! git ls-remote --exit-code --heads origin "$L10N_BRANCH" >/dev/null 2>&1; then
+            echo "No translation branch found to open a PR from"
             exit 0
           fi
 
-          git commit -m "$PR_TITLE"
-          git push --force-with-lease "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$L10N_BRANCH"
+          if git diff --quiet "origin/$TARGET_BRANCH" "origin/$L10N_BRANCH" -- \
+            custom_components/choreops/translations \
+            custom_components/choreops/translations_custom; then
+            echo "No translation changes to open a PR for"
+            exit 0
+          fi
 
           pr_number="$(gh pr list \
             --head "$L10N_BRANCH" \

--- a/.github/workflows/translation-sync-manual.yaml
+++ b/.github/workflows/translation-sync-manual.yaml
@@ -53,13 +53,23 @@ jobs:
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           TRANSLATION_PR_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
         run: |
-          if [ -z "$CROWDIN_PROJECT_ID" ] || [ -z "$CROWDIN_PERSONAL_TOKEN" ] || [ -z "$TRANSLATION_PR_TOKEN" ]; then
+          if [ -z "$CROWDIN_PROJECT_ID" ] || [ -z "$CROWDIN_PERSONAL_TOKEN" ]; then
             echo "run_crowdin=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Translation sync secrets are not fully configured. Skipping translation sync."
-            echo "::notice::Set CROWDIN_PROJECT_ID, CROWDIN_PERSONAL_TOKEN, and TRANSLATION_PR_TOKEN repository secrets to enable this workflow."
+            echo "run_pr_automation=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Crowdin secrets are not configured. Skipping translation sync."
+            echo "::notice::Set CROWDIN_PROJECT_ID and CROWDIN_PERSONAL_TOKEN repository secrets to enable Crowdin sync."
           else
             echo "run_crowdin=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::Crowdin and PR automation secrets detected. Translation sync will run."
+            echo "::notice::Crowdin secrets detected. Translation sync will run."
+
+            if [ -z "$TRANSLATION_PR_TOKEN" ]; then
+              echo "run_pr_automation=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::TRANSLATION_PR_TOKEN is not configured. Crowdin sync will run, but PR automation will be skipped."
+              echo "::notice::Set TRANSLATION_PR_TOKEN repository secret to enable translation PR creation and labeling."
+            else
+              echo "run_pr_automation=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::PR automation token detected. Translation PR automation will run."
+            fi
           fi
 
       # STEP 1: Upload Sources
@@ -72,7 +82,7 @@ jobs:
           download_translations: false
           create_pull_request: false
         env:
-          GITHUB_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
@@ -100,12 +110,12 @@ jobs:
           download_translations: true
           create_pull_request: false
         env:
-          GITHUB_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
       - name: Create or update translation PR
-        if: steps.crowdin_preflight.outputs.run_crowdin == 'true'
+        if: steps.crowdin_preflight.outputs.run_pr_automation == 'true'
         env:
           GH_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
           TARGET_BRANCH: ${{ steps.sync_branch.outputs.value }}
@@ -151,7 +161,7 @@ jobs:
           fi
 
       - name: Ensure translation PR labels
-        if: steps.crowdin_preflight.outputs.run_crowdin == 'true'
+        if: steps.crowdin_preflight.outputs.run_pr_automation == 'true'
         env:
           GH_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
           BASE_BRANCH: ${{ steps.sync_branch.outputs.value }}
@@ -187,3 +197,8 @@ jobs:
         if: steps.crowdin_preflight.outputs.run_crowdin != 'true'
         run: |
           echo "Crowdin sync skipped: repository secrets are not configured yet."
+
+      - name: Translation PR automation skipped
+        if: steps.crowdin_preflight.outputs.run_crowdin == 'true' && steps.crowdin_preflight.outputs.run_pr_automation != 'true'
+        run: |
+          echo "Translation PR automation skipped: TRANSLATION_PR_TOKEN is not configured yet."

--- a/.github/workflows/translation-sync-manual.yaml
+++ b/.github/workflows/translation-sync-manual.yaml
@@ -126,6 +126,10 @@ jobs:
           L10N_BRANCH: l10n_crowdin_action
           PR_TITLE: "chore(l10n): sync translations from Crowdin"
         run: |
+          # The Docker-based Crowdin action can leave git metadata owned by root.
+          # Restore ownership before local branch operations and pushes.
+          sudo chown -R "$(id -u):$(id -g)" .git
+
           git config user.name "Crowdin Bot"
           git config user.email "support+bot@crowdin.com"
 

--- a/.github/workflows/translation-sync-manual.yaml
+++ b/.github/workflows/translation-sync-manual.yaml
@@ -52,6 +52,7 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           TRANSLATION_PR_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
+          EFFECTIVE_PR_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN || github.token }}
         run: |
           if [ -z "$CROWDIN_PROJECT_ID" ] || [ -z "$CROWDIN_PERSONAL_TOKEN" ]; then
             echo "run_crowdin=false" >> "$GITHUB_OUTPUT"
@@ -62,13 +63,16 @@ jobs:
             echo "run_crowdin=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Crowdin secrets detected. Translation sync will run."
 
-            if [ -z "$TRANSLATION_PR_TOKEN" ]; then
-              echo "run_pr_automation=false" >> "$GITHUB_OUTPUT"
-              echo "::warning::TRANSLATION_PR_TOKEN is not configured. Crowdin sync will run, but PR automation will be skipped."
-              echo "::notice::Set TRANSLATION_PR_TOKEN repository secret to enable translation PR creation and labeling."
-            else
+            if [ -n "$TRANSLATION_PR_TOKEN" ]; then
               echo "run_pr_automation=true" >> "$GITHUB_OUTPUT"
-              echo "::notice::PR automation token detected. Translation PR automation will run."
+              echo "::notice::Dedicated PR automation token detected. Translation PR automation will run."
+            elif [ -n "$EFFECTIVE_PR_TOKEN" ]; then
+              echo "run_pr_automation=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::TRANSLATION_PR_TOKEN is not configured. Falling back to the default GitHub Actions token for translation PR automation."
+              echo "::notice::Translation PR creation and labeling will still run, but downstream workflows triggered by the automation branch or PR may be limited."
+            else
+              echo "run_pr_automation=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::No GitHub token is available for translation PR automation. Crowdin sync will run, but the downloaded translations will not be committed automatically."
             fi
           fi
 
@@ -117,7 +121,7 @@ jobs:
       - name: Create or update translation PR
         if: steps.crowdin_preflight.outputs.run_pr_automation == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN || github.token }}
           TARGET_BRANCH: ${{ steps.sync_branch.outputs.value }}
           L10N_BRANCH: l10n_crowdin_action
           PR_TITLE: "chore(l10n): sync translations from Crowdin"
@@ -163,7 +167,7 @@ jobs:
       - name: Ensure translation PR labels
         if: steps.crowdin_preflight.outputs.run_pr_automation == 'true'
         env:
-          GH_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN }}
+          GH_TOKEN: ${{ secrets.TRANSLATION_PR_TOKEN || github.token }}
           BASE_BRANCH: ${{ steps.sync_branch.outputs.value }}
           L10N_BRANCH: l10n_crowdin_action
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ Thumbs.db
 *.temp
 .cache/
 
+# Generated support exports
+utils/exports/*.txt
+
 # Local wiki guardrails (keep wiki repo separate from main code repo)
 wiki/
 wiki-local/

--- a/custom_components/choreops/button.py
+++ b/custom_components/choreops/button.py
@@ -392,6 +392,7 @@ class AssigneeChoreClaimButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Claim Chore '%s' for Assignee '%s': %s",
@@ -526,6 +527,7 @@ class ApproverChoreApproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to approve Chore '%s' for Assignee '%s': %s",
@@ -702,6 +704,7 @@ class ApproverChoreDisapproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Disapprove Chore '%s' for Assignee '%s': %s",
@@ -846,6 +849,7 @@ class AssigneeRewardRedeemButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Redeem Reward '%s' for Assignee '%s': %s",
@@ -982,6 +986,7 @@ class ApproverRewardApproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Approve Reward '%s' for Assignee '%s': %s",
@@ -1154,6 +1159,7 @@ class ApproverRewardDisapproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Disapprove Reward '%s' for Assignee '%s': %s",
@@ -1300,6 +1306,7 @@ class ApproverBonusApplyButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Apply Bonus '%s' for Assignee '%s': %s",
@@ -1453,6 +1460,7 @@ class ApproverPenaltyApplyButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to Apply Penalty '%s' for Assignee '%s': %s",
@@ -1637,6 +1645,7 @@ class ApproverPointsAdjustButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._delta,
                 e,
             )
+            raise
         except (KeyError, ValueError, AttributeError) as e:
             const.LOGGER.error(
                 "ERROR: Failed to adjust points for Assignee '%s' by %d: %s",

--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -134,6 +134,8 @@ PLACEHOLDER_DASHBOARD_MISSING_RECOMMENDED_DEPENDENCIES: Final = (
 )
 PLACEHOLDER_DASHBOARD_TEMPLATE_PREFERENCES: Final = "dashboard_template_preferences"
 PLACEHOLDER_DASHBOARD_STATUS_MESSAGE: Final = "dashboard_status_message"
+PLACEHOLDER_DASHBOARD_ACCESS_WARNING: Final = "dashboard_access_warning"
+PLACEHOLDER_USER_ACCESS_WARNING: Final = "user_access_warning"
 
 # ================================================================================================
 # Dashboard Template Configuration
@@ -839,6 +841,7 @@ CFOF_DASHBOARD_INPUT_ASSIGNEE_SELECTION: Final = "dashboard_assignee_selection"
 CFOF_DASHBOARD_INPUT_ACTION: Final = "dashboard_action"
 CFOF_DASHBOARD_INPUT_UPDATE_SELECTION: Final = "dashboard_update_selection"
 CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS: Final = "dashboard_dependency_bypass"
+CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK: Final = "dashboard_access_warning_ack"
 CFOF_DASHBOARD_INPUT_TEMPLATE_PROFILE: Final = "dashboard_template_profile"
 CFOF_DASHBOARD_INPUT_ADMIN_MODE: Final = "dashboard_admin_mode"
 CFOF_DASHBOARD_INPUT_ADMIN_TEMPLATE_GLOBAL: Final = "dashboard_admin_template_global"
@@ -3501,8 +3504,15 @@ TRANS_KEY_CFOF_DASHBOARD_ADMIN_PER_ASSIGNEE_NEEDS_ASSIGNEES: Final = (
 TRANS_KEY_CFOF_DASHBOARD_DEPENDENCY_ACK_REQUIRED: Final = (
     "dashboard_dependency_ack_required"
 )
+TRANS_KEY_CFOF_DASHBOARD_ACCESS_WARNING_ACK_REQUIRED: Final = (
+    "dashboard_access_warning_ack_required"
+)
 
 # Dashboard runtime message translation keys (exceptions category)
+TRANS_KEY_EXC_USER_NON_KIOSK_UNLINKED_WARNING: Final = "user_non_kiosk_unlinked_warning"
+TRANS_KEY_EXC_DASHBOARD_UNLINKED_USERS_WARNING: Final = (
+    "dashboard_unlinked_users_warning"
+)
 TRANS_KEY_EXC_DASHBOARD_STATUS_PREPARING_RELEASE_ASSETS: Final = (
     "dashboard_status_preparing_release_assets"
 )

--- a/custom_components/choreops/helpers/dashboard_helpers.py
+++ b/custom_components/choreops/helpers/dashboard_helpers.py
@@ -2300,19 +2300,31 @@ def build_dashboard_missing_dependencies_schema(
     continue_default: bool = False,
     *,
     show_dependency_bypass: bool = True,
+    show_access_warning_ack: bool = False,
 ) -> vol.Schema:
     """Build schema for final dashboard review step."""
-    if not show_dependency_bypass:
-        return vol.Schema({})
+    fields: dict[vol.Marker, Any] = {}
 
-    return vol.Schema(
-        {
+    if show_dependency_bypass:
+        fields[
             vol.Optional(
                 const.CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS,
                 default=continue_default,
-            ): selector.BooleanSelector(),
-        }
-    )
+            )
+        ] = selector.BooleanSelector()
+
+    if show_access_warning_ack:
+        fields[
+            vol.Optional(
+                const.CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK,
+                default=False,
+            )
+        ] = selector.BooleanSelector()
+
+    if not fields:
+        return vol.Schema({})
+
+    return vol.Schema(fields)
 
 
 def _get_lovelace_resource_urls(hass: Any) -> list[str]:

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -134,7 +134,7 @@ import voluptuous as vol
 
 from .. import const
 from ..utils.dt_utils import dt_parse, dt_parse_duration
-from . import translation_helpers as th
+from . import entity_helpers as eh, translation_helpers as th
 
 # =============================================================================
 # INPUT VALIDATION HELPERS
@@ -568,6 +568,64 @@ def build_user_section_suggested_values(flat_values: dict[str, Any]) -> dict[str
 def normalize_user_form_input(user_input: dict[str, Any]) -> dict[str, Any]:
     """Public wrapper to normalize USER-form payload shape."""
     return _normalize_user_form_input_impl(user_input)
+
+
+def has_linked_ha_user_id(value: Any) -> bool:
+    """Return whether a Home Assistant user link value is meaningfully set."""
+    if not isinstance(value, str):
+        return False
+
+    normalized_value = value.strip()
+    return bool(normalized_value and normalized_value != const.SENTINEL_NO_SELECTION)
+
+
+def should_warn_user_form_unlinked_non_kiosk(
+    user_input: dict[str, Any],
+    *,
+    kiosk_mode_enabled: bool,
+) -> bool:
+    """Return whether the user form should show the non-kiosk link warning."""
+    if kiosk_mode_enabled:
+        return False
+
+    return bool(user_input.get(const.CFOF_USERS_INPUT_CAN_BE_ASSIGNED, False)) and not (
+        has_linked_ha_user_id(user_input.get(const.CFOF_USERS_INPUT_HA_USER_ID))
+    )
+
+
+def get_dashboard_unlinked_assignee_names_for_warning(
+    coordinator: Any,
+    selected_assignee_names: list[str],
+    *,
+    kiosk_mode_enabled: bool,
+) -> list[str]:
+    """Return selected assignee names that are unlinked while kiosk mode is off."""
+    if kiosk_mode_enabled or not selected_assignee_names:
+        return []
+
+    selected_name_set = {
+        assignee_name
+        for assignee_name in selected_assignee_names
+        if isinstance(assignee_name, str) and assignee_name
+    }
+    if not selected_name_set:
+        return []
+
+    warning_names: list[str] = []
+    for assignee_id, assignee_data in coordinator.assignees_data.items():
+        if not eh.is_user_assignment_participant(coordinator, assignee_id):
+            continue
+
+        assignee_name = assignee_data.get(const.DATA_USER_NAME)
+        if not isinstance(assignee_name, str) or assignee_name not in selected_name_set:
+            continue
+
+        if has_linked_ha_user_id(assignee_data.get(const.DATA_USER_HA_USER_ID)):
+            continue
+
+        warning_names.append(assignee_name)
+
+    return sorted(set(warning_names), key=str.casefold)
 
 
 async def build_user_schema(hass, users, assignees_dict):

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -96,9 +96,11 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
         self._dashboard_delete_selection: list[str] = []
         self._dashboard_dedupe_removed: dict[str, int] = {}
         self._dashboard_skip_dependency_validation_once: bool = False
+        self._dashboard_skip_access_warning_once: bool = False
         self._dashboard_pending_configure_input: dict[str, Any] | None = None
         self._dashboard_missing_required_dependencies: list[str] = []
         self._dashboard_missing_recommended_dependencies: list[str] = []
+        self._dashboard_unlinked_warning_user_names: list[str] = []
         self._dashboard_missing_dependency_metadata: dict[str, dict[str, str]] = {}
         self._dashboard_template_preferences_markdown: str = const.SENTINEL_EMPTY
         self._dashboard_ui_none_label: str = const.TRANS_KEY_EXC_DASHBOARD_LABEL_NONE
@@ -111,6 +113,7 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
         self._dashboard_release_asset_cache_key: str | None = None
         self._dashboard_release_asset_cache: DashboardReleaseAssets | None = None
         self._dashboard_runtime_messages: dict[str, str] | None = None
+        self._pending_user_access_warning_input: dict[str, Any] | None = None
 
     async def _async_get_dashboard_runtime_message(
         self,
@@ -138,6 +141,82 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 message = message.format(**placeholders)
 
         return message
+
+    async def _async_get_exception_message(
+        self,
+        translation_key: str,
+        *,
+        placeholders: dict[str, Any] | None = None,
+        fallback: str = "",
+    ) -> str:
+        """Return localized exception text for options-flow warning placeholders."""
+        if self._dashboard_runtime_messages is None:
+            self._dashboard_runtime_messages = await translation.async_get_translations(
+                self.hass,
+                self.hass.config.language,
+                "exceptions",
+                integrations=[const.DOMAIN],
+            )
+
+        message = self._dashboard_runtime_messages.get(
+            f"component.{const.DOMAIN}.exceptions.{translation_key}.message",
+            fallback,
+        )
+        if placeholders:
+            with contextlib.suppress(KeyError, ValueError):
+                message = message.format(**placeholders)
+        return message
+
+    def _is_kiosk_mode_enabled(self) -> bool:
+        """Return whether kiosk mode is currently enabled for the integration."""
+        return bool(
+            self.config_entry.options.get(
+                const.CONF_KIOSK_MODE,
+                const.DEFAULT_KIOSK_MODE,
+            )
+        )
+
+    async def _async_get_user_access_warning_text(
+        self,
+        user_input: dict[str, Any],
+    ) -> str:
+        """Return the add/edit user warning text when needed."""
+        if not fh.should_warn_user_form_unlinked_non_kiosk(
+            user_input,
+            kiosk_mode_enabled=self._is_kiosk_mode_enabled(),
+        ):
+            return const.SENTINEL_EMPTY
+
+        return await self._async_get_exception_message(
+            const.TRANS_KEY_EXC_USER_NON_KIOSK_UNLINKED_WARNING,
+            fallback=const.SENTINEL_EMPTY,
+        )
+
+    def _should_pause_for_user_access_warning(
+        self,
+        user_input: dict[str, Any],
+    ) -> bool:
+        """Return whether the user form should pause once to show the warning."""
+        if not fh.should_warn_user_form_unlinked_non_kiosk(
+            user_input,
+            kiosk_mode_enabled=self._is_kiosk_mode_enabled(),
+        ):
+            self._pending_user_access_warning_input = None
+            return False
+
+        if self._pending_user_access_warning_input == user_input:
+            self._pending_user_access_warning_input = None
+            return False
+
+        self._pending_user_access_warning_input = dict(user_input)
+        return True
+
+    def _build_markdown_bullet_lines(self, items: list[str]) -> str:
+        """Return markdown bullet lines for simple string lists."""
+        if not items:
+            return self._dashboard_ui_none_label
+
+        return "\n".join(f"- {item}" for item in items)
 
     async def _async_refresh_dashboard_runtime_labels(self) -> None:
         """Refresh localized labels used in dashboard markdown placeholders."""
@@ -679,25 +758,30 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             )
 
             if not errors:
-                try:
-                    # Use UserManager for user-profile creation (handles linked profile internally)
-                    # Immediate persist for reload
-                    internal_id = coordinator.user_manager.create_user(
-                        user_input, immediate_persist=True
-                    )
-                    user_name = user_input.get(const.CFOF_USERS_INPUT_NAME, internal_id)
+                if self._should_pause_for_user_access_warning(user_input):
+                    errors[const.CFOP_ERROR_BASE] = const.SENTINEL_EMPTY
+                else:
+                    try:
+                        # Use UserManager for user-profile creation (handles linked profile internally)
+                        # Immediate persist for reload
+                        internal_id = coordinator.user_manager.create_user(
+                            user_input, immediate_persist=True
+                        )
+                        user_name = user_input.get(
+                            const.CFOF_USERS_INPUT_NAME, internal_id
+                        )
 
-                    self._mark_reload_needed()
+                        self._mark_reload_needed()
 
-                    const.LOGGER.debug(
-                        "Added user profile '%s' with ID: %s",
-                        user_name,
-                        internal_id,
-                    )
-                    return await self.async_step_init()
+                        const.LOGGER.debug(
+                            "Added user profile '%s' with ID: %s",
+                            user_name,
+                            internal_id,
+                        )
+                        return await self.async_step_init()
 
-                except EntityValidationError as err:
-                    errors[err.field] = err.translation_key
+                    except EntityValidationError as err:
+                        errors[err.field] = err.translation_key
 
         # Retrieve HA users and existing assignees for linking
         users = await self.hass.auth.async_get_users()
@@ -723,7 +807,10 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=user_schema,
             errors=fh.map_user_form_errors(errors),
             description_placeholders={
-                const.PLACEHOLDER_DOCUMENTATION_URL: const.DOC_URL_USERS
+                const.PLACEHOLDER_DOCUMENTATION_URL: const.DOC_URL_USERS,
+                const.PLACEHOLDER_USER_ACCESS_WARNING: (
+                    await self._async_get_user_access_warning_text(user_input or {})
+                ),
             },
         )
 
@@ -762,34 +849,39 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             )
 
             if not errors:
-                try:
-                    # Build merged user-profile data using data_builders
-                    updated_approver = db.build_user_profile(
-                        user_input,
-                        existing=user_profile,
-                    )
+                if self._should_pause_for_user_access_warning(user_input):
+                    errors[const.CFOP_ERROR_BASE] = const.SENTINEL_EMPTY
+                else:
+                    try:
+                        # Build merged user-profile data using data_builders
+                        updated_approver = db.build_user_profile(
+                            user_input,
+                            existing=user_profile,
+                        )
 
-                    # Use UserManager for user-profile update (handles linked profile create/unlink)
-                    # Immediate persist for reload
-                    coordinator.user_manager.update_user(
-                        str(internal_id), dict(updated_approver), immediate_persist=True
-                    )
+                        # Use UserManager for user-profile update (handles linked profile create/unlink)
+                        # Immediate persist for reload
+                        coordinator.user_manager.update_user(
+                            str(internal_id),
+                            dict(updated_approver),
+                            immediate_persist=True,
+                        )
 
-                    await coordinator.system_manager.remove_conditional_entities(
-                        user_ids=[str(internal_id)]
-                    )
+                        await coordinator.system_manager.remove_conditional_entities(
+                            user_ids=[str(internal_id)]
+                        )
 
-                    const.LOGGER.debug(
-                        "Edited user profile '%s' with ID: %s",
-                        updated_approver[const.DATA_USER_NAME],
-                        internal_id,
-                    )
-                    self._mark_reload_needed()
-                    return await self.async_step_init()
+                        const.LOGGER.debug(
+                            "Edited user profile '%s' with ID: %s",
+                            updated_approver[const.DATA_USER_NAME],
+                            internal_id,
+                        )
+                        self._mark_reload_needed()
+                        return await self.async_step_init()
 
-                except EntityValidationError as err:
-                    # Map field-specific error for form highlighting
-                    errors[err.field] = err.translation_key
+                    except EntityValidationError as err:
+                        # Map field-specific error for form highlighting
+                        errors[err.field] = err.translation_key
 
         # Retrieve HA users and existing assignees for linking
         users = await self.hass.auth.async_get_users()
@@ -901,7 +993,10 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=user_schema,
             errors=fh.map_user_form_errors(errors),
             description_placeholders={
-                const.PLACEHOLDER_DOCUMENTATION_URL: const.DOC_URL_USERS
+                const.PLACEHOLDER_DOCUMENTATION_URL: const.DOC_URL_USERS,
+                const.PLACEHOLDER_USER_ACCESS_WARNING: (
+                    await self._async_get_user_access_warning_text(suggested_values)
+                ),
             },
         )
 
@@ -4069,7 +4164,9 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             user_input = dh.normalize_dashboard_configure_input(user_input)
             await self._async_refresh_dashboard_runtime_labels()
             skip_dependency_validation = self._dashboard_skip_dependency_validation_once
+            skip_access_warning = self._dashboard_skip_access_warning_once
             self._dashboard_skip_dependency_validation_once = False
+            self._dashboard_skip_access_warning_once = False
             self._dashboard_dedupe_removed = {}
             selected_assignees_input = user_input.get(
                 const.CFOF_DASHBOARD_INPUT_ASSIGNEE_SELECTION,
@@ -4383,10 +4480,22 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                         )
 
                     if not errors:
+                        unlinked_warning_names = (
+                            []
+                            if skip_access_warning
+                            else fh.get_dashboard_unlinked_assignee_names_for_warning(
+                                coordinator,
+                                selected_assignees,
+                                kiosk_mode_enabled=self._is_kiosk_mode_enabled(),
+                            )
+                        )
                         self._dashboard_pending_configure_input = user_input
                         self._dashboard_missing_required_dependencies = missing_required
                         self._dashboard_missing_recommended_dependencies = (
                             missing_recommended
+                        )
+                        self._dashboard_unlinked_warning_user_names = (
+                            unlinked_warning_names
                         )
                         self._dashboard_missing_dependency_metadata = {
                             dependency_id: {
@@ -4633,6 +4742,9 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             continue_anyway = bool(
                 user_input.get(const.CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS, False)
             )
+            acknowledge_access_warning = bool(
+                user_input.get(const.CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK, False)
+            )
 
             if self._dashboard_missing_required_dependencies and not continue_anyway:
                 self._dashboard_status_message = await self._async_get_dashboard_runtime_message(
@@ -4665,14 +4777,71 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                     ),
                 )
 
+            if (
+                self._dashboard_unlinked_warning_user_names
+                and not acknowledge_access_warning
+            ):
+                errors[const.CFOP_ERROR_BASE] = (
+                    const.TRANS_KEY_CFOF_DASHBOARD_ACCESS_WARNING_ACK_REQUIRED
+                )
+
             if not self._dashboard_missing_required_dependencies or continue_anyway:
+                if (
+                    self._dashboard_unlinked_warning_user_names
+                    and not acknowledge_access_warning
+                ):
+                    schema = dh.build_dashboard_missing_dependencies_schema(
+                        show_dependency_bypass=bool(
+                            self._dashboard_missing_required_dependencies
+                        ),
+                        show_access_warning_ack=bool(
+                            self._dashboard_unlinked_warning_user_names
+                        ),
+                    )
+                    return self.async_show_form(
+                        step_id=const.OPTIONS_FLOW_STEP_DASHBOARD_MISSING_DEPENDENCIES,
+                        data_schema=schema,
+                        errors=errors,
+                        description_placeholders={
+                            const.PLACEHOLDER_DOCUMENTATION_URL: const.DOC_URL_DASHBOARD_GENERATION,
+                            const.PLACEHOLDER_DASHBOARD_MISSING_REQUIRED_DEPENDENCIES: (
+                                self._build_dashboard_dependency_markdown_lines(
+                                    self._dashboard_missing_required_dependencies,
+                                    item_prefix="❌",
+                                )
+                            ),
+                            const.PLACEHOLDER_DASHBOARD_MISSING_RECOMMENDED_DEPENDENCIES: (
+                                self._build_dashboard_dependency_markdown_lines(
+                                    self._dashboard_missing_recommended_dependencies,
+                                    item_prefix="❌",
+                                )
+                            ),
+                            const.PLACEHOLDER_DASHBOARD_TEMPLATE_PREFERENCES: (
+                                self._dashboard_template_preferences_markdown
+                            ),
+                            const.PLACEHOLDER_DASHBOARD_ACCESS_WARNING: (
+                                await self._async_get_exception_message(
+                                    const.TRANS_KEY_EXC_DASHBOARD_UNLINKED_USERS_WARNING,
+                                    placeholders={
+                                        "user_list": self._build_markdown_bullet_lines(
+                                            self._dashboard_unlinked_warning_user_names
+                                        )
+                                    },
+                                    fallback=const.SENTINEL_EMPTY,
+                                )
+                            ),
+                        },
+                    )
+
                 pending_input = self._dashboard_pending_configure_input
                 self._dashboard_pending_configure_input = None
                 self._dashboard_skip_dependency_validation_once = True
+                self._dashboard_skip_access_warning_once = True
                 return await self.async_step_dashboard_configure(pending_input)
 
         schema = dh.build_dashboard_missing_dependencies_schema(
-            show_dependency_bypass=bool(self._dashboard_missing_required_dependencies)
+            show_dependency_bypass=bool(self._dashboard_missing_required_dependencies),
+            show_access_warning_ack=bool(self._dashboard_unlinked_warning_user_names),
         )
         return self.async_show_form(
             step_id=const.OPTIONS_FLOW_STEP_DASHBOARD_MISSING_DEPENDENCIES,
@@ -4694,6 +4863,19 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 const.PLACEHOLDER_DASHBOARD_TEMPLATE_PREFERENCES: (
                     self._dashboard_template_preferences_markdown
+                ),
+                const.PLACEHOLDER_DASHBOARD_ACCESS_WARNING: (
+                    await self._async_get_exception_message(
+                        const.TRANS_KEY_EXC_DASHBOARD_UNLINKED_USERS_WARNING,
+                        placeholders={
+                            "user_list": self._build_markdown_bullet_lines(
+                                self._dashboard_unlinked_warning_user_names
+                            )
+                        },
+                        fallback=const.SENTINEL_EMPTY,
+                    )
+                    if self._dashboard_unlinked_warning_user_names
+                    else self._dashboard_ui_none_label
                 ),
             },
         )

--- a/custom_components/choreops/translations/ca.json
+++ b/custom_components/choreops/translations/ca.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Nom únic per a aquest perfil d'usuari.",
-              "ha_user_id": "Opcional: Enllaça aquest perfil a un usuari de Home Assistant.",
+              "ha_user_id": "Opcional: Enllaça aquest perfil a un usuari de Home Assistant. Si el mode quiosc està desactivat, les accions de reclamació i bescanvi de dispositius compartits depenen d'aquest enllaç.",
               "dashboard_language": "Idioma utilitzat per al contingut i les notificacions del tauler de control.",
               "mobile_notify_service": "Seleccioneu el servei de notificacions o deixeu-ho en blanc per desactivar les notificacions."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Afegeix un usuari",
-        "description": "Proporcioneu els detalls del nou perfil d'usuari.\n\n ℹ️ [Guia de configuració]({documentation_url})",
+        "description": "Proporcioneu els detalls del nou perfil d'usuari.\n\n{user_access_warning}\n\n ℹ️ [Guia de configuració]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitat i perfil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Nom únic per a aquest perfil d'usuari.",
-              "ha_user_id": "Opcional: Enllaça aquest perfil a un usuari de Home Assistant.",
+              "ha_user_id": "Opcional: Enllaça aquest perfil a un usuari de Home Assistant. Si el mode quiosc està desactivat, les accions de reclamació i bescanvi de dispositius compartits depenen d'aquest enllaç.",
               "dashboard_language": "Idioma utilitzat per al contingut i les notificacions del tauler de control.",
               "mobile_notify_service": "Seleccioneu el servei de notificacions o deixeu-ho en blanc per desactivar les notificacions."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Edita l'usuari",
-        "description": "Modifiqueu els detalls del perfil d'usuari seleccionat.\n\n ℹ️ [Guia de configuració]({documentation_url})",
+        "description": "Modifiqueu els detalls del perfil d'usuari seleccionat.\n\n{user_access_warning}\n\n ℹ️ [Guia de configuració]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitat i perfil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Nom únic per a aquest perfil d'usuari.",
-              "ha_user_id": "Opcional: Enllaça aquest perfil a un usuari de Home Assistant.",
+              "ha_user_id": "Opcional: Enllaça aquest perfil a un usuari de Home Assistant. Si el mode quiosc està desactivat, les accions de reclamació i bescanvi de dispositius compartits depenen d'aquest enllaç.",
               "dashboard_language": "Idioma utilitzat per al contingut i les notificacions del tauler de control.",
               "mobile_notify_service": "Seleccioneu el servei de notificacions o deixeu-ho en blanc per desactivar les notificacions."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Revisa els canvis del tauler de control",
-        "description": "Reviseu l'estat de les dependències i les preferències de plantilla per a les plantilles seleccionades abans d'aplicar els canvis al tauler de control.\n\n ℹ️ [Guia de configuració del tauler de control]({documentation_url})\n\n**Personalitzacions disponibles**\n{dashboard_template_preferences}\n\n**Falten les dependències obligatòries**\n{dashboard_missing_required_dependencies}\n\n**Falten les dependències recomanades**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Reviseu l'estat de les dependències i les preferències de plantilla per a les plantilles seleccionades abans d'aplicar els canvis al tauler de control.\n\n ℹ️ [Guia de configuració del tauler de control]({documentation_url})\n\n**Personalitzacions disponibles**\n{dashboard_template_preferences}\n\n**Falten dependències obligatòries**\n{dashboard_missing_required_dependencies}\n\n**Falten dependències recomanades**\n{dashboard_missing_recommended_dependencies}\n\n**Avís de control d'accés**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Continua igualment (falten requisits)"
+          "dashboard_dependency_bypass": "🚫 Continua igualment (falten requisits)",
+          "dashboard_access_warning_ack": "⚠️ Continua igualment (els usuaris seleccionats no estan vinculats)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Reconeix que falten dependències necessàries i continua igualment. És possible que el tauler de control no es renderitzi o es comporti incorrectament fins que no s'instal·lin les dependències necessàries."
+          "dashboard_dependency_bypass": "Reconeix que falten dependències necessàries i continua igualment. És possible que el tauler de control no es renderitzi o es comporti incorrectament fins que no s'instal·lin les dependències necessàries.",
+          "dashboard_access_warning_ack": "Tingueu en compte que alguns usuaris seleccionats no tenen usuaris de Home Assistant vinculats mentre el mode quiosc està desactivat. És possible que els botons de reclamació i bescanvi no funcionin correctament en dispositius compartits fins que aquests usuaris no estiguin vinculats o el mode quiosc estigui activat."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Cal una plantilla d'administració per usuari quan el disseny d'administració inclou Per usuari.",
       "dashboard_admin_per_assignee_needs_assignees": "El disseny d'administració per usuari requereix com a mínim un usuari seleccionat.",
       "dashboard_dependency_ack_required": "Activeu \"Continua igualment\" per continuar o torneu enrere i instal·leu primer les dependències necessàries que falten.",
+      "dashboard_access_warning_ack_required": "Reconeix l'avís de control d'accés per continuar, torna enrere i enllaça els usuaris afectats o activa el mode quiosc.",
       "dashboard_nonselectable_templates": "Una o més plantilles seleccionades no estan disponibles per a la generació.",
       "dashboard_release_strict_pin_failed": "La versió seleccionada del tauler de control ha d'estar fixada exactament, però no hi havia cap referència de versió efectiva disponible en el moment de l'execució. Torneu a seleccionar la versió al pas 1 i torneu-ho a provar.",
       "dashboard_release_asset_prep_failed": "No s'han pogut preparar els recursos del tauler de control en línia seleccionats. Trieu una versió diferent o utilitzeu les plantilles locals compatibles/actuals més recents i torneu-ho a provar."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Guia de preferències no proporcionada"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Avís d'accés:** El mode quiosc està desactivat i aquest usuari no està vinculat a cap usuari de Home Assistant. És possible que els botons de reclamació i bescanvi de dispositius compartits no funcionin per a aquest usuari fins que no vinculis un usuari de Home Assistant o activis el mode quiosc."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ El mode quiosc està desactivat i aquests usuaris seleccionats no tenen usuaris de Home Assistant vinculats:\n{user_list}\n\nÉs possible que els botons de reclamació i bescanvi no funcionin correctament en dispositius compartits fins que aquests usuaris no estiguin vinculats o el mode quiosc estigui habilitat."
     },
     "not_authorized_action": {
       "message": "No esteu autoritzat a {action} per a aquest cessionari."

--- a/custom_components/choreops/translations/da.json
+++ b/custom_components/choreops/translations/da.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Unikt navn for denne brugerprofil.",
-              "ha_user_id": "Valgfrit: Knyt denne profil til en Home Assistant-bruger.",
+              "ha_user_id": "Valgfrit: Link denne profil til en Home Assistant-bruger. Hvis kiosktilstand er deaktiveret, afhænger handlinger for krav og indløsning af delte enheder af dette link.",
               "dashboard_language": "Sprog, der bruges til dashboardindhold og meddelelser.",
               "mobile_notify_service": "Vælg notifikationstjeneste, eller lad feltet stå tomt for at deaktivere notifikationer."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Tilføj bruger",
-        "description": "Angiv oplysningerne for den nye brugerprofil.\n\n ℹ️ [Konfigurationsvejledning]({documentation_url})",
+        "description": "Angiv oplysningerne for den nye brugerprofil.\n\n{user_access_warning}\n\n ℹ️ [Konfigurationsvejledning]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitet og profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Unikt navn for denne brugerprofil.",
-              "ha_user_id": "Valgfrit: Knyt denne profil til en Home Assistant-bruger.",
+              "ha_user_id": "Valgfrit: Link denne profil til en Home Assistant-bruger. Hvis kiosktilstand er deaktiveret, afhænger handlinger for krav og indløsning af delte enheder af dette link.",
               "dashboard_language": "Sprog, der bruges til dashboardindhold og meddelelser.",
               "mobile_notify_service": "Vælg notifikationstjeneste, eller lad feltet stå tomt for at deaktivere notifikationer."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Rediger bruger",
-        "description": "Rediger detaljerne for den valgte brugerprofil.\n\n ℹ️ [Konfigurationsvejledning]({documentation_url})",
+        "description": "Rediger oplysningerne for den valgte brugerprofil.\n\n{user_access_warning}\n\n ℹ️ [Konfigurationsvejledning]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitet og profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Unikt navn for denne brugerprofil.",
-              "ha_user_id": "Valgfrit: Knyt denne profil til en Home Assistant-bruger.",
+              "ha_user_id": "Valgfrit: Link denne profil til en Home Assistant-bruger. Hvis kiosktilstand er deaktiveret, afhænger handlinger for krav og indløsning af delte enheder af dette link.",
               "dashboard_language": "Sprog, der bruges til dashboardindhold og meddelelser.",
               "mobile_notify_service": "Vælg notifikationstjeneste, eller lad feltet stå tomt for at deaktivere notifikationer."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Gennemgå ændringer i dashboardet",
-        "description": "Gennemgå afhængighedsstatus og skabelonpræferencer for dine valgte skabeloner, før du anvender ændringer af dashboardet.\n\n ℹ️ [Konfigurationsvejledning til dashboard]({documentation_url})\n\n**Tilgængelige tilpasninger**\n{dashboard_template_preferences}\n\n**Mangler nødvendige afhængigheder**\n{dashboard_missing_required_dependencies}\n\n**Mangler anbefalede afhængigheder**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Gennemgå afhængighedsstatus og skabelonpræferencer for dine valgte skabeloner, før du anvender ændringer af dashboardet.\n\n ℹ️ [Konfigurationsvejledning til dashboard]({documentation_url})\n\n**Tilgængelige tilpasninger**\n{dashboard_template_preferences}\n\n**Mangler nødvendige afhængigheder**\n{dashboard_missing_required_dependencies}\n\n**Mangler anbefalede afhængigheder**\n{dashboard_missing_recommended_dependencies}\n\n**Advarsel om adgangskontrol**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Fortsæt alligevel (krav mangler)"
+          "dashboard_dependency_bypass": "🚫 Fortsæt alligevel (krav mangler)",
+          "dashboard_access_warning_ack": "⚠️ Fortsæt alligevel (de valgte brugere er ikke linket)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Anerkend, at der mangler nødvendige afhængigheder, og fortsæt alligevel. Dashboardet gengives muligvis ikke eller fungerer muligvis forkert, før de nødvendige afhængigheder er installeret."
+          "dashboard_dependency_bypass": "Anerkend, at der mangler nødvendige afhængigheder, og fortsæt alligevel. Dashboardet gengives muligvis ikke eller fungerer muligvis forkert, før de nødvendige afhængigheder er installeret.",
+          "dashboard_access_warning_ack": "Anerkend, at nogle udvalgte brugere ikke har tilknyttede Home Assistant-brugere, mens kiosktilstand er deaktiveret. Knapper til at gøre krav på og indløse fungerer muligvis ikke som forventet på delte enheder, før disse brugere er tilknyttet, eller kiosktilstand er aktiveret."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "En administratorskabelon pr. bruger er påkrævet, når administratorlayoutet inkluderer pr. bruger.",
       "dashboard_admin_per_assignee_needs_assignees": "Adminlayout pr. bruger kræver mindst én valgt bruger.",
       "dashboard_dependency_ack_required": "Aktivér 'Fortsæt alligevel' for at fortsætte, eller gå tilbage og installer manglende nødvendige afhængigheder først.",
+      "dashboard_access_warning_ack_required": "Bekræft advarslen om adgangskontrol for at fortsætte, eller gå tilbage og forbind de berørte brugere eller aktiver kiosktilstand.",
       "dashboard_nonselectable_templates": "En eller flere valgte skabeloner kan ikke genereres.",
       "dashboard_release_strict_pin_failed": "Den valgte dashboard-udgivelse skal være præcist fastgjort, men der var ingen effektiv udgivelsesreference tilgængelig på udførelsestidspunktet. Vælg udgivelsen igen i trin 1, og prøv igen.",
       "dashboard_release_asset_prep_failed": "De valgte online dashboard-aktiver kunne ikke forberedes. Vælg en anden udgivelse, eller brug de seneste kompatible/aktuelle lokale skabeloner, og prøv igen."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Præferencevejledning ikke medtaget"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Adgangsadvarsel:** Kiosktilstand er deaktiveret, og denne bruger er ikke knyttet til en Home Assistant-bruger. Knapper til krav og indløsning af delte enheder fungerer muligvis ikke for denne bruger, før du linker en Home Assistant-bruger eller aktiverer kiosktilstand."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Kiosktilstand er deaktiveret, og disse valgte brugere har ikke tilknyttede Home Assistant-brugere:\n{user_list}\n\nKnapper til at gøre krav på og indløse fungerer muligvis ikke som forventet på delte enheder, før disse brugere er tilknyttet, eller kiosktilstand er aktiveret."
     },
     "not_authorized_action": {
       "message": "Du er ikke autoriseret til at {action} for denne overdragelsesmodtager."

--- a/custom_components/choreops/translations/de.json
+++ b/custom_components/choreops/translations/de.json
@@ -56,23 +56,23 @@
           "default_chore_points": "Standardmäßiger Punktewert verwendet, wenn eine Aufgabe erstellt wird, es sei denn, du legst für diese Aufgabe benutzerdefinierte Punkte fest.",
           "update_interval": "Wie oft sollen die Daten aktualisiert werden (Minimum: 1 Minute)",
           "calendar_show_period": "Tage des Verlaufs, die im Kalender angezeigt werden sollen (mindestens 1)",
-          "retention_daily": "Tage, um die täglichen Aggregate zu erfassen",
-          "retention_weekly": "Wochen, um wöchentliche Aggregate zu erfassen",
-          "retention_monthly": "Monate, um monatliche Aggregate zu erfassen",
-          "retention_yearly": "Jahre, um die jährlichen Aggregate zu erfassen",
+          "retention_daily": "Tage, um die tägliche Gesamtsumme zu erfassen",
+          "retention_weekly": "Wochen, um wöchentliche Gesamtsumme zu erfassen",
+          "retention_monthly": "Monate, um monatliche Gesamtsumme zu erfassen",
+          "retention_yearly": "Jahre, um jährliche Gesamtsumme zu erfassen",
           "points_adjust_values": "Durch Pipes getrennte Punktwerte für manuelle Einstellknöpfe (z. B. +1,0|-1,0|+10,0|-10,0)"
         }
       },
       "user_count": {
         "title": "Anzahl der Nutzer",
-        "description": "Wie viele Benutzer möchten Sie anfänglich definieren?",
+        "description": "Wie viele Benutzer möchtest du anfänglich definieren?",
         "data": {
           "user_count": "Anzahl der Nutzer"
         }
       },
       "users": {
         "title": "Benutzer definieren",
-        "description": "Geben Sie die Details für jedes Benutzerprofil ein.",
+        "description": "Gib die Details für jedes Benutzerprofil ein.",
         "sections": {
           "section_identity_profile": {
             "name": "Identität und Profil",
@@ -85,14 +85,14 @@
             },
             "data_description": {
               "name": "Eindeutiger Name für dieses Benutzerprofil.",
-              "ha_user_id": "Optional: Verknüpfen Sie dieses Profil mit einem Home Assistant-Benutzer.",
+              "ha_user_id": "Optional: Verknüpfen Sie dieses Profil mit einem Home Assistant-Benutzer. Wenn der Kioskmodus deaktiviert ist, basieren Aktionen zum Beanspruchen und Einlösen von gemeinsam genutzten Geräten auf dieser Verknüpfung.",
               "dashboard_language": "Sprache, die für Dashboard-Inhalte und Benachrichtigungen verwendet wird.",
-              "mobile_notify_service": "Wählen Sie einen Benachrichtigungsdienst aus oder lassen Sie das Feld leer, um Benachrichtigungen zu deaktivieren."
+              "mobile_notify_service": "Wähle einen Benachrichtigungsdienst aus oder lass das Feld leer, um Benachrichtigungen zu deaktivieren."
             }
           },
           "section_system_usage": {
             "name": "Systemnutzung",
-            "description": "Steuerungsmöglichkeiten für die normale Nutzung bei Hausarbeiten und Gamifizierung.",
+            "description": "Steuerungsmöglichkeiten für die normale Nutzung von Aufgaben und Gamifizierung.",
             "data": {
               "can_be_assigned": "Kann zugewiesen werden",
               "enable_chore_workflow": "Workflow aktiviert",
@@ -101,15 +101,15 @@
             "data_description": {
               "can_be_assigned": "Ermöglicht es, diesem Profil Aufgaben zuzuweisen.",
               "enable_chore_workflow": "Ermöglicht die Annahme/Ablehnung von Workflow-Aktionen für zugewiesene Aufgaben.",
-              "enable_gamification": "Ermöglicht das Sammeln von Punkten, Abzeichen und Belohnungen für die Teilnahme."
+              "enable_gamification": "Ermöglicht die Teilnahme an Punkten, Abzeichen und Belohnungen."
             }
           },
           "section_admin_approval": {
             "name": "Verwaltungs- und Genehmigungsoptionen",
-            "description": "Höherprivilegierte Genehmigungs- und Managementkontrollen.",
+            "description": "Genehmigungs- und Managementkontrollen mit höheren Berechtigungen.",
             "data": {
               "can_approve": "Kann genehmigen",
-              "can_manage": "Kann ich bewältigen",
+              "can_manage": "Kann verwalten",
               "associated_user_ids": "Zugehörige Benutzer"
             },
             "data_description": {
@@ -121,24 +121,24 @@
         }
       },
       "chore_count": {
-        "title": "Anzahl der Hausarbeiten",
-        "description": "Wie viele Hausarbeiten möchten Sie definieren?",
+        "title": "Anzahl der Aufgaben",
+        "description": "Wie viele Aufgaben möchtest du definieren?",
         "data": {
-          "chore_count": "Anzahl der Hausarbeiten"
+          "chore_count": "Anzahl der Aufgaben"
         }
       },
       "chores": {
-        "title": "Hausarbeit hinzufügen",
-        "description": "Geben Sie die Details für die neue Hausarbeit ein.",
+        "title": "Aufgabe hinzufügen",
+        "description": "Erstelle eine neue Aufgabe mit Punkten, Zuweisungen und einem wiederkehrenden Zeitplan.",
         "sections": {
           "section_root_form": {
             "name": "Definition",
-            "description": "Identität, Zuordnung und Kernvertragseinstellungen.",
+            "description": "Identität, Zuordnung und Kernvereinbarungseinstellungen.",
             "data": {
-              "name": "Name der Hausarbeit",
-              "chore_description": "Beschreibung (optional)",
-              "icon": "Symbol (mdi:xxx)",
-              "default_points": "Standard-Punkte",
+              "name": "📋 Name der Aufgabe",
+              "chore_description": "📋 Beschreibung (optional)",
+              "icon": "📋 Symbol (mdi:xxx)",
+              "default_points": "💰 Vergebene Punkte",
               "assigned_user_ids": "👥 Zugewiesen an",
               "completion_criteria": "👥 Abschlusskriterien"
             },
@@ -212,12 +212,12 @@
           "approval_reset_pending_claim_action": "➡️ Bearbeitung ausstehender Anträge nach Genehmigungs-Reset",
           "overdue_handling_type": "⏰ Überfällig: Bearbeitung",
           "chore_claim_lock_until_window": "🔒 Anspruch bis zum Fälligkeitstermin sperren?",
-          "auto_approve": "✅ Automatische Genehmigung von Schadensfällen?",
-          "recurring_frequency": "Wiederkehrende Häufigkeit",
-          "custom_interval": "Benutzerdefiniertes Intervall (nur verwenden, wenn benutzerdefinierte Häufigkeit gewählt ist)",
-          "custom_interval_unit": "Benutzerdefinierte wiederkehrende Periodizität",
-          "applicable_days": "Anwendbare Tage",
-          "due_date": "Fälligkeitsdatum",
+          "auto_approve": "✅ Automatische Genehmigung von Ansprüchen?",
+          "recurring_frequency": "🔄 Zeitplan: Häufigkeit",
+          "custom_interval": "🔄 Zeitplan: Benutzerdefiniertes Intervall (für benutzerdefinierte Frequenz)",
+          "custom_interval_unit": "🔄 Zeitplan: Benutzerdefinierte Intervalleinheit",
+          "applicable_days": "📅 Zeitplan: Anwendbare Tage (optional)",
+          "due_date": "📅 Zeitplan: Fälligkeitsdatum (optional)",
           "chore_due_window_offset": "⏱️ Fälligkeitszeitraum: Versatz vor dem Fälligkeitsdatum",
           "chore_due_reminder_offset": "🔔 Fälligkeitserinnerung: Verrechnung vor dem Fälligkeitsdatum",
           "show_on_calendar": "📅 Im Kalender anzeigen?",
@@ -226,48 +226,48 @@
         "data_description": {
           "name": "Eindeutiger Name, der im gesamten System angezeigt wird.",
           "chore_description": "Optionale Anweisungen oder Details zur Erledigung dieser Aufgabe.",
-          "icon": "Material Design Icon (z. B. mdi:broom, mdi:dishwasher).",
+          "icon": "Material Design Symbol (z. B. mdi:broom, mdi:dishwasher).",
           "chore_labels": "Schlagwörter zur Organisation von Aufgaben (z. B. „Küche“, „Garten“). Felder leer lassen, falls nicht benötigt.",
-          "default_points": "Punkte werden nach Abschluss gutgeschrieben.",
-          "assigned_user_ids": "Zugewiesene Personen, die diese Aufgabe sehen und übernehmen können.",
-          "completion_criteria": "Steuert, wie die Aufgabe erledigt wird, wenn mehrere Personen zugewiesen sind: individuelle Nachverfolgung, gemeinsame Erledigung oder turnusbasierte Rotation.",
+          "default_points": "Erhaltene Punkte nach Fertigstellung.",
+          "assigned_user_ids": "Zugewiesene Personen, die diese Aufgabe sehen und beanspruchen können.",
+          "completion_criteria": "Steuert, wie die Aufgabe erledigt wird, wenn mehrere Personen zugewiesen sind: individuelle Nachverfolgung, gemeinsame Erledigung oder wechselnde Rotation.",
           "approval_reset_type": "Steuert, wann die Genehmigungszyklusgrenze der Aufgabe ausgelöst wird (Mitternacht, Fälligkeitsdatum, nach Abschluss oder manueller Auslöser).",
-          "approval_reset_pending_claim_action": "Dies geschieht mit Anträgen, die noch auf Genehmigung warten, wenn der Genehmigungs-Reset erfolgt.",
-          "overdue_handling_type": "Vorgehensweise nach Ablauf der Frist: Überfälligen Status ausblenden, überfällig bis zur Inanspruchnahme beibehalten oder im nächsten Genehmigungszyklus auf ausstehend zurücksetzen.",
-          "chore_claim_lock_until_window": "Wenn diese Option aktiviert ist, können die Bearbeiter diese Aufgabe erst ab Beginn des Fälligkeitszeitraums beanspruchen.",
-          "auto_approve": "Wenn diese Funktion aktiviert ist, werden Anträge sofort und ohne Genehmigungsprüfung freigegeben.",
+          "approval_reset_pending_claim_action": "Dies geschieht mit Ansprüchen, die noch auf Genehmigung warten, wenn der Genehmigungs-Reset erfolgt.",
+          "overdue_handling_type": "Aktion nach dem Fälligkeitstermin: Status überfällig ausblenden, überfällig bis zur Inanspruchnahme beibehalten oder im nächsten Genehmigungszyklus auf ausstehend zurücksetzen.",
+          "chore_claim_lock_until_window": "Wenn diese Option aktiviert ist, können die zugewiesenen Personen diese Aufgabe nicht vor Beginn des Fälligkeitszeitraums beanspruchen.",
+          "auto_approve": "Wenn diese Funktion aktiviert ist, werden Ansprüche sofort und ohne Genehmigungsprüfung freigegeben.",
           "recurring_frequency": "Wie häufig die Aufgabe anfällt: Täglich, Wöchentlich, Monatlich, Jährlich, Benutzerdefiniert oder Keine.",
-          "custom_interval": "Anzahl der Zeiteinheiten zwischen den Wiederholungen (z. B. 3 für „alle 3 Wochen“). Wird nur bei benutzerdefinierter Frequenz verwendet.",
-          "custom_interval_unit": "Zeiteinheit für benutzerdefinierte Intervalle (Tage, Wochen, Monate). Nur bei benutzerdefinierter Frequenz verwendbar.",
-          "applicable_days": "Lassen Sie alle Felder leer. Wählen Sie NUR die gewünschten Tage aus, um die Einschränkung zu aktivieren.",
-          "due_date": "Optionale Frist. Kann mit wiederkehrenden Terminen kombiniert werden.",
-          "chore_due_window_offset": "Wenn sich der Status der Aufgabe von „Ausstehend“ auf „Fällig“ ändert. Format: „1d 6h 30m“ oder einfach „30“ für Minuten. Geben Sie „0“ ein, um die Funktion zu deaktivieren. Beispiel: „1d“ bedeutet, dass die Aufgabe einen Tag vor dem Fälligkeitstermin als „Fällig“ angezeigt wird.",
-          "chore_due_reminder_offset": "Wann soll die Erinnerungsbenachrichtigung versendet werden? Format: „1d 6h 30m“ oder einfach „30“ für Minuten. Standard: 30m (30 Minuten vor Fälligkeit). Geben Sie „0“ ein, um die Benachrichtigung zu deaktivieren.",
+          "custom_interval": "Anzahl der Zeiteinheiten zwischen den Wiederholungen (z. B. 3 für „alle 3 Wochen“). Wird nur bei benutzerdefinierter Häufigkeit verwendet.",
+          "custom_interval_unit": "Zeiteinheit für benutzerdefinierte Intervalle (Tage, Wochen, Monate). Nur bei benutzerdefinierter Häufigkeit verwendbar.",
+          "applicable_days": "Leer lassen für alle Tage. NUR auswählen, um auf bestimmte Tage einzuschränken.",
+          "due_date": "Optionale Frist. Kann mit wiederkehrenden Zeitplänen kombiniert werden.",
+          "chore_due_window_offset": "Wann sich der Status der Aufgabe von „Ausstehend“ auf „Fällig“ ändert. Format: „1d 6h 30m“ oder einfach „30“ für Minuten. Geben Sie „0“ ein, um die Funktion zu deaktivieren. Beispiel: „1d“ bedeutet, dass die Aufgabe einen Tag vor dem Fälligkeitstermin als „Fällig“ angezeigt wird.",
+          "chore_due_reminder_offset": "Wann die Erinnerungsbenachrichtigung versendet werden soll. Format: „1d 6h 30m“ oder einfach „30“ für Minuten. Standard: 30m (30 Minuten vor Fälligkeit). Gib „0“ ein, um die Benachrichtigung zu deaktivieren.",
           "show_on_calendar": "Diese Aufgabe in der Kalenderansicht anzeigen.",
-          "chore_notifications": "Wann Benachrichtigungen versendet werden sollen: Bei Antragstellung, bei Genehmigung, bei Ablehnung oder in beliebiger Kombination."
+          "chore_notifications": "Wann Benachrichtigungen versendet werden sollen: Bei Anspruch, bei Genehmigung, bei Ablehnung oder in beliebiger Kombination."
         }
       },
       "badge_count": {
         "title": "Anzahl der Abzeichen",
-        "description": "Wie viele Abzeichen möchten Sie definieren?",
+        "description": "Wie viele Abzeichen möchtest du definieren?",
         "data": {
           "badge_count": "Anzahl der Abzeichen"
         }
       },
       "badges": {
-        "title": "Abzeichen definieren",
-        "description": "Konfigurieren Sie die Details für ein kumulatives Abzeichen. Diese Abzeichen belohnen Empfänger für das Erreichen bestimmter Punktzahlen und unterstützen Wartungszyklen, um kontinuierliche Leistung zu fördern.\n\n ℹ️ [Konfigurationsanleitung]({documentation_url})",
+        "title": "Kumulatives Abzeichen hinzufügen",
+        "description": "Konfiguriere die Details für ein kumulatives Abzeichen. Diese Abzeichen belohnen Empfänger für das Erreichen bestimmter Punktzahlen und unterstützen Aufrechterhaltungszyklen, um kontinuierliche Leistung zu fördern.\n\n ℹ️ [Konfigurationsanleitung]({documentation_url})",
         "data": {
           "badge_name": "Abzeichenname",
-          "badge_description": "Beschreibung (optional)",
-          "badge_labels": "Abzeichen-Etiketten",
-          "icon": "Symbol (mdi:xxx)",
+          "badge_description": "Abzeichenbeschreibung (optional)",
+          "badge_labels": "Label (Optional)",
+          "icon": "Abzeichensymbol (mdi:xxx)",
           "target_type": "🎯 ZIEL: Zieltyp",
-          "threshold_value": "Schwellenwert",
-          "maintenance_rules": "Mindestaufrechterhaltungspunkte",
-          "occasion_type": "Art des Anlasses",
-          "associated_achievement": "Zugehörige Errungenschaft",
-          "selected_chores": "🧹 Erfasste Aufgaben (optional)",
+          "threshold_value": "🎯 ZIEL: Schwellenwert",
+          "maintenance_rules": "🎯 ZIEL: Aufrechterhaltungspunkte (optional)",
+          "occasion_type": "🎉 Anlassart",
+          "associated_achievement": "🏆 Zugehöriger Erfolg",
+          "selected_chores": "🧹 Verfolgte Aufgaben (optional)",
           "assigned_user_ids": "🧒 Zugewiesen an",
           "award_items": "🎁 AUSZEICHNUNGEN: Punkte, Prämien, Boni, Multiplikator auswählen (optional)",
           "award_points": "Punkte vergeben",
@@ -342,44 +342,44 @@
       },
       "bonus_count": {
         "title": "Anzahl der Boni",
-        "description": "Wie viele Boni möchten Sie definieren?",
+        "description": "Wie viele Boni möchtest du definieren?",
         "data": {
           "bonus_count": "Anzahl der Boni"
         }
       },
       "bonuses": {
         "title": "Bonus definieren",
-        "description": "Geben Sie Details für jeden Bonus ein.",
+        "description": "Gib Details für jeden Bonus ein.",
         "data": {
           "name": "Bonusname",
           "bonus_description": "Beschreibung (optional)",
-          "bonus_labels": "Bonus-Etiketten",
+          "bonus_labels": "Bonus-Label",
           "internal_id": "Interne ID",
           "bonus_points": "Bonuspunkte",
           "icon": "Symbol (mdi:xxx)"
         }
       },
       "achievement_count": {
-        "title": "Anzahl der Errungenschaften",
-        "description": "Wie viele Errungenschaften möchten Sie definieren?",
+        "title": "Anzahl der Erfolge",
+        "description": "Wie viele Erfolge möchtest du definieren?",
         "data": {
-          "achievement_count": "Anzahl der Errungenschaften"
+          "achievement_count": "Anzahl der Erfolge"
         }
       },
       "achievements": {
-        "title": "Errungenschaft definieren",
-        "description": "Geben Sie Details für jede Errungenschaft ein.",
+        "title": "Erfolge definieren",
+        "description": "Gib Details für jeden Erfolg ein.",
         "data": {
-          "name": "Name der Errungenschaft",
+          "name": "Name des Erfolgs",
           "description": "Beschreibung (optional)",
-          "achievement_labels": "Errungenschaft-Etiketten",
+          "achievement_labels": "Erfolgslabel",
           "icon": "Symbol (mdi:xxx)",
           "assigned_user_ids": "Zugewiesen an",
-          "type": "Art der Errungenschaft",
-          "selected_chore_id": "Zugehörige Hausarbeit auswählen",
+          "type": "Art des Erfolgs",
+          "selected_chore_id": "Zugehörige Aufgabe auswählen",
           "criteria": "Kriterien (optional)",
-          "target_value": "Zielwert für die Errungenschaft",
-          "reward_points": "Extrapunkte für das Erreichen der Errungenschaft",
+          "target_value": "Erfolgsziel",
+          "reward_points": "Extrapunkte für das Erreichen des Erfolgs",
           "internal_id": "Interne ID"
         }
       },
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Benutzer hinzufügen",
-        "description": "Geben Sie die Details für das neue Benutzerprofil an.\n\n ℹ️ [Konfigurationsanleitung]({documentation_url})",
+        "description": "Geben Sie die Details für das neue Benutzerprofil an.\n\n{user_access_warning}\n\n ℹ️ [Konfigurationsanleitung]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identität und Profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Eindeutiger Name für dieses Benutzerprofil.",
-              "ha_user_id": "Optional: Verknüpfen Sie dieses Profil mit einem Home Assistant-Benutzer.",
+              "ha_user_id": "Optional: Verknüpfen Sie dieses Profil mit einem Home Assistant-Benutzer. Wenn der Kioskmodus deaktiviert ist, basieren Aktionen zum Beanspruchen und Einlösen von gemeinsam genutzten Geräten auf dieser Verknüpfung.",
               "dashboard_language": "Sprache, die für Dashboard-Inhalte und Benachrichtigungen verwendet wird.",
               "mobile_notify_service": "Wählen Sie einen Benachrichtigungsdienst aus oder lassen Sie das Feld leer, um Benachrichtigungen zu deaktivieren."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Benutzer bearbeiten",
-        "description": "Ändern Sie die Details des ausgewählten Benutzerprofils.\n\n ℹ️ [Konfigurationsanleitung]({documentation_url})",
+        "description": "Ändern Sie die Details des ausgewählten Benutzerprofils.\n\n{user_access_warning}\n\n ℹ️ [Konfigurationsanleitung]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identität und Profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Eindeutiger Name für dieses Benutzerprofil.",
-              "ha_user_id": "Optional: Verknüpfen Sie dieses Profil mit einem Home Assistant-Benutzer.",
+              "ha_user_id": "Optional: Verknüpfen Sie dieses Profil mit einem Home Assistant-Benutzer. Wenn der Kioskmodus deaktiviert ist, basieren Aktionen zum Beanspruchen und Einlösen von gemeinsam genutzten Geräten auf dieser Verknüpfung.",
               "dashboard_language": "Sprache, die für Dashboard-Inhalte und Benachrichtigungen verwendet wird.",
               "mobile_notify_service": "Wählen Sie einen Benachrichtigungsdienst aus oder lassen Sie das Feld leer, um Benachrichtigungen zu deaktivieren."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Änderungen im Dashboard überprüfen",
-        "description": "Überprüfen Sie den Abhängigkeitsstatus und die Vorlageneinstellungen Ihrer ausgewählten Vorlagen, bevor Sie Dashboard-Änderungen anwenden.\n\n ℹ️ [Dashboard-Konfigurationsleitfaden]({documentation_url})\n\n**Verfügbare Anpassungen**\n{dashboard_template_preferences}\n\n**Fehlende erforderliche Abhängigkeiten**\n{dashboard_missing_required_dependencies}\n\n**Fehlende empfohlene Abhängigkeiten**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Überprüfen Sie den Abhängigkeitsstatus und die Vorlageneinstellungen Ihrer ausgewählten Vorlagen, bevor Sie Dashboard-Änderungen anwenden.\n\n ℹ️ [Dashboard-Konfigurationsleitfaden]({documentation_url})\n\n**Verfügbare Anpassungen**\n{dashboard_template_preferences}\n\n**Fehlende erforderliche Abhängigkeiten**\n{dashboard_missing_required_dependencies}\n\n**Fehlende empfohlene Abhängigkeiten**\n{dashboard_missing_recommended_dependencies}\n\n**Warnung zur Zugriffskontrolle**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Trotzdem fortfahren (Voraussetzungen fehlen)"
+          "dashboard_dependency_bypass": "🚫 Trotzdem fortfahren (Voraussetzungen fehlen)",
+          "dashboard_access_warning_ack": "⚠️ Trotzdem fortfahren (ausgewählte Benutzer sind nicht verknüpft)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Beachten Sie, dass erforderliche Abhängigkeiten fehlen, und fahren Sie trotzdem fort. Das Dashboard wird möglicherweise nicht korrekt angezeigt oder verhält sich fehlerhaft, bis die erforderlichen Abhängigkeiten installiert sind."
+          "dashboard_dependency_bypass": "Beachten Sie, dass erforderliche Abhängigkeiten fehlen, und fahren Sie trotzdem fort. Das Dashboard wird möglicherweise nicht korrekt angezeigt oder verhält sich fehlerhaft, bis die erforderlichen Abhängigkeiten installiert sind.",
+          "dashboard_access_warning_ack": "Beachten Sie, dass bei einigen ausgewählten Nutzern keine Home Assistant-Benutzer verknüpft sind, solange der Kioskmodus deaktiviert ist. Die Schaltflächen zum Beanspruchen und Einlösen funktionieren auf gemeinsam genutzten Geräten möglicherweise nicht wie erwartet, bis diese Benutzer verknüpft oder der Kioskmodus aktiviert ist."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Die Administratorvorlage pro Benutzer ist erforderlich, wenn das Administratorlayout die Option „Pro Benutzer“ enthält.",
       "dashboard_admin_per_assignee_needs_assignees": "Für das benutzerbasierte Admin-Layout ist mindestens ein ausgewählter Benutzer erforderlich.",
       "dashboard_dependency_ack_required": "Aktivieren Sie „Trotzdem fortfahren“, um fortzufahren, oder gehen Sie zurück und installieren Sie zuerst die fehlenden erforderlichen Abhängigkeiten.",
+      "dashboard_access_warning_ack_required": "Bestätigen Sie die Warnung zur Zugriffskontrolle, um fortzufahren, oder gehen Sie zurück und verknüpfen Sie die betroffenen Benutzer oder aktivieren Sie den Kioskmodus.",
       "dashboard_nonselectable_templates": "Eine oder mehrere ausgewählte Vorlagen können nicht generiert werden.",
       "dashboard_release_strict_pin_failed": "Die ausgewählte Dashboard-Version muss exakt festgelegt werden, jedoch war zum Zeitpunkt der Ausführung keine gültige Versionsreferenz verfügbar. Wählen Sie die Version in Schritt 1 erneut aus und versuchen Sie es noch einmal.",
       "dashboard_release_asset_prep_failed": "Die ausgewählten Online-Dashboard-Elemente konnten nicht vorbereitet werden. Wählen Sie eine andere Version oder verwenden Sie die neuesten kompatiblen/aktuellen lokalen Vorlagen und versuchen Sie es erneut."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Präferenzleitfaden nicht verfügbar"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Zugriffshinweis:** Der Kioskmodus ist deaktiviert und dieser Benutzer ist keinem Home Assistant-Benutzer zugeordnet. Die Schaltflächen zum Einlösen und Anfordern von gemeinsam genutzten Geräten funktionieren für diesen Benutzer möglicherweise erst, nachdem Sie einen Home Assistant-Benutzer zugeordnet oder den Kioskmodus aktiviert haben."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Der Kioskmodus ist deaktiviert und diese ausgewählten Benutzer haben keine verknüpften Home Assistant-Benutzer:\n{user_list}\n\nDie Schaltflächen „Anfordern“ und „Einlösen“ funktionieren auf gemeinsam genutzten Geräten möglicherweise nicht wie erwartet, bis diese Benutzer verknüpft sind oder der Kioskmodus aktiviert ist."
     },
     "not_authorized_action": {
       "message": "Sie sind nicht berechtigt, für diesen Beauftragten {action} zu verwenden."

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Unique name for this user profile.",
-              "ha_user_id": "Optional: Link this profile to a Home Assistant user.",
+              "ha_user_id": "Optional: Link this profile to a Home Assistant user. If kiosk mode is disabled, shared-device claim and redeem actions rely on this link.",
               "dashboard_language": "Language used for dashboard content and notifications.",
               "mobile_notify_service": "Select notification service or leave empty to disable notifications."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Add User",
-        "description": "Provide the details for the new user profile.\n\n ℹ️ [Configuration Guide]({documentation_url})",
+        "description": "Provide the details for the new user profile.\n\n{user_access_warning}\n\n ℹ️ [Configuration Guide]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identity and profile",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Unique name for this user profile.",
-              "ha_user_id": "Optional: Link this profile to a Home Assistant user.",
+              "ha_user_id": "Optional: Link this profile to a Home Assistant user. If kiosk mode is disabled, shared-device claim and redeem actions rely on this link.",
               "dashboard_language": "Language used for dashboard content and notifications.",
               "mobile_notify_service": "Select notification service or leave empty to disable notifications."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Edit User",
-        "description": "Modify the details of the selected user profile.\n\n ℹ️ [Configuration Guide]({documentation_url})",
+        "description": "Modify the details of the selected user profile.\n\n{user_access_warning}\n\n ℹ️ [Configuration Guide]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identity and profile",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Unique name for this user profile.",
-              "ha_user_id": "Optional: Link this profile to a Home Assistant user.",
+              "ha_user_id": "Optional: Link this profile to a Home Assistant user. If kiosk mode is disabled, shared-device claim and redeem actions rely on this link.",
               "dashboard_language": "Language used for dashboard content and notifications.",
               "mobile_notify_service": "Select notification service or leave empty to disable notifications."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Review dashboard changes",
-        "description": "Review dependency status and template preferences for your selected templates before applying dashboard changes.\n\n ℹ️ [Dashboard configuration guide]({documentation_url})\n\n**Available Customizations**\n{dashboard_template_preferences}\n\n**Missing required dependencies**\n{dashboard_missing_required_dependencies}\n\n**Missing recommended dependencies**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Review dependency status and template preferences for your selected templates before applying dashboard changes.\n\n ℹ️ [Dashboard configuration guide]({documentation_url})\n\n**Available Customizations**\n{dashboard_template_preferences}\n\n**Missing required dependencies**\n{dashboard_missing_required_dependencies}\n\n**Missing recommended dependencies**\n{dashboard_missing_recommended_dependencies}\n\n**Access-control warning**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Continue anyway (requirements are missing)"
+          "dashboard_dependency_bypass": "🚫 Continue anyway (requirements are missing)",
+          "dashboard_access_warning_ack": "⚠️ Continue anyway (selected users are not linked)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Acknowledge that required dependencies are missing and continue anyway. Dashboard may fail to render or behave incorrectly until required dependencies are installed."
+          "dashboard_dependency_bypass": "Acknowledge that required dependencies are missing and continue anyway. Dashboard may fail to render or behave incorrectly until required dependencies are installed.",
+          "dashboard_access_warning_ack": "Acknowledge that some selected users do not have linked Home Assistant users while kiosk mode is disabled. Claim and redeem buttons may not work as expected on shared devices until those users are linked or kiosk mode is enabled."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Per-user admin template is required when Admin Layout includes Per User.",
       "dashboard_admin_per_assignee_needs_assignees": "Per User Admin Layout requires at least one selected user.",
       "dashboard_dependency_ack_required": "Enable 'Continue anyway' to proceed, or go back and install missing required dependencies first.",
+      "dashboard_access_warning_ack_required": "Acknowledge the access-control warning to continue, or go back and link the affected users or enable kiosk mode.",
       "dashboard_nonselectable_templates": "One or more selected templates are unavailable for generation.",
       "dashboard_release_strict_pin_failed": "The selected dashboard release must be pinned exactly, but no effective release reference was available at execution time. Re-select the release in Step 1 and try again.",
       "dashboard_release_asset_prep_failed": "Unable to prepare selected online dashboard assets. Choose a different release or use latest compatible/current local templates and try again."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Preferences guide not provided"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Access warning:** Kiosk mode is disabled and this user is not linked to a Home Assistant user. Shared-device claim and redeem buttons may not work for this user until you link a Home Assistant user or enable kiosk mode."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Kiosk mode is disabled and these selected users do not have linked Home Assistant users:\n{user_list}\n\nClaim and redeem buttons may not work as expected on shared devices until those users are linked or kiosk mode is enabled."
     },
     "not_authorized_action": {
       "message": "You are not authorized to {action} for this assignee."

--- a/custom_components/choreops/translations/es.json
+++ b/custom_components/choreops/translations/es.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Nombre único para este perfil de usuario.",
-              "ha_user_id": "Opcional: Vincula este perfil a un usuario de Home Assistant.",
+              "ha_user_id": "Opcional: Vincula este perfil a un usuario de Home Assistant. Si el modo quiosco está desactivado, las acciones de reclamación y canje de dispositivos compartidos dependen de este vínculo.",
               "dashboard_language": "Idioma utilizado para el contenido del panel y las notificaciones.",
               "mobile_notify_service": "Seleccione el servicio de notificaciones o déjelo vacío para deshabilitar las notificaciones."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Agregar usuario",
-        "description": "Proporcione los detalles del nuevo perfil de usuario.\n\n ℹ️ [Guía de configuración]({documentation_url})",
+        "description": "Proporcione los detalles para el nuevo perfil de usuario.\n\n{user_access_warning}\n\n ℹ️ [Guía de configuración]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identidad y perfil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Nombre único para este perfil de usuario.",
-              "ha_user_id": "Opcional: Vincula este perfil a un usuario de Home Assistant.",
+              "ha_user_id": "Opcional: Vincula este perfil a un usuario de Home Assistant. Si el modo quiosco está desactivado, las acciones de reclamación y canje de dispositivos compartidos dependen de este vínculo.",
               "dashboard_language": "Idioma utilizado para el contenido del panel y las notificaciones.",
               "mobile_notify_service": "Seleccione el servicio de notificaciones o déjelo vacío para deshabilitar las notificaciones."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Editar usuario",
-        "description": "Modificar los detalles del perfil de usuario seleccionado.\n\n ℹ️ [Guía de configuración]({documentation_url})",
+        "description": "Modifique los detalles del perfil de usuario seleccionado.\n\n{user_access_warning}\n\n ℹ️ [Guía de configuración]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identidad y perfil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Nombre único para este perfil de usuario.",
-              "ha_user_id": "Opcional: Vincula este perfil a un usuario de Home Assistant.",
+              "ha_user_id": "Opcional: Vincula este perfil a un usuario de Home Assistant. Si el modo quiosco está desactivado, las acciones de reclamación y canje de dispositivos compartidos dependen de este vínculo.",
               "dashboard_language": "Idioma utilizado para el contenido del panel y las notificaciones.",
               "mobile_notify_service": "Seleccione el servicio de notificaciones o déjelo vacío para deshabilitar las notificaciones."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Revisar los cambios en el panel",
-        "description": "Revise el estado de las dependencias y las preferencias de plantilla de las plantillas seleccionadas antes de aplicar los cambios en el panel.\n\n ℹ️ [Guía de configuración del panel]({documentation_url})\n\n**Personalizaciones disponibles**\n{dashboard_template_preferences}\n\n**Dependencias obligatorias faltantes**\n{dashboard_missing_required_dependencies}\n\n**Dependencias recomendadas faltantes**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Revise el estado de las dependencias y las preferencias de plantilla para las plantillas seleccionadas antes de aplicar los cambios del panel.\n\n ℹ️ [Guía de configuración del panel]({documentation_url})\n\n**Personalizaciones disponibles**\n{dashboard_template_preferences}\n\n**Dependencias requeridas faltantes**\n{dashboard_missing_required_dependencies}\n\n**Dependencias recomendadas faltantes**\n{dashboard_missing_recommended_dependencies}\n\n**Advertencia de control de acceso**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Continuar de todos modos (faltan requisitos)"
+          "dashboard_dependency_bypass": "🚫 Continuar de todos modos (faltan requisitos)",
+          "dashboard_access_warning_ack": "⚠️ Continúa de todos modos (los usuarios seleccionados no están vinculados)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Reconozca que faltan las dependencias necesarias y continúe de todos modos. El panel podría no renderizarse o funcionar incorrectamente hasta que se instalen las dependencias necesarias."
+          "dashboard_dependency_bypass": "Reconozca que faltan las dependencias necesarias y continúe de todos modos. El panel podría no renderizarse o funcionar incorrectamente hasta que se instalen las dependencias necesarias.",
+          "dashboard_access_warning_ack": "Tenga en cuenta que algunos usuarios seleccionados no tienen usuarios de Home Assistant vinculados mientras el modo quiosco esté desactivado. Es posible que los botones de reclamación y canje no funcionen correctamente en dispositivos compartidos hasta que esos usuarios estén vinculados o se active el modo quiosco."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Se requiere una plantilla de administración por usuario cuando el diseño de administración incluye Por usuario.",
       "dashboard_admin_per_assignee_needs_assignees": "El diseño de administrador por usuario requiere al menos un usuario seleccionado.",
       "dashboard_dependency_ack_required": "Habilite \"Continuar de todas formas\" para continuar o regrese e instale primero las dependencias requeridas que faltan.",
+      "dashboard_access_warning_ack_required": "Confirme la advertencia de control de acceso para continuar, o bien, vuelva atrás y vincule a los usuarios afectados o habilite el modo quiosco.",
       "dashboard_nonselectable_templates": "Una o más plantillas seleccionadas no están disponibles para su generación.",
       "dashboard_release_strict_pin_failed": "La versión del panel seleccionada debe estar fijada con precisión, pero no había ninguna referencia de versión efectiva disponible en el momento de la ejecución. Vuelva a seleccionar la versión en el paso 1 e inténtelo de nuevo.",
       "dashboard_release_asset_prep_failed": "No se pueden preparar los recursos del panel en línea seleccionados. Elija una versión diferente o use las plantillas locales compatibles más recientes y vuelva a intentarlo."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Guía de preferencias no proporcionada"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Advertencia de acceso:** El modo quiosco está desactivado y este usuario no está vinculado a un usuario de Home Assistant. Es posible que los botones de reclamación y canje de dispositivos compartidos no funcionen para este usuario hasta que lo vincule a un usuario de Home Assistant o active el modo quiosco."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ El modo quiosco está desactivado y estos usuarios seleccionados no tienen usuarios de Home Assistant vinculados:\n{user_list}\n\nEs posible que los botones de reclamar y canjear no funcionen como se espera en dispositivos compartidos hasta que esos usuarios estén vinculados o se habilite el modo quiosco."
     },
     "not_authorized_action": {
       "message": "No está autorizado a {action} para este cesionario."

--- a/custom_components/choreops/translations/fi.json
+++ b/custom_components/choreops/translations/fi.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Tämän käyttäjäprofiilin yksilöllinen nimi.",
-              "ha_user_id": "Valinnainen: Linkitä tämä profiili Home Assistant -käyttäjään.",
+              "ha_user_id": "Valinnainen: Linkitä tämä profiili Home Assistant -käyttäjään. Jos kioskitila on poistettu käytöstä, jaetun laitteen lunastustoiminnot edellyttävät tätä linkkiä.",
               "dashboard_language": "Kojelaudan sisällössä ja ilmoituksissa käytetty kieli.",
               "mobile_notify_service": "Valitse ilmoituspalvelu tai jätä tyhjäksi poistaaksesi ilmoitukset käytöstä."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Lisää käyttäjä",
-        "description": "Anna uuden käyttäjäprofiilin tiedot.\n\n ℹ️ [Määritysopas]({documentation_url})",
+        "description": "Anna uuden käyttäjäprofiilin tiedot.\n\n{user_access_warning}\n\n ℹ️ [Määritysopas]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identiteetti ja profiili",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Tämän käyttäjäprofiilin yksilöllinen nimi.",
-              "ha_user_id": "Valinnainen: Linkitä tämä profiili Home Assistant -käyttäjään.",
+              "ha_user_id": "Valinnainen: Linkitä tämä profiili Home Assistant -käyttäjään. Jos kioskitila on poistettu käytöstä, jaetun laitteen lunastustoiminnot edellyttävät tätä linkkiä.",
               "dashboard_language": "Kojelaudan sisällössä ja ilmoituksissa käytetty kieli.",
               "mobile_notify_service": "Valitse ilmoituspalvelu tai jätä tyhjäksi poistaaksesi ilmoitukset käytöstä."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Muokkaa käyttäjää",
-        "description": "Muokkaa valitun käyttäjäprofiilin tietoja.\n\n ℹ️ [Määritysopas]({documentation_url})",
+        "description": "Muokkaa valitun käyttäjäprofiilin tietoja.\n\n{user_access_warning}\n\n ℹ️ [Määritysopas]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identiteetti ja profiili",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Tämän käyttäjäprofiilin yksilöllinen nimi.",
-              "ha_user_id": "Valinnainen: Linkitä tämä profiili Home Assistant -käyttäjään.",
+              "ha_user_id": "Valinnainen: Linkitä tämä profiili Home Assistant -käyttäjään. Jos kioskitila on poistettu käytöstä, jaetun laitteen lunastustoiminnot edellyttävät tätä linkkiä.",
               "dashboard_language": "Kojelaudan sisällössä ja ilmoituksissa käytetty kieli.",
               "mobile_notify_service": "Valitse ilmoituspalvelu tai jätä tyhjäksi poistaaksesi ilmoitukset käytöstä."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Tarkista kojelaudan muutokset",
-        "description": "Tarkista valittujen mallien riippuvuustila ja mallien asetukset ennen kuin otat koontinäytön muutokset käyttöön.\n\n ℹ️ [Kontrollinäytön määritysopas]({documentation_url})\n\n**Käytettävissä olevat mukautukset**\n{dashboard_template_preferences}\n\n**Puuttuvat pakolliset riippuvuudet**\n{dashboard_missing_required_dependencies}\n\n**Puuttuvat suositellut riippuvuudet**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Tarkista valittujen mallien riippuvuustila ja mallien asetukset ennen kuin otat koontinäytön muutokset käyttöön.\n\n ℹ️ [Kontrollinäytön määritysopas]({documentation_url})\n\n**Käytettävissä olevat mukautukset**\n{dashboard_template_preferences}\n\n**Puuttuvat pakolliset riippuvuudet**\n{dashboard_missing_required_dependencies}\n\n**Puuttuvat suositellut riippuvuudet**\n{dashboard_missing_recommended_dependencies}\n\n**Käyttöoikeuksien hallinnan varoitus**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Jatka joka tapauksessa (vaatimukset puuttuvat)"
+          "dashboard_dependency_bypass": "🚫 Jatka joka tapauksessa (vaatimukset puuttuvat)",
+          "dashboard_access_warning_ack": "⚠️ Jatka joka tapauksessa (valittuja käyttäjiä ei ole linkitetty)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Vahvista, että pakolliset riippuvuudet puuttuvat, ja jatka joka tapauksessa. Kojelauta ei välttämättä renderöidy tai toimii väärin, ennen kuin pakolliset riippuvuudet on asennettu."
+          "dashboard_dependency_bypass": "Vahvista, että pakolliset riippuvuudet puuttuvat, ja jatka joka tapauksessa. Kojelauta ei välttämättä renderöidy tai toimii väärin, ennen kuin pakolliset riippuvuudet on asennettu.",
+          "dashboard_access_warning_ack": "Huomaa, että joillakin valituilla käyttäjillä ei ole linkitettyjä Home Assistant -käyttäjiä, kun kioskitila on poistettu käytöstä. Lunastuspainikkeet eivät välttämättä toimi odotetulla tavalla jaetuilla laitteilla, ennen kuin kyseiset käyttäjät on linkitetty tai kioskitila on käytössä."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Käyttäjäkohtainen hallintamalli vaaditaan, kun hallintamalli sisältää käyttäjäkohtaisen mallin.",
       "dashboard_admin_per_assignee_needs_assignees": "Käyttäjäkohtainen hallinta-asettelu edellyttää vähintään yhden valitun käyttäjän.",
       "dashboard_dependency_ack_required": "Jatka ottamalla käyttöön 'Jatka joka tapauksessa' tai palaa takaisin ja asenna ensin puuttuvat pakolliset riippuvuudet.",
+      "dashboard_access_warning_ack_required": "Jatka kuittaamalla käyttöoikeusvaroitus tai palaa takaisin ja linkitä kyseiset käyttäjät tai ota käyttöön kioskitila.",
       "dashboard_nonselectable_templates": "Yksi tai useampi valittu mallipohja ei ole käytettävissä luomista varten.",
       "dashboard_release_strict_pin_failed": "Valitun kojelaudan julkaisun on oltava kiinnitetty tarkasti, mutta suoritushetkellä ei ollut käytettävissä voimassa olevaa julkaisuviittausta. Valitse julkaisu uudelleen vaiheessa 1 ja yritä uudelleen.",
       "dashboard_release_asset_prep_failed": "Valittujen verkkohallintapaneelin resurssien valmistelu epäonnistui. Valitse toinen versio tai käytä uusimpia yhteensopivia/nykyisiä paikallisia malleja ja yritä uudelleen."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Asetusopasta ei toimitettu"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Käyttöoikeusvaroitus:** Kioskitila on poistettu käytöstä, eikä tätä käyttäjää ole linkitetty Home Assistant -käyttäjään. Jaetun laitteen lunastuspainikkeet eivät välttämättä toimi tälle käyttäjälle, ennen kuin linkität Home Assistant -käyttäjän tai otat kioskitilan käyttöön."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Kioskitila on poistettu käytöstä, eikä näillä valituilla käyttäjillä ole linkitettyjä Home Assistant -käyttäjiä:\n{user_list}\n\nLunastuspainikkeet eivät välttämättä toimi odotetulla tavalla jaetuilla laitteilla, ennen kuin kyseiset käyttäjät on linkitetty tai kioskitila on käytössä."
     },
     "not_authorized_action": {
       "message": "Sinulla ei ole oikeutta {action} tämän vastuuhenkilön puolesta."

--- a/custom_components/choreops/translations/fr.json
+++ b/custom_components/choreops/translations/fr.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "intro": {
-        "title": "Bienvenue chez ChoreOps",
+        "title": "Bienvenue sur ChoreOps",
         "description": "Cet assistant vous guidera tout au long de la configuration de ChoreOps.\n\n ℹ️ [Guide de démarrage rapide]({documentation_url})"
       },
       "data_recovery": {
@@ -55,7 +55,7 @@
           "points_icon": "Icône MDI pour les points (ex. : « mdi:star », « mdi:coin », « mdi:trophy »)",
           "default_chore_points": "Valeur de points par défaut utilisée lors de la création d'une tâche, sauf si des points personnalisés sont définis.",
           "update_interval": "Fréquence de mise à jour des données (minimum : 1 minute)",
-          "calendar_show_period": "Jours historiques à afficher dans le calendrier (minimum 1)",
+          "calendar_show_period": "Jours d'historiques à afficher dans le calendrier (minimum 1)",
           "retention_daily": "Jours pour conserver les agrégats quotidiens",
           "retention_weekly": "Semaines pour conserver les agrégats hebdomadaires",
           "retention_monthly": "Mois pour conserver les agrégats mensuels",
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Nom unique pour ce profil utilisateur.",
-              "ha_user_id": "Facultatif : Liez ce profil à un utilisateur Home Assistant.",
+              "ha_user_id": "Facultatif : associez ce profil à un utilisateur Home Assistant. Si le mode kiosque est désactivé, les actions de revendication et d’utilisation d’appareils partagés dépendent de cette association.",
               "dashboard_language": "Langue utilisée pour le contenu du tableau de bord et les notifications.",
               "mobile_notify_service": "Sélectionnez un service de notification ou laissez vide pour désactiver les notifications."
             }
@@ -96,7 +96,7 @@
             "data": {
               "can_be_assigned": "Peut être attribué",
               "enable_chore_workflow": "Flux de travail activé",
-              "enable_gamification": "La gamification a permis"
+              "enable_gamification": "Activer la ludification"
             },
             "data_description": {
               "can_be_assigned": "Permet d'attribuer des tâches à ce profil.",
@@ -113,8 +113,8 @@
               "associated_user_ids": "Utilisateurs associés"
             },
             "data_description": {
-              "can_approve": "Permet les actions d'approbation et de désapprobation.",
-              "can_manage": "Autorise les actions de gestion nécessitant des autorisations élevées.",
+              "can_approve": "Permet les actions d'approbation et de refus.",
+              "can_manage": "Autorise la gestion d'actions demandant une permission élevé",
               "associated_user_ids": "Utilisateurs supervisés par cet approbateur/administrateur pour les actions d'approbation."
             }
           }
@@ -152,17 +152,17 @@
             }
           },
           "section_schedule": {
-            "name": "Calendrier",
+            "name": "Programmation",
             "description": "Paramètres de programmation, de fenêtre d'accès et d'intervalle de récurrence.",
             "data": {
-              "recurring_frequency": "🔄 Horaire : Fréquence",
-              "due_date": "📅 Calendrier : Date d’échéance (facultatif)",
-              "clear_due_date": "🗑️ Date d'échéance claire",
-              "applicable_days": "📅 Calendrier : Jours concernés (facultatif)",
+              "recurring_frequency": "🔄 Programmation : Fréquence",
+              "due_date": "📅 Programmation : Date d’échéance (facultatif)",
+              "clear_due_date": "🗑️ Date d'effacement",
+              "applicable_days": "📅 Programmation: Jours concernés (facultatif)",
               "chore_due_window_offset": "⏱️ Délai d'échéance : Décalage avant la date d'échéance",
               "chore_claim_lock_until_window": "🔒 Verrouiller la réclamation jusqu'à l'ouverture de la période d'échéance ?",
               "custom_interval": "🔄 Programmation : Intervalle personnalisé (pour une fréquence personnalisée)",
-              "custom_interval_unit": "🔄 Programme : Unité d’intervalle personnalisée"
+              "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée"
             },
             "data_description": {
               "recurring_frequency": "Fréquence de répétition de la tâche : Quotidienne, Hebdomadaire, Mensuelle, Annuelle, Personnalisée ou Aucune.",
@@ -190,7 +190,7 @@
             },
             "data_description": {
               "approval_reset_type": "Contrôle le déclenchement du cycle d'approbation de la tâche (minuit, date d'échéance, à l'achèvement ou déclenchement manuel).",
-              "approval_reset_pending_claim_action": "Voici ce qui arrive aux demandes d'indemnisation toujours en attente d'approbation lors de la réinitialisation du processus d'approbation.",
+              "approval_reset_pending_claim_action": "Voici ce qui arrive aux réclamations toujours en attente d'approbation lors de la réinitialisation des approbations.",
               "auto_approve": "Lorsqu'elle est activée, cette option permet d'approuver instantanément les demandes sans examen par un approbateur.",
               "overdue_handling_type": "Actions à entreprendre après la date d'échéance : Masquer le statut de retard, maintenir le statut de retard jusqu'à ce que la demande soit réclamée, ou réinitialiser le statut à « en attente » lors du prochain cycle d'approbation.",
               "chore_due_reminder_offset": "Quand envoyer la notification de rappel d'échéance ? Format : « 1j 6h 30m » ou simplement « 30 » pour les minutes. Par défaut : 30 min (30 minutes avant l'échéance). Saisissez « 0 » pour désactiver.",
@@ -213,11 +213,11 @@
           "overdue_handling_type": "⏰ En retard : Traitement",
           "chore_claim_lock_until_window": "🔒 Verrouiller la réclamation jusqu'à l'ouverture de la période d'échéance ?",
           "auto_approve": "✅ Approbation automatique des demandes ?",
-          "recurring_frequency": "🔄 Horaire : Fréquence",
+          "recurring_frequency": "🔄 Programmation : Fréquence",
           "custom_interval": "🔄 Programmation : Intervalle personnalisé (pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 Programme : Unité d’intervalle personnalisée",
-          "applicable_days": "📅 Calendrier : Jours concernés (facultatif)",
-          "due_date": "📅 Calendrier : Date d’échéance (facultatif)",
+          "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée",
+          "applicable_days": "📅 Programmation : Jours concernés (facultatif)",
+          "due_date": "📅 Programmation : Date d’échéance (facultatif)",
           "chore_due_window_offset": "⏱️ Délai d'échéance : Décalage avant la date d'échéance",
           "chore_due_reminder_offset": "🔔 Rappel d'échéance : Effectuez votre compensation avant la date d'échéance",
           "show_on_calendar": "📅 Afficher dans le calendrier ?",
@@ -232,7 +232,7 @@
           "assigned_user_ids": "Personnes désignées qui peuvent voir et revendiquer cette tâche.",
           "completion_criteria": "Contrôle la manière dont la tâche est effectuée lorsque plusieurs personnes sont désignées : suivi individuel, exécution partagée ou rotation à tour de rôle.",
           "approval_reset_type": "Contrôle le déclenchement du cycle d'approbation de la tâche (minuit, date d'échéance, à l'achèvement ou déclenchement manuel).",
-          "approval_reset_pending_claim_action": "Voici ce qui arrive aux demandes d'indemnisation toujours en attente d'approbation lors de la réinitialisation du processus d'approbation.",
+          "approval_reset_pending_claim_action": "Voici ce qui arrive aux réclamations toujours en attente d'approbation lors de la réinitialisation du processus d'approbation.",
           "overdue_handling_type": "Actions à entreprendre après la date d'échéance : Masquer le statut de retard, maintenir le statut de retard jusqu'à ce que la demande soit réclamée, ou réinitialiser le statut à « en attente » lors du prochain cycle d'approbation.",
           "chore_claim_lock_until_window": "Lorsque cette option est activée, les personnes assignées ne peuvent pas prendre en charge cette tâche avant le début de la période d'échéance.",
           "auto_approve": "Lorsqu'elle est activée, cette option permet d'approuver instantanément les demandes sans examen par un approbateur.",
@@ -272,12 +272,12 @@
           "award_items": "🎁 RÉCOMPENSES : Points, Récompenses, Bonus, Multiplicateur (Optionnel)",
           "award_points": "🎁 RÉCOMPENSES : Points attribués (facultatif)",
           "points_multiplier": "🎁 RÉCOMPENSES : Multiplicateur de points (Par défaut 💎 1,0x)",
-          "recurring_frequency": "🔄 CYCLE D'ENTRETIEN : Fréquence",
-          "custom_interval": "🔄 CYCLE D'ENTRETIEN : Intervalle personnalisé (requis pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 CYCLE DE MAINTENANCE : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
-          "start_date": "🔄 RÉINITIALISER LE CYCLE : Date de début (facultatif)",
-          "end_date": "🔄 CYCLE DE MAINTENANCE : Date de fin (facultatif)",
-          "grace_period_days": "🔄 CYCLE DE MAINTENANCE : Délai de grâce en jours (facultatif)"
+          "recurring_frequency": "🔄 Programmation : Fréquence",
+          "custom_interval": "🔄 Programmation : Intervalle personnalisé (requis pour une fréquence personnalisée)",
+          "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
+          "start_date": "🔄 Reset du cycle : Date de début (facultatif)",
+          "end_date": "🔄 Programmation : Date de fin (facultatif)",
+          "grace_period_days": "🔄 Programmation : Délai de grâce en jours (facultatif)"
         },
         "data_description": {
           "badge_name": "Saisissez un nom unique pour le badge. Ce nom sera affiché dans le système.",
@@ -297,7 +297,7 @@
           "recurring_frequency": "Activez le cycle de maintenance, exigeant que le nombre minimum de points spécifié soit atteint avant la fin de la période (par exemple, hebdomadaire, mensuel).",
           "custom_interval": "Indiquez le NOMBRE de jours, de semaines, de mois, etc. pour la fréquence personnalisée (par exemple, 3 si vous définissez 3 semaines). Ceci s'applique uniquement à la fréquence personnalisée.",
           "custom_interval_unit": "Sélectionnez l'unité de l'intervalle personnalisé (par exemple, jours, semaines). S'applique uniquement à la fréquence personnalisée.",
-          "start_date": "Définissez la date de début (facultatif).",
+          "start_date": "Sélectionnez la date de début (facultatif).",
           "end_date": "Sélectionnez la date de fin du cycle de maintenance. (facultatif).",
           "grace_period_days": "Indiquez le nombre de jours supplémentaires après la fin du cycle pour que les personnes affectées puissent accumuler les points requis avant une rétrogradation. (facultatif)."
         }
@@ -344,7 +344,7 @@
         "title": "Nombre de bonus",
         "description": "Combien de bonus souhaitez-vous définir ?",
         "data": {
-          "bonus_count": "Les bonus comptent"
+          "bonus_count": "Décompte des bonus"
         }
       },
       "bonuses": {
@@ -360,26 +360,26 @@
         }
       },
       "achievement_count": {
-        "title": "Nombre de réalisations",
+        "title": "Nombre de succès",
         "description": "Combien de réalisations souhaitez-vous définir ?",
         "data": {
-          "achievement_count": "Nombre de réalisations"
+          "achievement_count": "Nombre de succès"
         }
       },
       "achievements": {
-        "title": "Définir la réussite",
-        "description": "Saisissez les détails de chaque réalisation.",
+        "title": "Définir le succès",
+        "description": "Saisissez les détails de chaque succès.",
         "data": {
           "name": "Nom du succès",
           "description": "Description (facultatif)",
-          "achievement_labels": "Étiquettes de réussite",
+          "achievement_labels": "Étiquettes de succès",
           "icon": "Icône (mdi:xxx)",
           "assigned_user_ids": "Affecté à",
-          "type": "Type de réalisation",
+          "type": "Type de succès",
           "selected_chore_id": "Sélectionner la tâche associée",
           "criteria": "Critères (facultatif)",
-          "target_value": "Objectif de réalisation",
-          "reward_points": "Points bonus pour avoir accompli la mission",
+          "target_value": "Objectif de succès",
+          "reward_points": "Points bonus pour avoir accompli le succès",
           "internal_id": "ID interne"
         }
       },
@@ -387,7 +387,7 @@
         "title": "Nombre de défis",
         "description": "Combien de défis souhaitez-vous définir ?",
         "data": {
-          "challenge_count": "Défi du nombre"
+          "challenge_count": "Décompte du défi"
         }
       },
       "challenges": {
@@ -402,7 +402,7 @@
           "type": "Type de défi",
           "selected_chore_id": "Sélectionnez la tâche associée au défi (facultatif)",
           "criteria": "Critères (facultatif)",
-          "target_value": "Défis Cible",
+          "target_value": "Cible du défi",
           "reward_points": "Points bonus pour avoir relevé le défi",
           "start_date": "Date de début",
           "end_date": "Date de fin",
@@ -417,7 +417,7 @@
     "error": {
       "a_chore_must_be_selected": "Une tâche doit être sélectionnée",
       "badge_requires_assignment": "Au moins une personne doit être affectée à ce badge.",
-      "error_badge_achievement_required": "Une réalisation doit être sélectionnée pour les badges liés aux réalisations.",
+      "error_badge_achievement_required": "Une réalisation doit être sélectionnée pour les badges liés aux succès.",
       "error_badge_occasion_type_required": "Un type d'occasion est requis pour les badges d'occasions spéciales.",
       "target_threshold_required": "Un seuil cible est requis",
       "invalid_maintenance_rules": "La valeur des règles de maintenance est invalide.",
@@ -432,7 +432,7 @@
       "duplicate_badge": "Un badge portant ce nom existe déjà.",
       "duplicate_challenge": "Un défi portant ce nom existe déjà.",
       "duplicate_chore": "Il existe déjà une tâche portant ce nom",
-      "duplicate_assignee": "Un cessionnaire portant ce nom existe déjà.",
+      "duplicate_assignee": "Une personne portant ce nom existe déjà.",
       "duplicate_approver": "Un utilisateur portant ce nom existe déjà.",
       "duplicate_penalty": "Une sanction portant ce nom existe déjà.",
       "duplicate_reward": "Une récompense portant ce nom existe déjà.",
@@ -466,8 +466,8 @@
       "invalid_due_date": "Date d'échéance invalide",
       "date_required_for_frequency": "Une date d'échéance est requise pour cette fréquence récurrente. L'option « Date d'échéance » ne fonctionne qu'avec les fréquences « Aucune » ou « Quotidienne ».",
       "invalid_end_date": "Date de fin invalide.",
-      "invalid_assignee_count": "Nombre de bénéficiaires invalide",
-      "invalid_assignee_name": "Nom du bénéficiaire invalide",
+      "invalid_assignee_count": "Nombre personne invalide",
+      "invalid_assignee_name": "Nom de la personne invalide",
       "invalid_user_count": "Nombre d'utilisateurs invalide",
       "invalid_approver_name": "Nom d'utilisateur invalide",
       "no_assignees_assigned": "Au moins une personne doit être affectée à cette tâche.",
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Ajouter un utilisateur",
-        "description": "Veuillez fournir les informations nécessaires au nouveau profil utilisateur.\n\n ℹ️ [Guide de configuration]({documentation_url})",
+        "description": "Veuillez fournir les informations du nouveau profil utilisateur.\n\n{user_access_warning}\n\n ℹ️ [Guide de configuration]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identité et profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Nom unique pour ce profil utilisateur.",
-              "ha_user_id": "Facultatif : Liez ce profil à un utilisateur Home Assistant.",
+              "ha_user_id": "Facultatif : associez ce profil à un utilisateur Home Assistant. Si le mode kiosque est désactivé, les actions de revendication et d’utilisation d’appareils partagés dépendent de cette association.",
               "dashboard_language": "Langue utilisée pour le contenu du tableau de bord et les notifications.",
               "mobile_notify_service": "Sélectionnez un service de notification ou laissez vide pour désactiver les notifications."
             }
@@ -579,7 +579,7 @@
             "data": {
               "can_be_assigned": "Peut être attribué",
               "enable_chore_workflow": "Flux de travail activé",
-              "enable_gamification": "La gamification a permis"
+              "enable_gamification": "Activer la ludification"
             },
             "data_description": {
               "can_be_assigned": "Permet d'attribuer des tâches à ce profil.",
@@ -631,14 +631,14 @@
             "name": "Calendrier",
             "description": "Paramètres de programmation, de fenêtre d'accès et d'intervalle de récurrence.",
             "data": {
-              "recurring_frequency": "🔄 Horaire : Fréquence",
-              "due_date": "📅 Calendrier : Date d’échéance (facultatif)",
-              "clear_due_date": "🗑️ Date d'échéance claire",
-              "applicable_days": "📅 Calendrier : Jours concernés (facultatif)",
+              "recurring_frequency": "🔄 Programmation : Fréquence",
+              "due_date": "📅 Programmation : Date d’échéance (facultatif)",
+              "clear_due_date": "🗑️ Effacement de la date d'échéance",
+              "applicable_days": "📅 Programmation : Jours concernés (facultatif)",
               "chore_due_window_offset": "⏱️ Délai d'échéance : Décalage avant la date d'échéance",
               "chore_claim_lock_until_window": "🔒 Verrouiller la réclamation jusqu'à l'ouverture de la période d'échéance ?",
               "custom_interval": "🔄 Programmation : Intervalle personnalisé (pour une fréquence personnalisée)",
-              "custom_interval_unit": "🔄 Programme : Unité d’intervalle personnalisée"
+              "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée"
             },
             "data_description": {
               "recurring_frequency": "Fréquence de la tâche : Quotidienne, Hebdomadaire, Mensuelle, Annuelle, Personnalisée ou Aucune. Si vous sélectionnez « Quotidienne – Plusieurs fois par jour », un écran supplémentaire s’affichera pour configurer les horaires précis.",
@@ -689,12 +689,12 @@
           "overdue_handling_type": "⏰ En retard : Traitement",
           "chore_claim_lock_until_window": "🔒 Verrouiller la réclamation jusqu'à l'ouverture de la période d'échéance ?",
           "auto_approve": "✅ Approbation automatique des demandes ?",
-          "recurring_frequency": "🔄 Horaire : Fréquence",
+          "recurring_frequency": "🔄 Programmation : Fréquence",
           "custom_interval": "🔄 Programmation : Intervalle personnalisé (pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 Programme : Unité d’intervalle personnalisée",
-          "applicable_days": "📅 Calendrier : Jours concernés (facultatif)",
-          "due_date": "📅 Calendrier : Date d’échéance (facultatif)",
-          "clear_due_date": "🗑️ Date d'échéance claire",
+          "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée",
+          "applicable_days": "📅 Programmation : Jours concernés (facultatif)",
+          "due_date": "📅 Programmation : Date d’échéance (facultatif)",
+          "clear_due_date": "Effacement de la date d'échéance",
           "chore_due_window_offset": "⏱️ Délai d'échéance : Décalage avant la date d'échéance",
           "chore_due_reminder_offset": "🔔 Rappel d'échéance : Effectuez votre compensation avant la date d'échéance",
           "show_on_calendar": "📅 Afficher dans le calendrier ?",
@@ -750,12 +750,12 @@
           "award_items": "🎁 RÉCOMPENSES : Points, Récompenses, Bonus, Multiplicateur (Optionnel)",
           "award_points": "🎁 RÉCOMPENSES : Points attribués (facultatif)",
           "points_multiplier": "🎁 RÉCOMPENSES : Multiplicateur de points (Par défaut 💎 1,0x)",
-          "recurring_frequency": "🔄 CYCLE D'ENTRETIEN : Fréquence",
-          "custom_interval": "🔄 CYCLE D'ENTRETIEN : Intervalle personnalisé (requis pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 CYCLE DE MAINTENANCE : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
-          "start_date": "🔄 RÉINITIALISER LE CYCLE : Date de début (facultatif)",
-          "end_date": "🔄 CYCLE DE MAINTENANCE : Date de fin (facultatif)",
-          "grace_period_days": "🔄 CYCLE DE MAINTENANCE : Délai de grâce en jours (facultatif)"
+          "recurring_frequency": "🔄 Programmation : Fréquence",
+          "custom_interval": "🔄 Programmation : Intervalle personnalisé (requis pour une fréquence personnalisée)",
+          "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
+          "start_date": "🔄 Reset du cycle : Date de début (facultatif)",
+          "end_date": "🔄 Programmation : Date de fin (facultatif)",
+          "grace_period_days": "🔄 Programmation : Délai de grâce en jours (facultatif)"
         },
         "data_description": {
           "badge_name": "Saisissez un nom unique pour le badge. Ce nom sera affiché dans le système.",
@@ -820,16 +820,16 @@
           "threshold_value": "🎯 CIBLE : Valeur seuil",
           "maintenance_rules": "🎯 CIBLE : Points de maintenance (facultatif)",
           "occasion_type": "🎉 Type d'occasion",
-          "associated_achievement": "🏆 Réalisation associée",
+          "associated_achievement": "🏆 Succès associé",
           "selected_chores": "🧹 Suivi des tâches ménagères (facultatif)",
           "assigned_user_ids": "🧒 Attribué à",
           "award_items": "🎁 RÉCOMPENSES : Points, récompenses, bonus, pénalités (facultatif)",
           "award_points": "🎁 RÉCOMPENSES : Points attribués (facultatif)",
-          "recurring_frequency": "🔄 CYCLE DE RÉINITIALISATION : Fréquence",
-          "custom_interval": "🔄 CYCLE DE RÉINITIALISATION : Intervalle personnalisé (requis pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 CYCLE DE RÉINITIALISATION : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
-          "start_date": "🔄 RÉINITIALISER LE CYCLE : Date de début (facultatif)",
-          "end_date": "🔄 RÉINITIALISATION DU CYCLE : Date de fin (facultatif)"
+          "recurring_frequency": "🔄 Reset du cycle : Fréquence",
+          "custom_interval": "🔄 Reset du cycle  : Intervalle personnalisé (requis pour une fréquence personnalisée)",
+          "custom_interval_unit": "🔄 Reset du cycle  : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
+          "start_date": "🔄 Reset du cycle  : Date de début (facultatif)",
+          "end_date": "🔄 Reset du cycle  : Date de fin (facultatif)"
         },
         "data_description": {
           "badge_name": "Saisissez un nom unique pour le badge. Ce nom sera affiché dans le système.",
@@ -954,13 +954,13 @@
         "data": {
           "name": "Nom du succès",
           "description": "Description (facultatif)",
-          "achievement_labels": "Étiquettes de réussite",
+          "achievement_labels": "Étiquettes de succès",
           "icon": "Icône (mdi:xxx)",
           "assigned_user_ids": "Affecté à",
           "type": "Type de réalisation",
           "selected_chore_id": "Sélectionner la tâche associée",
           "criteria": "Critères (facultatif)",
-          "target_value": "Objectif de réalisation",
+          "target_value": "Objectif du succès",
           "reward_points": "Points bonus pour avoir accompli la mission",
           "internal_id": "ID interne"
         }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Modifier l'utilisateur",
-        "description": "Modifier les détails du profil utilisateur sélectionné.\n\n ℹ️ [Guide de configuration]({documentation_url})",
+        "description": "Modifier les détails du profil utilisateur sélectionné.\n\n{user_access_warning}\n\n ℹ️ [Guide de configuration]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identité et profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Nom unique pour ce profil utilisateur.",
-              "ha_user_id": "Facultatif : Liez ce profil à un utilisateur Home Assistant.",
+              "ha_user_id": "Facultatif : associez ce profil à un utilisateur Home Assistant. Si le mode kiosque est désactivé, les actions de revendication et d’utilisation d’appareils partagés dépendent de cette association.",
               "dashboard_language": "Langue utilisée pour le contenu du tableau de bord et les notifications.",
               "mobile_notify_service": "Sélectionnez un service de notification ou laissez vide pour désactiver les notifications."
             }
@@ -1062,14 +1062,14 @@
             "name": "Calendrier",
             "description": "Paramètres de programmation, de fenêtre d'accès et d'intervalle de récurrence.",
             "data": {
-              "recurring_frequency": "🔄 Horaire : Fréquence",
-              "due_date": "📅 Calendrier : Date d’échéance (facultatif)",
-              "clear_due_date": "🗑️ Date d'échéance claire",
-              "applicable_days": "📅 Calendrier : Jours concernés (facultatif)",
+              "recurring_frequency": "🔄 Programmation : Fréquence",
+              "due_date": "📅 Programmation : Date d’échéance (facultatif)",
+              "clear_due_date": "🗑️ Effacement à la date d'échéance",
+              "applicable_days": "📅 Programmation : Jours concernés (facultatif)",
               "chore_due_window_offset": "⏱️ Délai d'échéance : Décalage avant la date d'échéance",
               "chore_claim_lock_until_window": "🔒 Verrouiller la réclamation jusqu'à l'ouverture de la période d'échéance ?",
               "custom_interval": "🔄 Programmation : Intervalle personnalisé (pour une fréquence personnalisée)",
-              "custom_interval_unit": "🔄 Programme : Unité d’intervalle personnalisée"
+              "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée"
             },
             "data_description": {
               "recurring_frequency": "Fréquence de la tâche : Quotidienne, Hebdomadaire, Mensuelle, Annuelle, Personnalisée ou Aucune. Si vous sélectionnez « Quotidienne – Plusieurs fois par jour », un écran supplémentaire s’affichera pour configurer les horaires précis.",
@@ -1121,12 +1121,12 @@
           "overdue_handling_type": "⏰ En retard : Traitement",
           "chore_claim_lock_until_window": "🔒 Verrouiller la réclamation jusqu'à l'ouverture de la période d'échéance ?",
           "auto_approve": "✅ Approbation automatique des demandes ?",
-          "recurring_frequency": "🔄 Horaire : Fréquence",
+          "recurring_frequency": "🔄 Programmation : Fréquence",
           "custom_interval": "🔄 Programmation : Intervalle personnalisé (pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 Programme : Unité d’intervalle personnalisée",
-          "applicable_days": "📅 Calendrier : Jours concernés (facultatif)",
-          "due_date": "📅 Calendrier : Date d’échéance (facultatif)",
-          "clear_due_date": "🗑️ Date d'échéance claire",
+          "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée",
+          "applicable_days": "📅 Programmation : Jours concernés (facultatif)",
+          "due_date": "📅 Programmation: Date d’échéance (facultatif)",
+          "clear_due_date": "🗑️Effacement à l'échéance",
           "chore_due_window_offset": "⏱️ Délai d'échéance : Décalage avant la date d'échéance",
           "chore_due_reminder_offset": "🔔 Rappel d'échéance : Effectuez votre compensation avant la date d'échéance",
           "show_on_calendar": "📅 Afficher dans le calendrier ?",
@@ -1203,18 +1203,18 @@
           "threshold_value": "🎯 CIBLE : Valeur seuil",
           "maintenance_rules": "🎯 CIBLE : Points de maintenance (facultatif)",
           "occasion_type": "🎉 Type d'occasion",
-          "associated_achievement": "🏆 Réalisation associée",
+          "associated_achievement": "🏆 Succès associée",
           "selected_chores": "🧹 Suivi des tâches ménagères (facultatif)",
           "assigned_user_ids": "🧒 Attribué à",
           "award_items": "🎁 RÉCOMPENSES : Points, Récompenses, Bonus, Multiplicateur (Optionnel)",
           "award_points": "🎁 RÉCOMPENSES : Points attribués (facultatif)",
           "points_multiplier": "🎁 RÉCOMPENSES : Multiplicateur de points (Par défaut 💎 1,0x)",
-          "recurring_frequency": "🔄 CYCLE D'ENTRETIEN : Fréquence",
-          "custom_interval": "🔄 CYCLE D'ENTRETIEN : Intervalle personnalisé (requis pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 CYCLE DE MAINTENANCE : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
-          "start_date": "🔄 RÉINITIALISER LE CYCLE : Date de début (facultatif)",
-          "end_date": "🔄 CYCLE DE MAINTENANCE : Date de fin (facultatif)",
-          "grace_period_days": "🔄 CYCLE DE MAINTENANCE : Délai de grâce en jours (facultatif)"
+          "recurring_frequency": "🔄 Programmation : Fréquence",
+          "custom_interval": "🔄 Programmation : Intervalle personnalisé (requis pour une fréquence personnalisée)",
+          "custom_interval_unit": "🔄 Programmation : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
+          "start_date": "🔄 Reset du cycle : Date de début (facultatif)",
+          "end_date": "🔄 Programmation : Date de fin (facultatif)",
+          "grace_period_days": "🔄 Programmation : Délai de grâce en jours (facultatif)"
         },
         "data_description": {
           "badge_name": "Saisissez un nom unique pour le badge. Ce nom sera affiché dans le système.",
@@ -1279,16 +1279,16 @@
           "threshold_value": "🎯 CIBLE : Valeur seuil",
           "maintenance_rules": "🎯 CIBLE : Points de maintenance (facultatif)",
           "occasion_type": "🎉 Type d'occasion",
-          "associated_achievement": "🏆 Réalisation associée",
+          "associated_achievement": "🏆 Succès associée",
           "selected_chores": "🧹 Suivi des tâches ménagères (facultatif)",
           "assigned_user_ids": "🧒 Attribué à",
           "award_items": "🎁 RÉCOMPENSES : Points, récompenses, bonus, pénalités (facultatif)",
           "award_points": "🎁 RÉCOMPENSES : Points attribués (facultatif)",
-          "recurring_frequency": "🔄 CYCLE DE RÉINITIALISATION : Fréquence",
-          "custom_interval": "🔄 CYCLE DE RÉINITIALISATION : Intervalle personnalisé (requis pour une fréquence personnalisée)",
-          "custom_interval_unit": "🔄 CYCLE DE RÉINITIALISATION : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
-          "start_date": "🔄 RÉINITIALISER LE CYCLE : Date de début (facultatif)",
-          "end_date": "🔄 RÉINITIALISATION DU CYCLE : Date de fin (facultatif)"
+          "recurring_frequency": "🔄 Reset du cycle : Fréquence",
+          "custom_interval": "🔄 Reset du cycle : Intervalle personnalisé (requis pour une fréquence personnalisée)",
+          "custom_interval_unit": "🔄 Reset du cycle : Unité d’intervalle personnalisée (requise pour une fréquence personnalisée)",
+          "start_date": "🔄 Reset du cycle : Date de début (facultatif)",
+          "end_date": "🔄 Reset du cycle : Date de fin (facultatif)"
         },
         "data_description": {
           "badge_name": "Saisissez un nom unique pour le badge. Ce nom sera affiché dans le système.",
@@ -1319,7 +1319,7 @@
           "badge_description": "Description du badge (facultatif)",
           "badge_labels": "Étiquettes (facultatif)",
           "icon": "Icône de badge (mdi:xxx)",
-          "associated_achievement": "🏆 Réalisation associée",
+          "associated_achievement": "🏆 Succès associée",
           "assigned_user_ids": "🧒 Attribué à",
           "award_items": "🎁 RÉCOMPENSES : Points, récompenses, bonus au choix (facultatif)",
           "award_points": "🎁 RÉCOMPENSES : Points attribués (facultatif)"
@@ -1408,19 +1408,19 @@
         }
       },
       "edit_achievement": {
-        "title": "Définir la réussite",
+        "title": "Définir le succès",
         "description": "Saisissez les détails de chaque succès.\n\n ℹ️ [Guide de configuration]({documentation_url})",
         "data": {
           "name": "Nom du succès",
           "description": "Description (facultatif)",
-          "achievement_labels": "Étiquettes de réussite",
+          "achievement_labels": "Étiquettes du succès",
           "icon": "Icône (mdi:xxx)",
           "assigned_user_ids": "Affecté à",
-          "type": "Type de réalisation",
+          "type": "Type de succès",
           "selected_chore_id": "Sélectionner la tâche associée",
           "criteria": "Critères (facultatif)",
           "target_value": "Objectif de réalisation",
-          "reward_points": "Points bonus pour avoir accompli la mission",
+          "reward_points": "Points bonus pour avoir accompli le succès",
           "internal_id": "ID interne"
         }
       },
@@ -1436,7 +1436,7 @@
           "type": "Type de défi",
           "selected_chore_id": "Sélectionnez la tâche associée au défi (facultatif)",
           "criteria": "Critères (facultatif)",
-          "target_value": "Défis Cible",
+          "target_value": "Cible du défi",
           "reward_points": "Points bonus pour avoir relevé le défi",
           "start_date": "Date de début",
           "end_date": "Date de fin",
@@ -1479,7 +1479,7 @@
         "data": {}
       },
       "delete_challenge": {
-        "title": "Défi de suppression",
+        "title": "Supprimer le défi",
         "description": "Êtes-vous sûr de vouloir supprimer le défi {challenge_name}?",
         "data": {}
       },
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Consulter les modifications du tableau de bord",
-        "description": "Vérifiez l'état des dépendances et les préférences des modèles sélectionnés avant d'appliquer les modifications au tableau de bord.\n\n ℹ️ [Guide de configuration du tableau de bord]({documentation_url})\n\n**Personnalisations disponibles**\n{dashboard_template_preferences}\n\n**Dépendances requises manquantes**\n{dashboard_missing_required_dependencies}\n\n**Dépendances recommandées manquantes**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Vérifiez l'état des dépendances et les préférences des modèles sélectionnés avant d'appliquer les modifications au tableau de bord.\n\n ℹ️ [Guide de configuration du tableau de bord]({documentation_url})\n\n**Personnalisations disponibles**\n{dashboard_template_preferences}\n\n**Dépendances requises manquantes**\n{dashboard_missing_required_dependencies}\n\n**Dépendances recommandées manquantes**\n{dashboard_missing_recommended_dependencies}\n\n**Avertissement relatif au contrôle d'accès**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Continuez quand même (conditions requises manquantes)"
+          "dashboard_dependency_bypass": "🚫 Continuez quand même (conditions requises manquantes)",
+          "dashboard_access_warning_ack": "⚠️ Continuez quand même (les utilisateurs sélectionnés ne sont pas liés)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Veuillez noter que des dépendances requises sont manquantes et poursuivre malgré tout. Le tableau de bord risque de ne pas s'afficher correctement ou de fonctionner incorrectement tant que les dépendances requises ne seront pas installées."
+          "dashboard_dependency_bypass": "Veuillez noter que des dépendances requises sont manquantes et poursuivre malgré tout. Le tableau de bord risque de ne pas s'afficher correctement ou de fonctionner incorrectement tant que les dépendances requises ne seront pas installées.",
+          "dashboard_access_warning_ack": "Veuillez noter que certains utilisateurs sélectionnés n'ont pas d'utilisateur Home Assistant associé lorsque le mode kiosque est désactivé. Les boutons « Réclamer » et « Utiliser » peuvent ne pas fonctionner correctement sur les appareils partagés tant que ces utilisateurs ne sont pas associés ou que le mode kiosque n'est pas activé."
         }
       },
       "dashboard_create": {
@@ -1761,7 +1763,7 @@
       "duplicate_badge": "Un badge portant ce nom existe déjà.",
       "duplicate_challenge": "Un défi portant ce nom existe déjà.",
       "duplicate_chore": "Il existe déjà une tâche portant ce nom",
-      "duplicate_assignee": "Un cessionnaire portant ce nom existe déjà.",
+      "duplicate_assignee": "Une personne portant ce nom existe déjà.",
       "duplicate_approver": "Un utilisateur portant ce nom existe déjà.",
       "duplicate_penalty": "Une sanction portant ce nom existe déjà.",
       "duplicate_reward": "Une récompense portant ce nom existe déjà.",
@@ -1834,19 +1836,20 @@
       "dashboard_admin_per_assignee_template_required": "Un modèle d'administration par utilisateur est requis lorsque la mise en page d'administration inclut « Par utilisateur ».",
       "dashboard_admin_per_assignee_needs_assignees": "La configuration d'administration par utilisateur nécessite au moins un utilisateur sélectionné.",
       "dashboard_dependency_ack_required": "Activez l'option « Continuer quand même » pour poursuivre, ou revenez en arrière et installez d'abord les dépendances requises manquantes.",
+      "dashboard_access_warning_ack_required": "Accusez réception de l'avertissement de contrôle d'accès pour continuer, ou revenez en arrière et associez les utilisateurs concernés ou activez le mode kiosque.",
       "dashboard_nonselectable_templates": "Un ou plusieurs modèles sélectionnés ne sont pas disponibles pour la génération.",
       "dashboard_release_strict_pin_failed": "La version du tableau de bord sélectionnée doit être épinglée avec précision, mais aucune référence de version valide n'était disponible au moment de l'exécution. Veuillez resélectionner la version à l'étape 1 et réessayer.",
       "dashboard_release_asset_prep_failed": "Impossible de préparer les éléments sélectionnés du tableau de bord en ligne. Choisissez une autre version ou utilisez les modèles locaux compatibles les plus récents et réessayez."
     },
     "abort": {
       "invalid_action": "Action invalide",
-      "invalid_achievement": "Réalisation invalide",
+      "invalid_achievement": "Succès invalide",
       "invalid_badge": "Badge invalide",
       "invalid_badge_type": "Type de badge invalide",
       "invalid_challenge": "Défi invalide",
       "invalid_chore": "Tâche invalide",
       "invalid_entity": "Entité invalide",
-      "invalid_assignee": "Cessionnaire invalide",
+      "invalid_assignee": "Personne invalide",
       "invalid_approver": "Approbateur invalide",
       "invalid_penalty": "Pénalité invalide",
       "invalid_reward": "Récompense invalide",
@@ -1870,13 +1873,13 @@
       "options": {
         "manage_points": "Gérer les points",
         "manage_user": "Gérer les utilisateurs",
-        "manage_approver": "Gérer les utilisateurs",
+        "manage_approver": "Gérer les administrateurs",
         "manage_chore": "Gérer les tâches ménagères",
         "manage_badge": "Gérer les badges",
         "manage_reward": "Gérer les récompenses",
         "manage_penalty": "Gérer les pénalités",
         "manage_bonus": "Gérer les bonus",
-        "manage_achievement": "Gérer les réalisations",
+        "manage_achievement": "Gérer les succès",
         "manage_challenge": "Gérer le défi",
         "dashboard_generator": "Tableau de bord de gestion",
         "general_options": "Options générales",
@@ -1953,7 +1956,7 @@
         "cumulative": "Cumulatif",
         "daily": "Tous les jours",
         "periodic": "Périodique",
-        "achievement_linked": "Réussite liée",
+        "achievement_linked": "Succès liée",
         "special_occasion": "Occasion spéciale"
       }
     },
@@ -1962,7 +1965,7 @@
         "points": "Points",
         "points_all_time": "Points (tous temps confondus)",
         "points_chores": "Points obtenus grâce aux tâches ménagères",
-        "chore_count": "Compte des tâches",
+        "chore_count": "Décompte des tâches",
         "days_all_chores": "Jours Tâches sélectionnées terminées",
         "days_80pct_chores": "Jours où 80 % des tâches sélectionnées sont terminées",
         "days_all_chores_no_overdue": "Jours où les tâches sélectionnées ont été effectuées (aucune tâche en retard)",
@@ -2017,7 +2020,7 @@
         "at_midnight_multi": "Plusieurs fois par jour - Réinitialisation à minuit",
         "at_due_date_once": "Une fois par période - Réinitialisation à la date d'échéance",
         "at_due_date_multi": "Plusieurs fois par période - Réinitialisation à la date d'échéance",
-        "upon_completion": "Nombre de complétions illimité - Réinitialisation une fois la complétion terminée",
+        "upon_completion": "Nombre d'achèvements illimité - Réinitialisation une fois la complétion terminée",
         "manual": "Réinitialisation manuelle uniquement - Aucune réinitialisation automatique"
       }
     },
@@ -2059,11 +2062,11 @@
         "monthly": "Mensuel",
         "quarterly": "Trimestriel",
         "yearly": "Annuel",
-        "custom": "Coutume",
+        "custom": "Personnalisé",
         "custom_from_complete": "Personnalisé (Reprogrammer à partir de la date d'achèvement)",
-        "custom_1_week": "Délai de livraison : 1 semaine",
+        "custom_1_week": "Personnalisé : 1 semaine",
         "custom_1_month": "Personnalisé : 1 mois",
-        "custom_1_quarter": "Personnalisé : 1 quart",
+        "custom_1_quarter": "Personnalisé : 1 trimestre",
         "custom_1_year": "Personnalisation : 1 an",
         "week_end": "Fin de semaine",
         "month_end": "Fin de mois",
@@ -2075,7 +2078,7 @@
       "options": {
         "birthday": "Anniversaire",
         "holiday": "Vacances",
-        "custom": "Coutume"
+        "custom": "Personnalisé"
       }
     },
     "custom_interval_unit": {
@@ -2100,7 +2103,7 @@
     "threshold_type": {
       "options": {
         "points": "Points",
-        "chore_count": "Compte des tâches"
+        "chore_count": "Décompte des tâches"
       }
     },
     "daily_threshold_type": {
@@ -2183,7 +2186,7 @@
       }
     },
     "disapprove_chore": {
-      "name": "Désapprouver la corvée",
+      "name": "Désapprouver la tâche",
       "description": "L'approbateur refuse une tâche confiée à un désigné, annulant ainsi son statut.",
       "fields": {
         "config_entry_id": {
@@ -2209,7 +2212,7 @@
         "chore_name": {
           "name": "Nom de la tâche",
           "description": "Le nom de la tâche désapprouvé.",
-          "example": "salle blanche"
+          "example": "Nettoyer la pièce"
         }
       }
     },
@@ -2337,12 +2340,12 @@
         "penalty_name": {
           "name": "Nom de la pénalité",
           "description": "Le nom de la sanction à appliquer.",
-          "example": "Cris"
+          "example": "Râler / répondre"
         }
       }
     },
     "apply_bonus": {
-      "name": "Postuler à la prime",
+      "name": "Appliquer un bonus",
       "description": "Un approbateur attribue une prime à un mandataire, en lui octroyant des points.",
       "fields": {
         "config_entry_id": {
@@ -2368,12 +2371,12 @@
         "bonus_name": {
           "name": "Nom du bonus",
           "description": "Le nom de la prime à appliquer.",
-          "example": "Très utile"
+          "example": "A bien aidé"
         }
       }
     },
     "manual_adjust_points": {
-      "name": "Points de réglage manuel",
+      "name": "Ajuster les points manuellement",
       "description": "Ajuster manuellement les points d'un utilisateur à l'aide d'un montant entier signé et d'une raison requise enregistrée dans le registre.",
       "fields": {
         "config_entry_id": {
@@ -2543,7 +2546,7 @@
         "name": {
           "name": "Nom de la tâche",
           "description": "Le nom de la tâche à créer.",
-          "example": "salle blanche"
+          "example": "Nettoyage de la pièce"
         },
         "assigned_user_names": {
           "name": "Affecté à",
@@ -2603,12 +2606,12 @@
         "chore_claim_lock_until_window": {
           "name": "Verrouiller la réclamation jusqu'à l'ouverture de la fenêtre",
           "description": "Si cela s'avère exact, les cessionnaires ne pourront pas prétendre à cette tâche avant le début du délai imparti.",
-          "example": "FAUX"
+          "example": "Faux"
         },
         "auto_approve": {
           "name": "Approbation automatique",
           "description": "Si cela s'avère exact, la tâche est automatiquement approuvée lorsqu'elle est demandée.",
-          "example": "FAUX"
+          "example": "Faux"
         },
         "due_date": {
           "name": "Date d'échéance",
@@ -2616,12 +2619,12 @@
           "example": "2025-03-01T23:59:00Z"
         },
         "due_window_offset": {
-          "name": "Décalage de fenêtre dû",
+          "name": "Décalage de l'échéance",
           "description": "Durée avant la date d'échéance lorsque la tâche passe à l'état « à faire ». Format : « 30 min », « 1 h », « 1 j 6 h 30 min », etc. Utilisez « 0 » pour désactiver l'affichage de la période d'échéance.",
           "example": "30 m"
         },
         "due_reminder_offset": {
-          "name": "Compensation du rappel d'échéance",
+          "name": "Décalage du rappel d'échéance",
           "description": "Durée avant l'échéance pour l'envoi d'un rappel. Format : « 30 min », « 1 h », « 1 j 6 h 30 min », etc. Utilisez « 0 » pour désactiver les rappels.",
           "example": "30 m"
         }
@@ -2649,7 +2652,7 @@
         "name": {
           "name": "Nom de la tâche (Identifiant)",
           "description": "Nom de la tâche à mettre à jour (alternative à l'identifiant). Plus convivial que l'identifiant.",
-          "example": "salle blanche"
+          "example": "Nettoyer la pièce"
         },
         "assigned_user_names": {
           "name": "Affecté à",
@@ -2673,7 +2676,7 @@
         },
         "labels": {
           "name": "Étiquettes",
-          "description": "De nouvelles étiquettes pour la corvée.",
+          "description": "De nouvelles étiquettes pour la tâche",
           "example": "['hebdomadaire', 'nettoyage']"
         },
         "frequency": {
@@ -2750,7 +2753,7 @@
         "name": {
           "name": "Nom",
           "description": "Nom de la tâche à supprimer.",
-          "example": "salle blanche"
+          "example": "Nettoyage de la pièce"
         }
       }
     },
@@ -2812,7 +2815,7 @@
         "chore_name": {
           "name": "Nom de la tâche",
           "description": "Nom de la tâche de rotation à réinitialiser. Facultatif si chore_id est fourni.",
-          "example": "Chambre propre"
+          "example": "Nettoyer la chambre"
         }
       }
     },
@@ -2838,7 +2841,7 @@
         "chore_name": {
           "name": "Nom de la tâche",
           "description": "Nom de la tâche de rotation à ouvrir. Facultatif si chore_id est fourni.",
-          "example": "Chambre propre"
+          "example": "Nettoyer la chambre"
         }
       }
     },
@@ -2866,7 +2869,7 @@
         },
         "report_title": {
           "name": "Titre du rapport",
-          "description": "Personnalisation optionnelle du titre pour la sortie Markdown."
+          "description": "Titre optionnel pour un texte plus petit"
         },
         "notify_service": {
           "name": "Service de notification",
@@ -2915,7 +2918,7 @@
         "key": {
           "name": "Chemin clé",
           "description": "Chemin d'accès aux contrôles d'interface utilisateur délimité par des barres obliques, par exemple : gamification/rewards/header_collapse. Laissez ce champ vide uniquement pour l'action de suppression, qui efface toutes les valeurs enregistrées pour la cible sélectionnée.",
-          "example": "gamification/récompenses/réduire_l'en-tête"
+          "example": "gamification/récompenses/réduire l'en-tête"
         },
         "value": {
           "name": "Valeur",
@@ -3117,7 +3120,7 @@
           "pending": "En attente",
           "completed": "Complété",
           "claimed": "Réclamé",
-          "due": "Exigible",
+          "due": "À faire",
           "overdue": "En retard",
           "completed_by_other": "Réalisé par d'autres",
           "waiting": "En attente (fenêtre fermée)",
@@ -3201,7 +3204,7 @@
             }
           },
           "chore_due_window_offset": {
-            "name": "Décalage de fenêtre dû"
+            "name": "Décalage de l'échéance"
           },
           "auto_approve": {
             "name": "Approbation automatique des demandes de remboursement",
@@ -3211,7 +3214,7 @@
             }
           },
           "recurring_frequency": {
-            "name": "Fréquence récurrente",
+            "name": "Fréquence de récurrence",
             "state": {
               "none": "Aucun",
               "daily": "Tous les jours",
@@ -3221,11 +3224,11 @@
               "monthly": "Mensuel",
               "quarterly": "Trimestriel",
               "yearly": "Annuel",
-              "custom": "Coutume",
+              "custom": "Personnalisé",
               "custom_from_complete": "Personnalisé (Reprogrammer à partir de la date d'achèvement)",
-              "custom_1_week": "Délai de livraison : 1 semaine",
+              "custom_1_week": "Personnalisé : 1 semaine",
               "custom_1_month": "Personnalisé : 1 mois",
-              "custom_1_quarter": "Personnalisé : 1 quart",
+              "custom_1_quarter": "Personnalisé : 1 trimestre",
               "custom_1_year": "Personnalisation : 1 an"
             }
           },
@@ -3295,25 +3298,25 @@
             "name": "Manqué (toutes périodes confondues)"
           },
           "chore_last_missed": {
-            "name": "Dernière absence"
+            "name": "Dernières manquées"
           },
           "last_claimed": {
-            "name": "Dernière réclamation"
+            "name": "Dernières réclamations"
           },
           "last_approved": {
-            "name": "Dernière approbation"
+            "name": "Dernières approbations"
           },
           "last_completed": {
-            "name": "Dernières données terminées"
+            "name": "Dernières terminées"
           },
           "last_disapproved": {
-            "name": "Dernière désapprobation"
+            "name": "Dernières désapprobations"
           },
           "last_overdue": {
             "name": "Dernière échéance"
           },
           "global_state": {
-            "name": "État mondial",
+            "name": "État global",
             "state": {
               "pending": "En attente",
               "completed": "Complété",
@@ -3322,7 +3325,7 @@
               "completed_in_part": "Terminé (en partie)",
               "claimed_in_part": "Revendiqué (en partie)",
               "independent": "Indépendant",
-              "due": "Exigible",
+              "due": "À faire",
               "waiting": "En attendant",
               "missed": "Manqué (Verrouillé)"
             }
@@ -3351,7 +3354,7 @@
             "name": "ID d'entité du bouton de réclamation"
           },
           "due_window_start": {
-            "name": "Début de la fenêtre d'échéance"
+            "name": "Début de l'échéance"
           },
           "time_until_due": {
             "name": "Délai jusqu'à l'échéance"
@@ -3363,11 +3366,11 @@
             "name": "Mode de réclamation",
             "state": {
               "claimable": "Réclamation",
-              "steal_available": "Offre spéciale disponible",
+              "steal_available": "Vol disponible",
               "blocked_completed_by_other": "Complété par d'autres",
               "blocked_already_approved": "Déjà approuvé",
               "blocked_pending_claim": "Réclamation en cours",
-              "blocked_waiting_window": "En attente de la fenêtre d'échéance",
+              "blocked_waiting_window": "En attente de l'échéance",
               "blocked_not_my_turn": "À votre tour",
               "blocked_missed_locked": "Manqué et verrouillé"
             }
@@ -3408,13 +3411,13 @@
             "name": "Gagné cette année"
           },
           "point_stat_points_earned_all_time": {
-            "name": "Gagné tout le temps"
+            "name": "Gagné depuis le début"
           },
           "point_stat_points_by_source_today": {
             "name": "Par Source Aujourd'hui"
           },
           "point_stat_points_by_source_week": {
-            "name": "Source : This Week"
+            "name": "Par Source cette semaine"
           },
           "point_stat_points_by_source_month": {
             "name": "Par Source Ce mois-ci"
@@ -3423,7 +3426,7 @@
             "name": "Par source Cette année"
           },
           "point_stat_points_by_source_all_time": {
-            "name": "Par Source All Time"
+            "name": "Par Source depuis le début"
           },
           "point_stat_points_spent_today": {
             "name": "Dépensé aujourd'hui"
@@ -3438,10 +3441,10 @@
             "name": "Dépensé cette année"
           },
           "point_stat_points_spent_all_time": {
-            "name": "J'ai passé tout mon temps"
+            "name": "Dépensé depuis le début"
           },
           "point_stat_points_net_today": {
-            "name": "Net Today"
+            "name": "Net aujourd'hui"
           },
           "point_stat_points_net_week": {
             "name": "Net cette semaine"
@@ -3453,13 +3456,13 @@
             "name": "Net cette année"
           },
           "point_stat_points_net_all_time": {
-            "name": "Temps net"
+            "name": "Net depuis le début"
           },
           "point_stat_points_earning_streak_current": {
             "name": "Série de gains actuelle"
           },
           "point_stat_points_earning_streak_longest": {
-            "name": "Plus longue période de gains"
+            "name": "Plus longue Série de gains"
           },
           "point_stat_avg_points_per_day_week": {
             "name": "Moyenne par jour (semaine)"
@@ -3471,12 +3474,12 @@
             "name": "Moyenne par tâche"
           },
           "point_stat_highest_balance_all_time": {
-            "name": "Solde le plus élevé jamais enregistré"
+            "name": "Solde le plus élevé jamais atteint"
           }
         }
       },
       "assignee_points_max_ever_sensor": {
-        "name": "Maximum {points} Jamais",
+        "name": "Maximum {points} Jamais atteint",
         "state_attributes": {
           "purpose": {
             "name": "But",
@@ -3531,8 +3534,8 @@
         }
       },
       "assignee_chores_sensor": {
-        "name": "Corvées",
-        "unit_of_measurement": "Corvées",
+        "name": "Tâches",
+        "unit_of_measurement": "Tâches",
         "state_attributes": {
           "purpose": {
             "name": "But",
@@ -3556,7 +3559,7 @@
             "name": "Approuvé cette année"
           },
           "chore_stat_approved_all_time": {
-            "name": "Approuvé en permanence"
+            "name": "Approuvé depuis le début"
           },
           "chore_stat_most_completed_chore_all_time": {
             "name": "Tâche la plus accomplie (depuis toujours)"
@@ -3571,7 +3574,7 @@
             "name": "Tâche la plus accomplie (Année)"
           },
           "chore_stat_total_points_from_chores_today": {
-            "name": "Points tirés des tâches ménagères d'aujourd'hui"
+            "name": "Points obtenus grâce aux tâches ménagères d'aujourd'hui"
           },
           "chore_stat_total_points_from_chores_week": {
             "name": "Points obtenus grâce aux tâches ménagères cette semaine"
@@ -3580,46 +3583,46 @@
             "name": "Points obtenus grâce aux tâches ménagères ce mois-ci"
           },
           "chore_stat_total_points_from_chores_year": {
-            "name": "Points obtenus grâce aux corvées cette année"
+            "name": "Points obtenus grâce aux tâches ménagères cette année"
           },
           "chore_stat_total_points_from_chores_all_time": {
-            "name": "Points obtenus grâce aux corvées (tous temps)"
+            "name": "Points obtenus grâce aux tâches ménagères depuis le début"
           },
           "chore_stat_overdue_today": {
             "name": "En retard aujourd'hui"
           },
           "chore_stat_missed_today": {
-            "name": "J'ai manqué aujourd'hui"
+            "name": "Manquées aujourd'hui"
           },
           "chore_stat_overdue_week": {
             "name": "En retard cette semaine"
           },
           "chore_stat_missed_week": {
-            "name": "J'ai manqué cette semaine"
+            "name": "Manquées cette semaine"
           },
           "chore_stat_overdue_month": {
             "name": "En retard ce mois-ci"
           },
           "chore_stat_missed_month": {
-            "name": "J'ai manqué ce mois-ci"
+            "name": "Manquées ce mois-ci"
           },
           "chore_stat_overdue_year": {
             "name": "En retard cette année"
           },
           "chore_stat_missed_year": {
-            "name": "J'ai manqué cette année"
+            "name": "Manquées cette année"
           },
           "chore_stat_overdue_count_all_time": {
             "name": "En retard depuis toujours"
           },
           "chore_stat_missed_all_time": {
-            "name": "Manqué à tout le temps"
+            "name": "Manquées depuis le début"
           },
           "chore_stat_claimed_today": {
             "name": "Réclamé aujourd'hui"
           },
           "chore_stat_claimed_week": {
-            "name": "Affirmé cette semaine"
+            "name": "Réclamé cette semaine"
           },
           "chore_stat_claimed_month": {
             "name": "Réclamé ce mois-ci"
@@ -3628,7 +3631,7 @@
             "name": "Réclamé cette année"
           },
           "chore_stat_claimed_all_time": {
-            "name": "Réclamé à tout moment"
+            "name": "Réclamé depuis le début"
           },
           "chore_stat_disapproved_today": {
             "name": "Désapprouvé aujourd'hui"
@@ -3643,7 +3646,7 @@
             "name": "Désapprouvé cette année"
           },
           "chore_stat_disapproved_all_time": {
-            "name": "Désapprouvé en permanence"
+            "name": "Désapprouvé depuis le début"
           },
           "chore_stat_completed_today": {
             "name": "Terminé aujourd'hui"
@@ -3658,7 +3661,7 @@
             "name": "Terminé cette année"
           },
           "chore_stat_completed_all_time": {
-            "name": "Terminé à tout moment"
+            "name": "Terminé depuis le début"
           },
           "chore_stat_points_today": {
             "name": "Points aujourd'hui"
@@ -3673,7 +3676,7 @@
             "name": "Points cette année"
           },
           "chore_stat_points_all_time": {
-            "name": "Points marqués au total"
+            "name": "Points depuis le début"
           },
           "chore_stat_top_chores_week": {
             "name": "Tâche principale (semaine)"
@@ -3697,16 +3700,16 @@
             "name": "Terminé cette année"
           },
           "chore_stat_current_due_today": {
-            "name": "Échéance actuelle aujourd'hui"
+            "name": "Faites couramment"
           },
           "chore_stat_current_overdue": {
-            "name": "En retard de paiement"
+            "name": "En retard couramment"
           },
           "chore_stat_current_claimed": {
-            "name": "Revendus actuels"
+            "name": "Revendiquée couramment"
           },
           "chore_stat_current_approved": {
-            "name": "Approuvé en vigueur"
+            "name": "Approuvé couramment"
           },
           "chore_stat_longest_streak_week": {
             "name": "Série la plus longue (semaine)"
@@ -3718,13 +3721,13 @@
             "name": "Série la plus longue (année)"
           },
           "chore_stat_longest_streak_all_time": {
-            "name": "Plus longue série (de tous les temps)"
+            "name": "Série la plus longue (depuis le début)"
           },
           "chore_stat_longest_streak": {
-            "name": "Plus longue série"
+            "name": "Série la plus longue"
           },
           "chore_stat_longest_missed_streak": {
-            "name": "Plus longue série d'échecs"
+            "name": "Série la plus longue manquée"
           },
           "chore_stat_avg_per_day_week": {
             "name": "Moyenne par jour (semaine)"
@@ -3806,25 +3809,25 @@
             "name": "Points de cycle"
           },
           "maintenance_grace_end_date": {
-            "name": "Date de fin de grâce pour la maintenance"
+            "name": "Maintenance : Date de fin de grâce"
           },
           "maintenance_points_required": {
-            "name": "Points de maintenance requis"
+            "name": "Maintenance : Points requis"
           },
           "maintenance_end_date": {
-            "name": "Date de fin de maintenance"
+            "name": "Maintenance : Date de fin"
           },
           "maintenance_points_remaining": {
-            "name": "Points de maintenance restants"
+            "name": "Maintenance : Points restants"
           },
           "reset_schedule": {
-            "name": "Réinitialiser le calendrier"
+            "name": "Réinitialiser le programme"
           },
           "target": {
             "name": "Cible"
           },
           "awards": {
-            "name": "Prix"
+            "name": "Récompenses"
           }
         }
       },
@@ -3848,9 +3851,9 @@
             "name": "Type de badge",
             "state": {
               "cumulative": "Cumulatif",
-              "achievement": "Réalisation",
+              "achievement": "Succès",
               "challenge": "Défi",
-              "daily": "Tous les jours",
+              "daily": "Journalier",
               "periodic": "Périodique",
               "special": "Spécial"
             }
@@ -3868,7 +3871,7 @@
             "name": "Cible"
           },
           "associated_achievement": {
-            "name": "Réalisation associée"
+            "name": "Succès associé"
           },
           "associated_challenge": {
             "name": "Défi associé"
@@ -3883,7 +3886,7 @@
             "name": "Récompenses pour badges"
           },
           "reset_schedule": {
-            "name": "Réinitialiser le calendrier"
+            "name": "Réinitialiser le programme"
           }
         }
       },
@@ -3906,7 +3909,7 @@
             "name": "Type de badge",
             "state": {
               "cumulative": "Cumulatif",
-              "achievement": "Réalisation",
+              "achievement": "Succès",
               "challenge": "Défi",
               "daily": "Tous les jours",
               "periodic": "Périodique",
@@ -3924,10 +3927,10 @@
           "target_type": {
             "name": "Type de cible",
             "state": {
-              "chores": "Corvées",
+              "chores": "Tâches",
               "points": "Points",
               "days": "Jours",
-              "achievement": "Réalisation",
+              "achievement": "Succès",
               "challenge": "Défi"
             }
           },
@@ -3979,7 +3982,7 @@
             "name": "Cible"
           },
           "required_chores": {
-            "name": "Tâches obligatoires"
+            "name": "Tâches requises"
           },
           "tracked_chores": {
             "name": "Tâches suivies"
@@ -3988,10 +3991,10 @@
             "name": "Prix"
           },
           "reset_schedule": {
-            "name": "Réinitialiser le calendrier"
+            "name": "Réinitialiser le programme"
           },
           "associated_achievement": {
-            "name": "Réalisation associée"
+            "name": "Succès associé"
           },
           "associated_challenge": {
             "name": "Défi associé"
@@ -4032,7 +4035,7 @@
           "pending": "En attente",
           "completed": "Complété",
           "claimed": "Réclamé",
-          "due": "Exigible",
+          "due": "À faire",
           "overdue": "En retard",
           "completed_in_part": "Terminé (en partie)",
           "claimed_in_part": "Revendiqué (en partie)",
@@ -4094,7 +4097,7 @@
               "weekly": "Hebdomadaire",
               "biweekly": "Bihebdomadaire",
               "monthly": "Mensuel",
-              "custom": "Coutume"
+              "custom": "Personnalisé"
             }
           },
           "applicable_days": {
@@ -4133,7 +4136,7 @@
             "name": "Dernière approbation"
           },
           "last_completed": {
-            "name": "Dernières données terminées"
+            "name": "Dernière complétée"
           },
           "chore_claimed_by": {
             "name": "Revendiqué par"
@@ -4142,7 +4145,7 @@
             "name": "Terminé par"
           },
           "due_window_start": {
-            "name": "Début de la fenêtre d'échéance"
+            "name": "Début de l'échéance"
           },
           "time_until_due": {
             "name": "Délai jusqu'à l'échéance"
@@ -4155,7 +4158,7 @@
       "assignee_reward_status_sensor": {
         "name": "Statut de récompense - {reward_name}",
         "state": {
-          "locked": "Fermé",
+          "locked": "Verrouillée",
           "available": "Disponible",
           "requested": "Demandé",
           "approved": "Approuvé",
@@ -4209,7 +4212,7 @@
             "name": "Réclamations cette année"
           },
           "claimed_all_time": {
-            "name": "Réclamations à tout moment"
+            "name": "Réclamations depuis le début"
           },
           "approved_today": {
             "name": "Approuvé aujourd'hui"
@@ -4224,7 +4227,7 @@
             "name": "Approuvé cette année"
           },
           "approved_all_time": {
-            "name": "Approuvé en permanence"
+            "name": "Approuvé depuis le début"
           },
           "disapproved_today": {
             "name": "Désapprouvé aujourd'hui"
@@ -4239,7 +4242,7 @@
             "name": "Désapprouvé cette année"
           },
           "disapproved_all_time": {
-            "name": "Désapprouvé en permanence"
+            "name": "Désapprouvé depuis le début"
           },
           "points_spent_today": {
             "name": "Points dépensés aujourd'hui"
@@ -4254,16 +4257,16 @@
             "name": "Points dépensés cette année"
           },
           "points_spent_all_time": {
-            "name": "Points dépensés au total"
+            "name": "Points dépensés depuis le début"
           },
           "approval_rate": {
             "name": "Taux d'approbation (%)"
           },
           "claim_rate_week": {
-            "name": "Nombre moyen de sinistres par jour (semaine)"
+            "name": "Moyenne des réclamations par jour (semaine)"
           },
           "claim_rate_month": {
-            "name": "Nombre moyen de sinistres par jour (mois)"
+            "name": "Moyenne des réclamations par jour (mois)"
           },
           "claim_button_eid": {
             "name": "ID d'entité du bouton de réclamation"
@@ -4386,7 +4389,7 @@
             "name": "Taper",
             "state": {
               "chore_total": "Total des tâches",
-              "chore_streak": "Série de corvées",
+              "chore_streak": "Série de tâches",
               "daily_minimum": "Minimum quotidien"
             }
           },
@@ -4486,7 +4489,7 @@
             "name": "Taper",
             "state": {
               "chore_total": "Total des tâches",
-              "chore_streak": "Série de corvées",
+              "chore_streak": "Série de tâches",
               "daily_minimum": "Minimum quotidien"
             }
           },
@@ -4648,7 +4651,7 @@
             }
           },
           "chores": {
-            "name": "Corvées"
+            "name": "Tâches"
           },
           "rewards": {
             "name": "Récompenses"
@@ -4666,7 +4669,7 @@
             "name": "Pénalités"
           },
           "achievements": {
-            "name": "Réalisations"
+            "name": "Succès"
           },
           "challenges": {
             "name": "Défis"
@@ -4681,7 +4684,7 @@
             "name": "Approbations en attente"
           },
           "core_sensors": {
-            "name": "Capteurs principaux"
+            "name": "Capteurs essentiels"
           },
           "dashboard_helpers": {
             "name": "Assistants de tableau de bord"
@@ -4714,7 +4717,7 @@
         }
       },
       "system_rewards_select": {
-        "name": "Récompense Select",
+        "name": "Sélection de récompenses",
         "state_attributes": {
           "purpose": {
             "name": "But",
@@ -4725,7 +4728,7 @@
         }
       },
       "system_penalties_select": {
-        "name": "Sélectionner la pénalité",
+        "name": "Sélection de pénalités",
         "state_attributes": {
           "purpose": {
             "name": "But",
@@ -4736,7 +4739,7 @@
         }
       },
       "system_bonuses_select": {
-        "name": "Sélectionner le bonus",
+        "name": "Sélection de bonus",
         "state_attributes": {
           "purpose": {
             "name": "But",
@@ -4855,12 +4858,12 @@
         }
       },
       "approver_chore_disapprove_button": {
-        "name": "Désapprouver la corvée - {chore_name}",
+        "name": "Désapprouver la tâche - {chore_name}",
         "state_attributes": {
           "purpose": {
             "name": "But",
             "state": {
-              "purpose_button_chore_disapprove": "L'approbateur désapprouve la tâche revendiquée"
+              "purpose_button_chore_disapprove": "L'approbateur refuse la tâche revendiquée"
             }
           },
           "user_name": {
@@ -4920,7 +4923,7 @@
           "purpose": {
             "name": "But",
             "state": {
-              "purpose_button_reward_disapprove": "L'approbateur désapprouve la récompense perçue"
+              "purpose_button_reward_disapprove": "L'approbateur refuse la récompense perçue"
             }
           },
           "user_name": {
@@ -4995,16 +4998,16 @@
         }
       },
       "approver_points_adjust_button_positive": {
-        "name": "Incrémenter {delta} {points_label}"
+        "name": "Augmenter {delta} {points_label}"
       },
       "approver_points_adjust_button_negative": {
-        "name": "Décrémenter {delta} {points_label}"
+        "name": "Diminuer {delta} {points_label}"
       }
     }
   },
   "exceptions": {
     "assignee_not_found_by_name": {
-      "message": "Aucun cessionnaire trouvé avec le nom {name}"
+      "message": "Aucun utilisateur trouvé avec le nom {name}"
     },
     "approver_not_found_by_name": {
       "message": "Aucun approbateur trouvé avec le nom {name}"
@@ -5084,8 +5087,14 @@
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Guide des préférences non fourni"
     },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Avertissement d'accès :** Le mode kiosque est désactivé et cet utilisateur n'est associé à aucun compte Home Assistant. Les boutons de récupération et d'utilisation des appareils partagés peuvent ne pas fonctionner pour cet utilisateur tant que vous n'aurez pas associé un compte Home Assistant ou activé le mode kiosque."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Le mode kiosque est désactivé et ces utilisateurs sélectionnés n'ont pas d'utilisateurs Home Assistant liés :\n{user_list}\n\nLes boutons de réclamation et d'échange peuvent ne pas fonctionner comme prévu sur les appareils partagés tant que ces utilisateurs ne sont pas liés ou que le mode kiosque n'est pas activé."
+    },
     "not_authorized_action": {
-      "message": "Vous n'êtes pas autorisé à {action} pour ce cessionnaire."
+      "message": "Vous n'êtes pas autorisé à {action} pour cet utilisateur"
     },
     "not_authorized_action_global": {
       "message": "Vous n'êtes pas autorisé à {action}."
@@ -5142,7 +5151,7 @@
       "message": "Tâche déjà approuvée aujourd'hui. Veuillez réessayer après la période de réinitialisation des approbations."
     },
     "chore_pending_claim": {
-      "message": "Chore a une demande en cours, en attente d'approbation ou de rejet."
+      "message": "La tâche a une demande en cours, en attente d'approbation ou de rejet."
     },
     "chore_waiting": {
       "message": "Cette tâche ne peut pas encore être prise en charge. La période d'échéance n'est pas encore ouverte."
@@ -5160,7 +5169,7 @@
       "message": "{entity} statut est {status}, attendu {expected}"
     },
     "entity_mismatch": {
-      "message": "{provided} ne correspond pas à {expected}"
+      "message": "{provided} ne corresponds pas à {expected}"
     },
     "invalid_frequency": {
       "message": "La fréquence récurrente {frequency} n'est pas valide"

--- a/custom_components/choreops/translations/nb.json
+++ b/custom_components/choreops/translations/nb.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Unikt navn for denne brukerprofilen.",
-              "ha_user_id": "Valgfritt: Koble denne profilen til en Home Assistant-bruker.",
+              "ha_user_id": "Valgfritt: Koble denne profilen til en Home Assistant-bruker. Hvis kioskmodus er deaktivert, er krav på og innløsning av delte enheter avhengig av denne lenken.",
               "dashboard_language": "Språk som brukes for innhold og varsler på dashbordet.",
               "mobile_notify_service": "Velg varslingstjeneste eller la feltet stå tomt for å deaktivere varsler."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Legg til bruker",
-        "description": "Oppgi detaljene for den nye brukerprofilen.\n\n ℹ️ [Konfigurasjonsveiledning]({documentation_url})",
+        "description": "Oppgi detaljene for den nye brukerprofilen.\n\n{user_access_warning}\n\n ℹ️ [Konfigurasjonsveiledning]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitet og profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Unikt navn for denne brukerprofilen.",
-              "ha_user_id": "Valgfritt: Koble denne profilen til en Home Assistant-bruker.",
+              "ha_user_id": "Valgfritt: Koble denne profilen til en Home Assistant-bruker. Hvis kioskmodus er deaktivert, er krav på og innløsning av delte enheter avhengig av denne lenken.",
               "dashboard_language": "Språk som brukes for innhold og varsler på dashbordet.",
               "mobile_notify_service": "Velg varslingstjeneste eller la feltet stå tomt for å deaktivere varsler."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Rediger bruker",
-        "description": "Endre detaljene for den valgte brukerprofilen.\n\n ℹ️ [Konfigurasjonsveiledning]({documentation_url})",
+        "description": "Endre detaljene for den valgte brukerprofilen.\n\n{user_access_warning}\n\n ℹ️ [Konfigurasjonsveiledning]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitet og profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Unikt navn for denne brukerprofilen.",
-              "ha_user_id": "Valgfritt: Koble denne profilen til en Home Assistant-bruker.",
+              "ha_user_id": "Valgfritt: Koble denne profilen til en Home Assistant-bruker. Hvis kioskmodus er deaktivert, er krav på og innløsning av delte enheter avhengig av denne lenken.",
               "dashboard_language": "Språk som brukes for innhold og varsler på dashbordet.",
               "mobile_notify_service": "Velg varslingstjeneste eller la feltet stå tomt for å deaktivere varsler."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Se gjennom endringer i dashbordet",
-        "description": "Se gjennom avhengighetsstatus og malpreferanser for de valgte malene før du bruker endringer i dashbordet.\n\n ℹ️ [Konfigurasjonsveiledning for dashbord]({documentation_url})\n\n**Tilgjengelige tilpasninger**\n{dashboard_template_preferences}\n\n**Mangler nødvendige avhengigheter**\n{dashboard_missing_required_dependencies}\n\n**Mangler anbefalte avhengigheter**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Se gjennom avhengighetsstatus og malpreferanser for de valgte malene før du bruker endringer i dashbordet.\n\n ℹ️ [Konfigurasjonsveiledning for dashbord]({documentation_url})\n\n**Tilgjengelige tilpasninger**\n{dashboard_template_preferences}\n\n**Mangler nødvendige avhengigheter**\n{dashboard_missing_required_dependencies}\n\n**Mangler anbefalte avhengigheter**\n{dashboard_missing_recommended_dependencies}\n\n**Advarsel om tilgangskontroll**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Fortsett likevel (krav mangler)"
+          "dashboard_dependency_bypass": "🚫 Fortsett likevel (krav mangler)",
+          "dashboard_access_warning_ack": "⚠️ Fortsett likevel (valgte brukere er ikke lenket)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Bekreft at nødvendige avhengigheter mangler, og fortsett uansett. Dashbordet kan mislykkes med å gjengis eller oppføre seg feil før nødvendige avhengigheter er installert."
+          "dashboard_dependency_bypass": "Bekreft at nødvendige avhengigheter mangler, og fortsett uansett. Dashbordet kan mislykkes med å gjengis eller oppføre seg feil før nødvendige avhengigheter er installert.",
+          "dashboard_access_warning_ack": "Bekreft at noen utvalgte brukere ikke har koblet Home Assistant-brukere mens kioskmodus er deaktivert. Knapper for å kreve og innløse fungerer kanskje ikke som forventet på delte enheter før disse brukerne er koblet sammen eller kioskmodus er aktivert."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "En administratormal per bruker er nødvendig når administratoroppsettet inkluderer per bruker.",
       "dashboard_admin_per_assignee_needs_assignees": "Adminoppsett per bruker krever minst én valgt bruker.",
       "dashboard_dependency_ack_required": "Aktiver «Fortsett likevel» for å fortsette, eller gå tilbake og installer manglende nødvendige avhengigheter først.",
+      "dashboard_access_warning_ack_required": "Bekreft advarselen om tilgangskontroll for å fortsette, eller gå tilbake og koble til de berørte brukerne eller aktiver kioskmodus.",
       "dashboard_nonselectable_templates": "Én eller flere valgte maler er ikke tilgjengelige for generering.",
       "dashboard_release_strict_pin_failed": "Den valgte dashbordutgivelsen må være nøyaktig festet, men ingen effektiv utgivelsesreferanse var tilgjengelig på utførelsestidspunktet. Velg utgivelsen på nytt i trinn 1 og prøv på nytt.",
       "dashboard_release_asset_prep_failed": "Kan ikke forberede valgte nettbaserte dashbordressurser. Velg en annen versjon, eller bruk de nyeste kompatible/gjeldende lokale malene, og prøv på nytt."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Preferanseguide ikke oppgitt"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Tilgangsadvarsel:** Kioskmodus er deaktivert, og denne brukeren er ikke koblet til en Home Assistant-bruker. Knapper for å kreve og innløse delte enheter fungerer kanskje ikke for denne brukeren før du kobler til en Home Assistant-bruker eller aktiverer kioskmodus."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Kioskmodus er deaktivert, og disse valgte brukerne har ingen tilknyttede Home Assistant-brukere:\n{user_list}\n\nKnapper for å kreve og innløse fungerer kanskje ikke som forventet på delte enheter før disse brukerne er tilknyttet eller kioskmodus er aktivert."
     },
     "not_authorized_action": {
       "message": "Du er ikke autorisert til å {action} for denne rettighetshaveren."

--- a/custom_components/choreops/translations/nl.json
+++ b/custom_components/choreops/translations/nl.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Unieke naam voor dit gebruikersprofiel.",
-              "ha_user_id": "Optioneel: koppel dit profiel aan een Home Assistant-gebruiker.",
+              "ha_user_id": "Optioneel: Koppel dit profiel aan een Home Assistant-gebruiker. Als de kioskmodus is uitgeschakeld, zijn het claimen en inwisselen van gedeelde apparaten afhankelijk van deze koppeling.",
               "dashboard_language": "De taal die wordt gebruikt voor de inhoud van het dashboard en meldingen.",
               "mobile_notify_service": "Selecteer de notificatieservice of laat het veld leeg om notificaties uit te schakelen."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Gebruiker toevoegen",
-        "description": "Geef de gegevens voor het nieuwe gebruikersprofiel op.\n\n ℹ️ [Configuratiehandleiding]({documentation_url})",
+        "description": "Geef de gegevens voor het nieuwe gebruikersprofiel op.\n\n{user_access_warning}\n\n ℹ️ [Configuratiehandleiding]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identiteit en profiel",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Unieke naam voor dit gebruikersprofiel.",
-              "ha_user_id": "Optioneel: koppel dit profiel aan een Home Assistant-gebruiker.",
+              "ha_user_id": "Optioneel: Koppel dit profiel aan een Home Assistant-gebruiker. Als de kioskmodus is uitgeschakeld, zijn het claimen en inwisselen van gedeelde apparaten afhankelijk van deze koppeling.",
               "dashboard_language": "De taal die wordt gebruikt voor de inhoud van het dashboard en meldingen.",
               "mobile_notify_service": "Selecteer de notificatieservice of laat het veld leeg om notificaties uit te schakelen."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Gebruiker bewerken",
-        "description": "Wijzig de details van het geselecteerde gebruikersprofiel.\n\n ℹ️ [Configuratiehandleiding]({documentation_url})",
+        "description": "Wijzig de details van het geselecteerde gebruikersprofiel.\n\n{user_access_warning}\n\n ℹ️ [Configuratiehandleiding]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identiteit en profiel",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Unieke naam voor dit gebruikersprofiel.",
-              "ha_user_id": "Optioneel: koppel dit profiel aan een Home Assistant-gebruiker.",
+              "ha_user_id": "Optioneel: Koppel dit profiel aan een Home Assistant-gebruiker. Als de kioskmodus is uitgeschakeld, zijn het claimen en inwisselen van gedeelde apparaten afhankelijk van deze koppeling.",
               "dashboard_language": "De taal die wordt gebruikt voor de inhoud van het dashboard en meldingen.",
               "mobile_notify_service": "Selecteer de notificatieservice of laat het veld leeg om notificaties uit te schakelen."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Wijzigingen in het dashboard bekijken",
-        "description": "Controleer de afhankelijkheidsstatus en sjabloonvoorkeuren voor uw geselecteerde sjablonen voordat u wijzigingen in het dashboard toepast.\n\n ℹ️ [Dashboardconfiguratiehandleiding]({documentation_url})\n\n**Beschikbare aanpassingen**\n{dashboard_template_preferences}\n\n**Ontbrekende vereiste afhankelijkheden**\n{dashboard_missing_required_dependencies}\n\n**Ontbrekende aanbevolen afhankelijkheden**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Controleer de afhankelijkheidsstatus en sjabloonvoorkeuren voor uw geselecteerde sjablonen voordat u dashboardwijzigingen toepast.\n\n ℹ️ [Dashboardconfiguratiehandleiding]({documentation_url})\n\n**Beschikbare aanpassingen**\n{dashboard_template_preferences}\n\n**Ontbrekende vereiste afhankelijkheden**\n{dashboard_missing_required_dependencies}\n\n**Ontbrekende aanbevolen afhankelijkheden**\n{dashboard_missing_recommended_dependencies}\n\n**Waarschuwing toegangsbeheer**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Toch doorgaan (vereisten ontbreken)"
+          "dashboard_dependency_bypass": "🚫 Toch doorgaan (vereisten ontbreken)",
+          "dashboard_access_warning_ack": "⚠️ Toch doorgaan (geselecteerde gebruikers zijn niet gekoppeld)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Erken dat de vereiste afhankelijkheden ontbreken en ga desondanks verder. Het dashboard kan mogelijk niet correct worden weergegeven of onjuist functioneren totdat de vereiste afhankelijkheden zijn geïnstalleerd."
+          "dashboard_dependency_bypass": "Erken dat de vereiste afhankelijkheden ontbreken en ga desondanks verder. Het dashboard kan mogelijk niet correct worden weergegeven of onjuist functioneren totdat de vereiste afhankelijkheden zijn geïnstalleerd.",
+          "dashboard_access_warning_ack": "Houd er rekening mee dat sommige geselecteerde gebruikers geen gekoppelde Home Assistant-gebruikers hebben wanneer de kioskmodus is uitgeschakeld. De knoppen voor claimen en inwisselen werken mogelijk niet zoals verwacht op gedeelde apparaten totdat die gebruikers zijn gekoppeld of de kioskmodus is ingeschakeld."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Een beheerdersjabloon per gebruiker is vereist wanneer de beheerdersindeling 'Per gebruiker' bevat.",
       "dashboard_admin_per_assignee_needs_assignees": "Voor de beheerderslay-out per gebruiker is minimaal één geselecteerde gebruiker vereist.",
       "dashboard_dependency_ack_required": "Schakel 'Toch doorgaan' in om verder te gaan, of ga terug en installeer eerst de ontbrekende vereiste afhankelijkheden.",
+      "dashboard_access_warning_ack_required": "Bevestig de waarschuwing over toegangscontrole om verder te gaan, of ga terug en koppel de betreffende gebruikers of schakel de kioskmodus in.",
       "dashboard_nonselectable_templates": "Een of meer geselecteerde sjablonen kunnen niet worden gegenereerd.",
       "dashboard_release_strict_pin_failed": "De geselecteerde dashboardversie moet exact worden vastgezet, maar er was geen geldige versiereferentie beschikbaar tijdens de uitvoering. Selecteer de versie in stap 1 opnieuw en probeer het nogmaals.",
       "dashboard_release_asset_prep_failed": "Het lukt niet om de geselecteerde online dashboard-elementen voor te bereiden. Kies een andere versie of gebruik de nieuwste compatibele/actuele lokale sjablonen en probeer het opnieuw."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Voorkeurenhandleiding niet beschikbaar"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Toegangswaarschuwing:** De kioskmodus is uitgeschakeld en deze gebruiker is niet gekoppeld aan een Home Assistant-gebruiker. De knoppen voor het claimen en inwisselen van gedeelde apparaten werken mogelijk niet voor deze gebruiker totdat u een Home Assistant-gebruiker koppelt of de kioskmodus inschakelt."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ De kioskmodus is uitgeschakeld en de volgende geselecteerde gebruikers hebben geen gekoppelde Home Assistant-gebruikers:\n{user_list}\n\nDe knoppen 'Claim' en 'Reserveer' werken mogelijk niet zoals verwacht op gedeelde apparaten totdat deze gebruikers zijn gekoppeld of de kioskmodus is ingeschakeld."
     },
     "not_authorized_action": {
       "message": "U bent niet gemachtigd om {action} namens deze toegewezen persoon uit te voeren."

--- a/custom_components/choreops/translations/pt.json
+++ b/custom_components/choreops/translations/pt.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Nome único para este perfil de utilizador.",
-              "ha_user_id": "Opcional: Ligue este perfil a um utilizador do Home Assistant.",
+              "ha_user_id": "Opcional: ligue este perfil a um utilizador do Home Assistant. Se o modo quiosque estiver desativado, as ações de reclamação e resgate de dispositivos partilhados dependerão desta ligação.",
               "dashboard_language": "Idioma utilizado para o conteúdo do painel de controlo e notificações.",
               "mobile_notify_service": "Selecione o serviço de notificação ou deixe em branco para desativar as notificações."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Adicionar utilizador",
-        "description": "Forneça os detalhes para o novo perfil de utilizador.\n\n ℹ️ [Guia de Configuração]({documentation_url})",
+        "description": "Forneça os detalhes para o novo perfil de utilizador.\n\n{user_access_warning}\n\n ℹ️ [Guia de Configuração]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identidade e perfil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Nome único para este perfil de utilizador.",
-              "ha_user_id": "Opcional: Ligue este perfil a um utilizador do Home Assistant.",
+              "ha_user_id": "Opcional: ligue este perfil a um utilizador do Home Assistant. Se o modo quiosque estiver desativado, as ações de reclamação e resgate de dispositivos partilhados dependerão desta ligação.",
               "dashboard_language": "Idioma utilizado para o conteúdo do painel de controlo e notificações.",
               "mobile_notify_service": "Selecione o serviço de notificação ou deixe em branco para desativar as notificações."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Editar utilizador",
-        "description": "Modifique os detalhes do perfil de utilizador selecionado.\n\n ℹ️ [Guia de Configuração]({documentation_url})",
+        "description": "Modifique os detalhes do perfil de utilizador selecionado.\n\n{user_access_warning}\n\n ℹ️ [Guia de Configuração]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identidade e perfil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Nome único para este perfil de utilizador.",
-              "ha_user_id": "Opcional: Ligue este perfil a um utilizador do Home Assistant.",
+              "ha_user_id": "Opcional: ligue este perfil a um utilizador do Home Assistant. Se o modo quiosque estiver desativado, as ações de reclamação e resgate de dispositivos partilhados dependerão desta ligação.",
               "dashboard_language": "Idioma utilizado para o conteúdo do painel de controlo e notificações.",
               "mobile_notify_service": "Selecione o serviço de notificação ou deixe em branco para desativar as notificações."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Analise as alterações no painel de controlo.",
-        "description": "Reveja o estado das dependências e as preferências dos modelos selecionados antes de aplicar as alterações no painel.\n\n ℹ️ [Guia de configuração do painel]({documentation_url})\n\n**Personalizações disponíveis**\n{dashboard_template_preferences}\n\n**Dependências obrigatórias em falta**\n{dashboard_missing_required_dependencies}\n\n**Dependências recomendadas em falta**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Reveja o estado das dependências e as preferências dos modelos selecionados antes de aplicar as alterações no painel.\n\n ℹ️ [Guia de configuração do painel]({documentation_url})\n\n**Personalizações disponíveis**\n{dashboard_template_preferences}\n\n**Dependências obrigatórias em falta**\n{dashboard_missing_required_dependencies}\n\n**Dependências recomendadas em falta**\n{dashboard_missing_recommended_dependencies}\n\n**Aviso de controlo de acesso**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Continue na mesma (requisitos não cumpridos)"
+          "dashboard_dependency_bypass": "🚫 Continue na mesma (requisitos não cumpridos)",
+          "dashboard_access_warning_ack": "⚠️ Continuar mesmo assim (os utilizadores selecionados não estão vinculados)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Reconheça que as dependências necessárias estão em falta e continue mesmo assim. O painel pode não ser apresentado corretamente ou apresentar um comportamento incorreto até que as dependências necessárias sejam instaladas."
+          "dashboard_dependency_bypass": "Reconheça que as dependências necessárias estão em falta e continue mesmo assim. O painel pode não ser apresentado corretamente ou apresentar um comportamento incorreto até que as dependências necessárias sejam instaladas.",
+          "dashboard_access_warning_ack": "Tenha em consideração que alguns utilizadores selecionados não têm utilizadores do Home Assistant vinculados enquanto o modo quiosque estiver desativado. Os botões de resgate e solicitação podem não funcionar corretamente em dispositivos partilhados até que estes utilizadores sejam vinculados ou o modo quiosque seja ativado."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "É necessário um modelo de administração por utilizador quando o layout de administração inclui a opção \"Por Utilizador\".",
       "dashboard_admin_per_assignee_needs_assignees": "O layout de administração por utilizador requer pelo menos um utilizador selecionado.",
       "dashboard_dependency_ack_required": "Ative a opção \"Continuar mesmo assim\" para prosseguir ou volte atrás e instale primeiro as dependências necessárias que estão em falta.",
+      "dashboard_access_warning_ack_required": "Confirme o aviso de controlo de acesso para continuar, ou volte atrás e ligue os utilizadores afetados ou ative o modo quiosque.",
       "dashboard_nonselectable_templates": "Um ou mais modelos selecionados não estão disponíveis para geração.",
       "dashboard_release_strict_pin_failed": "A versão do painel selecionada deve estar fixada exatamente, mas não estava disponível nenhuma referência de versão efetiva no momento da execução. Selecione novamente a versão no Passo 1 e tente novamente.",
       "dashboard_release_asset_prep_failed": "Não foi possível preparar as funcionalidades selecionadas do painel de controlo online. Escolha uma versão diferente ou utilize os modelos locais compatíveis/atuais mais recentes e tente novamente."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Guia de preferências não fornecido"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Aviso de acesso:** O modo quiosque está desativado e este utilizador não está ligado a um utilizador do Home Assistant. Os botões de resgate e de reclamação de dispositivo partilhado podem não funcionar para este utilizador até que ligue um utilizador do Home Assistant ou ative o modo quiosque."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ O modo quiosque está desativado e estes utilizadores selecionados não têm utilizadores do Home Assistant vinculados:\n{user_list}\n\nOs botões de resgate e de reivindicação podem não funcionar como esperado em dispositivos partilhados até que esses utilizadores sejam vinculados ou o modo quiosque seja ativado."
     },
     "not_authorized_action": {
       "message": "Não está autorizado a {action} para este responsável."

--- a/custom_components/choreops/translations/sk.json
+++ b/custom_components/choreops/translations/sk.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Jedinečný názov pre tento používateľský profil.",
-              "ha_user_id": "Voliteľné: Prepojte tento profil s používateľom služby Home Assistant.",
+              "ha_user_id": "Voliteľné: Prepojte tento profil s používateľom služby Home Assistant. Ak je režim kiosku vypnutý, akcie nárokovania a uplatnenia na zdieľanom zariadení sa spoliehajú na toto prepojenie.",
               "dashboard_language": "Jazyk používaný pre obsah a upozornenia ovládacieho panela.",
               "mobile_notify_service": "Vyberte službu upozornení alebo nechajte pole prázdne, ak chcete upozornenia vypnúť."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Pridať používateľa",
-        "description": "Poskytnite podrobnosti o novom používateľskom profile.\n\n ℹ️ [Sprievodca konfiguráciou]({documentation_url})",
+        "description": "Uveďte podrobnosti o novom používateľskom profile.\n\n{user_access_warning}\n\n ℹ️ [Sprievodca konfiguráciou]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identita a profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Jedinečný názov pre tento používateľský profil.",
-              "ha_user_id": "Voliteľné: Prepojte tento profil s používateľom služby Home Assistant.",
+              "ha_user_id": "Voliteľné: Prepojte tento profil s používateľom služby Home Assistant. Ak je režim kiosku vypnutý, akcie nárokovania a uplatnenia na zdieľanom zariadení sa spoliehajú na toto prepojenie.",
               "dashboard_language": "Jazyk používaný pre obsah a upozornenia ovládacieho panela.",
               "mobile_notify_service": "Vyberte službu upozornení alebo nechajte pole prázdne, ak chcete upozornenia vypnúť."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Upraviť používateľa",
-        "description": "Upravte podrobnosti vybraného používateľského profilu.\n\n ℹ️ [Sprievodca konfiguráciou]({documentation_url})",
+        "description": "Upravte podrobnosti vybraného používateľského profilu.\n\n{user_access_warning}\n\n ℹ️ [Sprievodca konfiguráciou]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identita a profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Jedinečný názov pre tento používateľský profil.",
-              "ha_user_id": "Voliteľné: Prepojte tento profil s používateľom služby Home Assistant.",
+              "ha_user_id": "Voliteľné: Prepojte tento profil s používateľom služby Home Assistant. Ak je režim kiosku vypnutý, akcie nárokovania a uplatnenia na zdieľanom zariadení sa spoliehajú na toto prepojenie.",
               "dashboard_language": "Jazyk používaný pre obsah a upozornenia ovládacieho panela.",
               "mobile_notify_service": "Vyberte službu upozornení alebo nechajte pole prázdne, ak chcete upozornenia vypnúť."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Skontrolujte zmeny na hlavnom paneli",
-        "description": "Pred použitím zmien na ovládacom paneli si skontrolujte stav závislostí a preferencie šablón pre vybraté šablóny.\n\n ℹ️ [Sprievodca konfiguráciou ovládacieho panela]({documentation_url})\n\n**Dostupné prispôsobenia**\n{dashboard_template_preferences}\n\n**Chýbajúce požadované závislosti**\n{dashboard_missing_required_dependencies}\n\n**Chýbajúce odporúčané závislosti**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Pred použitím zmien na ovládacom paneli si skontrolujte stav závislostí a preferencie šablón pre vybraté šablóny.\n\n ℹ️ [Sprievodca konfiguráciou ovládacieho panela]({documentation_url})\n\n**Dostupné prispôsobenia**\n{dashboard_template_preferences}\n\n**Chýbajúce požadované závislosti**\n{dashboard_missing_required_dependencies}\n\n**Chýbajúce odporúčané závislosti**\n{dashboard_missing_recommended_dependencies}\n\n**Upozornenie na riadenie prístupu**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Pokračovať aj tak (chýbajú požiadavky)"
+          "dashboard_dependency_bypass": "🚫 Pokračovať aj tak (chýbajú požiadavky)",
+          "dashboard_access_warning_ack": "⚠️ Pokračovať aj tak (vybraní používatelia nie sú prepojení)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Potvrďte, že chýbajú požadované závislosti a aj tak pokračujte. Ovládací panel sa nemusí vykresliť alebo sa môže správať nesprávne, kým nebudú nainštalované požadované závislosti."
+          "dashboard_dependency_bypass": "Potvrďte, že chýbajú požadované závislosti a aj tak pokračujte. Ovládací panel sa nemusí vykresliť alebo sa môže správať nesprávne, kým nebudú nainštalované požadované závislosti.",
+          "dashboard_access_warning_ack": "Berte na vedomie, že niektorí vybraní používatelia nemajú prepojených používateľov služby Home Assistant, kým je režim kiosku vypnutý. Tlačidlá pre uplatnenie a nárokovanie nemusia na zdieľaných zariadeniach fungovať podľa očakávaní, kým títo používatelia nebudú prepojení alebo kým nebude povolený režim kiosku."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Šablóna správcu pre jednotlivých používateľov je vyžadovaná, keď rozloženie správcu zahŕňa možnosť „Na používateľa“.",
       "dashboard_admin_per_assignee_needs_assignees": "Rozloženie administrátora na používateľa vyžaduje aspoň jedného vybratého používateľa.",
       "dashboard_dependency_ack_required": "Ak chcete pokračovať, povoľte možnosť „Pokračovať aj tak“ alebo sa vráťte a najprv nainštalujte chýbajúce požadované závislosti.",
+      "dashboard_access_warning_ack_required": "Potvrďte upozornenie týkajúce sa kontroly prístupu a pokračujte, alebo sa vráťte a prepojte dotknutých používateľov, prípadne povoľte režim kiosku.",
       "dashboard_nonselectable_templates": "Jedna alebo viacero vybratých šablón nie je k dispozícii na generovanie.",
       "dashboard_release_strict_pin_failed": "Vybrané vydanie na dashboarde musí byť presne pripnuté, ale v čase vykonávania nebol k dispozícii žiadny platný referenčný odkaz na vydanie. V kroku 1 znova vyberte vydanie a skúste to znova.",
       "dashboard_release_asset_prep_failed": "Nepodarilo sa pripraviť vybrané prvky online ovládacieho panela. Vyberte inú verziu alebo použite najnovšie kompatibilné/aktuálne lokálne šablóny a skúste to znova."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Sprievodca preferenciami nie je k dispozícii"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Upozornenie na prístup:** Režim kiosku je vypnutý a tento používateľ nie je prepojený s používateľom aplikácie Home Assistant. Tlačidlá na uplatnenie a nárokovanie na zdieľanom zariadení nemusia pre tohto používateľa fungovať, kým neprepojíte používateľa aplikácie Home Assistant alebo nepovolíte režim kiosku."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Režim kiosku je vypnutý a títo vybraní používatelia nemajú prepojených používateľov služby Domáci asistent:\n{user_list}\n\nTlačidlá prevzatia a uplatnenia nemusia na zdieľaných zariadeniach fungovať podľa očakávaní, kým títo používatelia nebudú prepojení alebo kým nebude povolený režim kiosku."
     },
     "not_authorized_action": {
       "message": "Nemáte oprávnenie na {action} pre tohto nadobúdateľa."

--- a/custom_components/choreops/translations/sl.json
+++ b/custom_components/choreops/translations/sl.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Edinstveno ime za ta uporabniški profil.",
-              "ha_user_id": "Izbirno: Povežite ta profil z uporabnikom storitve Home Assistant.",
+              "ha_user_id": "Izbirno: Povežite ta profil z uporabnikom storitve Home Assistant. Če je način kioska onemogočen, so dejanja prevzema in unovčenja v skupni napravi odvisna od te povezave.",
               "dashboard_language": "Jezik, ki se uporablja za vsebino in obvestila nadzorne plošče.",
               "mobile_notify_service": "Izberite storitev obveščanja ali pustite prazno, da obvestila onemogočite."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Dodaj uporabnika",
-        "description": "Navedite podrobnosti za novi uporabniški profil.\n\n ℹ️ [Vodnik za konfiguracijo]({documentation_url})",
+        "description": "Navedite podrobnosti za novi uporabniški profil.\n\n{user_access_warning}\n\n ℹ️ [Vodnik za konfiguracijo]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identiteta in profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Edinstveno ime za ta uporabniški profil.",
-              "ha_user_id": "Izbirno: Povežite ta profil z uporabnikom storitve Home Assistant.",
+              "ha_user_id": "Izbirno: Povežite ta profil z uporabnikom storitve Home Assistant. Če je način kioska onemogočen, so dejanja prevzema in unovčenja v skupni napravi odvisna od te povezave.",
               "dashboard_language": "Jezik, ki se uporablja za vsebino in obvestila nadzorne plošče.",
               "mobile_notify_service": "Izberite storitev obveščanja ali pustite prazno, da obvestila onemogočite."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Uredi uporabnika",
-        "description": "Spremenite podrobnosti izbranega uporabniškega profila.\n\n ℹ️ [Vodnik za konfiguracijo]({documentation_url})",
+        "description": "Spremenite podrobnosti izbranega uporabniškega profila.\n\n{user_access_warning}\n\n ℹ️ [Vodnik za konfiguracijo]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identiteta in profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Edinstveno ime za ta uporabniški profil.",
-              "ha_user_id": "Izbirno: Povežite ta profil z uporabnikom storitve Home Assistant.",
+              "ha_user_id": "Izbirno: Povežite ta profil z uporabnikom storitve Home Assistant. Če je način kioska onemogočen, so dejanja prevzema in unovčenja v skupni napravi odvisna od te povezave.",
               "dashboard_language": "Jezik, ki se uporablja za vsebino in obvestila nadzorne plošče.",
               "mobile_notify_service": "Izberite storitev obveščanja ali pustite prazno, da obvestila onemogočite."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Pregled sprememb nadzorne plošče",
-        "description": "Preden uporabite spremembe nadzorne plošče, preglejte stanje odvisnosti in nastavitve predlog za izbrane predloge.\n\n ℹ️ [Vodnik za konfiguracijo nadzorne plošče]({documentation_url})\n\n**Razpoložljive prilagoditve**\n{dashboard_template_preferences}\n\n**Manjkajoče zahtevane odvisnosti**\n{dashboard_missing_required_dependencies}\n\n**Manjkajoče priporočene odvisnosti**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Preden uporabite spremembe nadzorne plošče, preglejte stanje odvisnosti in nastavitve predlog za izbrane predloge.\n\n ℹ️ [Vodnik za konfiguracijo nadzorne plošče]({documentation_url})\n\n**Razpoložljive prilagoditve**\n{dashboard_template_preferences}\n\n**Manjkajoče zahtevane odvisnosti**\n{dashboard_missing_required_dependencies}\n\n**Manjkajoče priporočene odvisnosti**\n{dashboard_missing_recommended_dependencies}\n\n**Opozorilo o nadzoru dostopa**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Vseeno nadaljuj (zahteve manjkajo)"
+          "dashboard_dependency_bypass": "🚫 Vseeno nadaljuj (zahteve manjkajo)",
+          "dashboard_access_warning_ack": "⚠️ Vseeno nadaljuj (izbrani uporabniki niso povezani)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Potrdite, da manjkajo zahtevane odvisnosti, in vseeno nadaljujte. Nadzorna plošča se morda ne bo prikazala ali pa se bo obnašala nepravilno, dokler ne bodo nameščene zahtevane odvisnosti."
+          "dashboard_dependency_bypass": "Potrdite, da manjkajo zahtevane odvisnosti, in vseeno nadaljujte. Nadzorna plošča se morda ne bo prikazala ali pa se bo obnašala nepravilno, dokler ne bodo nameščene zahtevane odvisnosti.",
+          "dashboard_access_warning_ack": "Upoštevajte, da nekateri izbrani uporabniki nimajo povezanih uporabnikov storitve Home Assistant, medtem ko je način kioska onemogočen. Gumba za prevzem in unovčenje morda ne bosta delovala pravilno na napravah v skupni rabi, dokler ti uporabniki niso povezani ali način kioska omogočen."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "Predloga skrbnika na uporabnika je obvezna, če skrbniška postavitev vključuje na uporabnika.",
       "dashboard_admin_per_assignee_needs_assignees": "Za postavitev skrbnika na uporabnika je potreben vsaj en izbran uporabnik.",
       "dashboard_dependency_ack_required": "Za nadaljevanje omogočite »Nadaljuj vseeno« ali se vrnite in najprej namestite manjkajoče zahtevane odvisnosti.",
+      "dashboard_access_warning_ack_required": "Za nadaljevanje potrdite opozorilo o nadzoru dostopa ali se vrnite in povežite prizadete uporabnike oziroma omogočite način kioska.",
       "dashboard_nonselectable_templates": "Ena ali več izbranih predlog ni na voljo za generiranje.",
       "dashboard_release_strict_pin_failed": "Izbrana izdaja na nadzorni plošči mora biti natančno pripeta, vendar v času izvajanja ni bila na voljo nobena veljavna referenca za izdajo. V 1. koraku ponovno izberite izdajo in poskusite znova.",
       "dashboard_release_asset_prep_failed": "Izbranih spletnih elementov nadzorne plošče ni mogoče pripraviti. Izberite drugo izdajo ali uporabite najnovejše združljive/trenutne lokalne predloge in poskusite znova."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Vodnik po nastavitvah ni na voljo"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Opozorilo o dostopu:** Način kioska je onemogočen in ta uporabnik ni povezan z uporabnikom storitve Home Assistant. Gumbi za prevzem in unovčenje na skupni napravi morda ne bodo delovali za tega uporabnika, dokler ne povežete uporabnika storitve Home Assistant ali omogočite načina kioska."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Način kioska je onemogočen in ti izbrani uporabniki nimajo povezanih uporabnikov Domačega pomočnika:\n{user_list}\n\nGumba za prevzem in unovčenje morda ne bosta delovala pravilno na napravah v skupni rabi, dokler ti uporabniki niso povezani ali dokler ni omogočen način kioska."
     },
     "not_authorized_action": {
       "message": "Niste pooblaščeni za {action} za tega prejemnika."

--- a/custom_components/choreops/translations/sv.json
+++ b/custom_components/choreops/translations/sv.json
@@ -85,7 +85,7 @@
             },
             "data_description": {
               "name": "Unikt namn för denna användarprofil.",
-              "ha_user_id": "Valfritt: Länka den här profilen till en Home Assistant-användare.",
+              "ha_user_id": "Valfritt: Länka den här profilen till en Home Assistant-användare. Om kioskläget är inaktiverat är anspråk och inlösen av delade enheter beroende av den här länken.",
               "dashboard_language": "Språk som används för instrumentpanelsinnehåll och aviseringar.",
               "mobile_notify_service": "Välj aviseringstjänst eller lämna tomt för att inaktivera aviseringar."
             }
@@ -555,7 +555,7 @@
       },
       "add_user": {
         "title": "Lägg till användare",
-        "description": "Ange informationen för den nya användarprofilen.\n\n ℹ️ [Konfigurationsguide]({documentation_url})",
+        "description": "Ange informationen för den nya användarprofilen.\n\n{user_access_warning}\n\n ℹ️ [Konfigurationsguide]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitet och profil",
@@ -568,7 +568,7 @@
             },
             "data_description": {
               "name": "Unikt namn för denna användarprofil.",
-              "ha_user_id": "Valfritt: Länka den här profilen till en Home Assistant-användare.",
+              "ha_user_id": "Valfritt: Länka den här profilen till en Home Assistant-användare. Om kioskläget är inaktiverat är anspråk och inlösen av delade enheter beroende av den här länken.",
               "dashboard_language": "Språk som används för instrumentpanelsinnehåll och aviseringar.",
               "mobile_notify_service": "Välj aviseringstjänst eller lämna tomt för att inaktivera aviseringar."
             }
@@ -986,7 +986,7 @@
       },
       "edit_user": {
         "title": "Redigera användare",
-        "description": "Ändra detaljerna för den valda användarprofilen.\n\n ℹ️ [Konfigurationsguide]({documentation_url})",
+        "description": "Ändra detaljerna för den valda användarprofilen.\n\n{user_access_warning}\n\n ℹ️ [Konfigurationsguide]({documentation_url})",
         "sections": {
           "section_identity_profile": {
             "name": "Identitet och profil",
@@ -999,7 +999,7 @@
             },
             "data_description": {
               "name": "Unikt namn för denna användarprofil.",
-              "ha_user_id": "Valfritt: Länka den här profilen till en Home Assistant-användare.",
+              "ha_user_id": "Valfritt: Länka den här profilen till en Home Assistant-användare. Om kioskläget är inaktiverat är anspråk och inlösen av delade enheter beroende av den här länken.",
               "dashboard_language": "Språk som används för instrumentpanelsinnehåll och aviseringar.",
               "mobile_notify_service": "Välj aviseringstjänst eller lämna tomt för att inaktivera aviseringar."
             }
@@ -1497,12 +1497,14 @@
       },
       "dashboard_missing_dependencies": {
         "title": "Granska ändringar i instrumentpanelen",
-        "description": "Granska beroendestatus och mallinställningar för dina valda mallar innan du tillämpar ändringar i instrumentpanelen.\n\n ℹ️ [Konfigurationsguide för instrumentpanel]({documentation_url})\n\n**Tillgängliga anpassningar**\n{dashboard_template_preferences}\n\n**Obligatoriska beroenden saknas**\n{dashboard_missing_required_dependencies}\n\n**Rekommenderade beroenden saknas**\n{dashboard_missing_recommended_dependencies}",
+        "description": "Granska beroendestatus och mallinställningar för dina valda mallar innan du tillämpar ändringar i instrumentpanelen.\n\n ℹ️ [Konfigurationsguide för instrumentpanel]({documentation_url})\n\n**Tillgängliga anpassningar**\n{dashboard_template_preferences}\n\n**Obligatoriska beroenden saknas**\n{dashboard_missing_required_dependencies}\n\n**Rekommenderade beroenden saknas**\n{dashboard_missing_recommended_dependencies}\n\n**Varning för åtkomstkontroll**\n{dashboard_access_warning}",
         "data": {
-          "dashboard_dependency_bypass": "🚫 Fortsätt ändå (krav saknas)"
+          "dashboard_dependency_bypass": "🚫 Fortsätt ändå (krav saknas)",
+          "dashboard_access_warning_ack": "⚠️ Fortsätt ändå (valda användare är inte länkade)"
         },
         "data_description": {
-          "dashboard_dependency_bypass": "Bekräfta att nödvändiga beroenden saknas och fortsätt ändå. Instrumentpanelen kanske inte renderas eller beter sig felaktigt förrän nödvändiga beroenden har installerats."
+          "dashboard_dependency_bypass": "Bekräfta att nödvändiga beroenden saknas och fortsätt ändå. Instrumentpanelen kanske inte renderas eller beter sig felaktigt förrän nödvändiga beroenden har installerats.",
+          "dashboard_access_warning_ack": "Bekräfta att vissa utvalda användare inte har länkade Home Assistant-användare medan kioskläget är inaktiverat. Knappar för att göra anspråk och lösa in fungerar eventuellt inte som förväntat på delade enheter förrän dessa användare är länkade eller kioskläget är aktiverat."
         }
       },
       "dashboard_create": {
@@ -1834,6 +1836,7 @@
       "dashboard_admin_per_assignee_template_required": "En administratörsmall per användare krävs när administratörslayouten inkluderar per användare.",
       "dashboard_admin_per_assignee_needs_assignees": "Administratörslayout per användare kräver minst en vald användare.",
       "dashboard_dependency_ack_required": "Aktivera \"Fortsätt ändå\" för att fortsätta, eller gå tillbaka och installera först saknade nödvändiga beroenden.",
+      "dashboard_access_warning_ack_required": "Bekräfta åtkomstkontrollvarningen för att fortsätta, eller gå tillbaka och länka de berörda användarna eller aktivera kioskläge.",
       "dashboard_nonselectable_templates": "En eller flera valda mallar är inte tillgängliga för generering.",
       "dashboard_release_strict_pin_failed": "Den valda dashboard-versionen måste vara exakt fäst, men ingen effektiv versionsreferens fanns tillgänglig vid körningstillfället. Välj versionen igen i steg 1 och försök igen.",
       "dashboard_release_asset_prep_failed": "Det gick inte att förbereda valda online-instrumentpanelsresurser. Välj en annan version eller använd de senaste kompatibla/aktuella lokala mallarna och försök igen."
@@ -5083,6 +5086,12 @@
     },
     "dashboard_label_preferences_guide_not_provided": {
       "message": "Inställningsguide tillhandahålls inte"
+    },
+    "user_non_kiosk_unlinked_warning": {
+      "message": "⚠️ **Åtkomstvarning:** Kioskläget är inaktiverat och den här användaren är inte länkad till en Home Assistant-användare. Knappar för att göra anspråk på och lösa in delade enheter kanske inte fungerar för den här användaren förrän du länkar en Home Assistant-användare eller aktiverar kioskläget."
+    },
+    "dashboard_unlinked_users_warning": {
+      "message": "⚠️ Kioskläget är inaktiverat och dessa valda användare har inga länkade Home Assistant-användare:\n{user_list}\n\nKnappar för att göra anspråk och lösa in fungerar eventuellt inte som förväntat på delade enheter förrän dessa användare är länkade eller kioskläget är aktiverat."
     },
     "not_authorized_action": {
       "message": "Du har inte behörighet att {action} för denna tilldelade person."

--- a/custom_components/choreops/translations_custom/fr_notifications.json
+++ b/custom_components/choreops/translations_custom/fr_notifications.json
@@ -7,7 +7,7 @@
     "message": "{chore_name} approuvé! Vous avez gagné des points {points}"
   },
   "chore_disapproved_assignee": {
-    "title": "↩️ La corvée est revenue",
+    "title": "↩️ La tâche est revenue",
     "message": "{chore_name} nécessite plus de travail."
   },
   "chore_overdue_assignee": {
@@ -15,7 +15,7 @@
     "message": "{chore_name} est en retard ! Terminez-le maintenant pour gagner {points} points"
   },
   "chore_overdue_steal_available": {
-    "title": "Alerte corvée",
+    "title": "Alerte tâches",
     "message": "{chore_name} est en retard et disponible pour être volé ! Terminez-le en premier pour gagner {points} points"
   },
   "chore_missed_assignee": {
@@ -24,18 +24,18 @@
   },
   "chore_due_reminder_assignee": {
     "title": "⏰ Rappel des tâches ménagères",
-    "message": "{chore_name} est dû dans {minutes} minutes ! Vaut {points} points"
+    "message": "{chore_name} doit être terminée avant {minutes} minutes ! Vaut {points} points"
   },
   "chore_due_window_assignee": {
     "title": "🎯 Tâches ménagères à faire maintenant",
-    "message": "{chore_name} est maintenant à rendre ! Terminez-le dans un délai de {hours} heure(s) pour gagner {points} points"
+    "message": "{chore_name} est maintenant à faire ! Terminez-la dans un délai de {hours} heure(s) pour gagner {points} points"
   },
   "reward_approved_assignee": {
     "title": "🎉 Récompense approuvée !",
     "message": "{reward_name} approuvé !"
   },
   "reward_disapproved_assignee": {
-    "title": "💭 Demande de récompense retournée",
+    "title": "💭 Demande de récompense rejetée",
     "message": "{reward_name} n'a pas été approuvé cette fois-ci."
   },
   "badge_earned_assignee": {
@@ -51,7 +51,7 @@
     "message": "Vous avez terminé {challenge_name}! Continuez comme ça !"
   },
   "penalty_applied_assignee": {
-    "title": "⚠️ Sanction appliquée",
+    "title": "⚠️ Pénalité appliquée",
     "message": "{penalty_name}: {points} points déduits. Reprenons le fil !"
   },
   "bonus_applied_assignee": {
@@ -66,7 +66,7 @@
   "_comment_approver_desc": "NOTIFICATIONS DES APPROUVEURS : Informatives, à la troisième personne, exploitables. Format : « {assignee_name} : Action ». Sans préfixe « ChoreOps : ».",
   "_comment_approver_footer": "══════════════════════════════════════════════════════════════",
   "chore_claimed_approver": {
-    "title": "✋ {assignee_name}: Tâche prise",
+    "title": "✋ {assignee_name}: Tâche réclamée",
     "message": "{assignee_name} a revendiqué {chore_name}"
   },
   "chore_reminder_approver": {
@@ -134,8 +134,8 @@
   "actions": {
     "approve": "✅ Approuver",
     "claim": "✋ J'ai réussi !",
-    "complete": "✅ Complet",
-    "disapprove": "↩️ Désapprouver",
+    "complete": "✅ Terminé",
+    "disapprove": "↩️ Refuser",
     "remind_30": "⏰ Rappel dans 30 min",
     "skip": "⏭️ Passer"
   }

--- a/custom_components/choreops/translations_custom/fr_report.json
+++ b/custom_components/choreops/translations_custom/fr_report.json
@@ -18,7 +18,7 @@
   "badges_earned_none": "🏅 Badges obtenus : aucun durant cette période",
   "bonus_points": "✨ Points bonus",
   "rewards_highlight": "🎁 Récompenses",
-  "daily_ledger": "Détails du grand livre",
+  "daily_ledger": "Détails livre de comptes",
   "best_day": "🏆 Meilleure journée : {date} (points nets {net})",
   "no_activity": "Aucune activité trouvée pour la plage sélectionnée.",
   "day_points_earned": "🌟 Points gagnés",
@@ -30,11 +30,11 @@
   "automation_summary": "## Résumé",
   "automation_daily": "## Tous les jours",
   "automation_no_activity": "- aucune activité",
-  "automation_assignees": "cessionnaires",
+  "automation_assignees": "Participants",
   "automation_range_start": "début de la plage",
   "automation_range_end": "fin de plage",
-  "automation_total_earned": "total_gagné",
-  "automation_total_spent": "total_dépensé",
-  "automation_net": "filet",
-  "automation_transactions": "transactions"
+  "automation_total_earned": "Total gagné",
+  "automation_total_spent": "Total dépensé",
+  "automation_net": "Net",
+  "automation_transactions": "Transactions"
 }

--- a/docs/in-process/UI_ERROR_SURFACING_AND_KIOSK_DISCOVERABILITY_IN-PROCESS.md
+++ b/docs/in-process/UI_ERROR_SURFACING_AND_KIOSK_DISCOVERABILITY_IN-PROCESS.md
@@ -1,0 +1,188 @@
+# Initiative snapshot
+
+- **Name / Code**: UI error surfacing and kiosk discoverability / `UI_ERROR_SURFACING_KIOSK_DISCOVERABILITY`
+- **Target release / milestone**: TBD; suitable for next user-facing feature release after the claim-button proof of concept
+- **Owner / driver(s)**: TBD
+- **Status**: In progress
+
+## Summary & immediate steps
+
+| Phase / Step                                   | Description                                                                                                       | % complete | Quick notes                                                                |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------------- |
+| Phase 1 – Error surface audit and UX contract  | Define where backend failures should reach the UI and lock the narrow wording scope before implementation         | 100%       | Audit complete; wording gate approved as propagation-only with current IDs |
+| Phase 2 – Buttons and service-call propagation | Stop swallowing actionable exceptions in button/service entry points and keep wording changes intentionally small | 100%       | Actionable button handlers now re-raise after logging; auth copy unchanged |
+| Phase 3 – Kiosk and user-link discoverability  | Add proactive warnings when users are unlinked and kiosk mode is off, including dashboard generator guidance      | 100%       | User form and dashboard generator warnings now land before save/apply      |
+| Phase 4 – Tests, docs, and rollout             | Add regression coverage, update quick-start/access-control docs, and prepare release-note language                | 80%        | Wiki docs updated; release-note work intentionally deferred                |
+
+1. **Key objective** – Surface backend failures in the Home Assistant UI wherever the failure is actionable for an end user, and reduce kiosk-mode/user-linking confusion by warning earlier when a user profile has no linked HA user while kiosk mode is disabled.
+2. **Summary of recent work** –
+
+- Completed the Phase 1 audit across button and service entry points and locked the auth wording gate to keep existing `ERROR_ACTION_*` identifiers unchanged for v1.
+- Updated all remaining actionable button handlers in `custom_components/choreops/button.py` so `HomeAssistantError` exceptions are re-raised after logging instead of being swallowed.
+- Added focused regression coverage in `tests/test_kiosk_mode_buttons.py` for unauthorized chore, reward, bonus, penalty, and manual-points button presses.
+- Aligned three pre-existing tests with the corrected surfaced-error behavior in `tests/test_chore_scheduling.py`, `tests/test_rotation_services.py`, and `tests/test_workflow_chores.py`.
+- Added Phase 3 non-kiosk discoverability in the add/edit user flow and dashboard generator review step, including a one-time soft warning before saving an unlinked assignee profile and an explicit acknowledgement gate before generating dashboards for selected unlinked users.
+- Updated user-form `ha_user_id` help text to explain the shared-device consequence when kiosk mode is disabled.
+- Updated the wiki quick start, access control guide, and FAQ so claiming or authorization errors now route users toward linked-user and kiosk-mode guidance before they hit deeper troubleshooting.
+- Validation is clean for the current scope: `./utils/quick_lint.sh --fix` passed and `python -m pytest tests/ -v --tb=line` passed with `1758 passed, 4 skipped, 2 deselected`.
+
+3. **Next steps (short term)** –
+
+- Release-note language is intentionally deferred for later.
+- Decide whether any remaining wiki pages need cross-links back to the updated quick start, FAQ, and access-control docs.
+- Decide whether a follow-up issue is needed for any broader access-control copy cleanup beyond this scoped warning work.
+
+4. **Risks / blockers** –
+
+- Some current error text is technically correct but not especially polished for end users; however, this initiative remains intentionally **not** a broad translation cleanup.
+- Over-surfacing low-value internal failures could create noisy UI if exceptions that should remain logs-only are exposed without triage.
+- Kiosk-mode guidance must remain explicit about the security tradeoff on shared devices and must not weaken service-level authorization.
+  - Standalone `mypy custom_components/choreops/` still collides with the separate Core checkout parser environment, even though repo-local mypy inside `./utils/quick_lint.sh --fix` passes.
+
+5. **References** –
+   - [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+   - [docs/DEVELOPMENT_STANDARDS.md](../DEVELOPMENT_STANDARDS.md)
+   - [docs/CODE_REVIEW_GUIDE.md](../CODE_REVIEW_GUIDE.md)
+   - [tests/AGENT_TEST_CREATION_INSTRUCTIONS.md](../../tests/AGENT_TEST_CREATION_INSTRUCTIONS.md)
+   - [docs/RELEASE_CHECKLIST.md](../RELEASE_CHECKLIST.md)
+   - [docs/completed/legacy-kidschores/KIOSK_MODE_CLAIMS_COMPLETED.md](../completed/legacy-kidschores/KIOSK_MODE_CLAIMS_COMPLETED.md)
+6. **Decisions & completion check**
+   - **Decisions captured**:
+     - Keep the first release focused on actionable user-facing failures from buttons and service calls; do not broaden to every internal exception path by default.
+     - This is **not** a full translation or message-normalization initiative.
+     - Auth wording changes, if any, must stay intentionally small and require an explicit approval gate with the exact list of changed phrases before implementation.
+     - If the approved wording list is empty, the implementation proceeds with existing action identifiers such as `claim_chores` and only changes propagation behavior.
+     - Include the kiosk/user-linking warning idea from user feedback, with highest priority on the soft warning when a user has no linked HA account and kiosk mode is disabled.
+     - Add a dashboard generator warning/check when selected assignees are not linked to HA users and kiosk mode is disabled, using the same override pattern users already understand from dependency validation if implementation complexity remains reasonable.
+     - Initial setup onboarding question is explicitly out of scope for this initiative.
+     - No schema bump is expected because the scoped changes are exception propagation, light copy adjustments, and options-flow/dashboard validation only.
+   - **Completion confirmation**: `[ ]` All follow-up items completed (architecture updates, cleanup, documentation, etc.) before requesting owner approval to mark initiative done.
+
+> **Important:** Keep the entire Summary section (table + bullets) current with every meaningful update (after commits, tickets, or blockers change). Records should stay concise, fact-based, and readable so anyone can instantly absorb where each phase stands. This summary is the only place readers should look for the high-level snapshot.
+
+## Tracking expectations
+
+- **Summary upkeep**: Whoever works on the initiative must refresh the Summary section after each significant change, including updated percentages per phase, new blockers, or completed steps. Mention dates or commit references if helpful.
+- **Detailed tracking**: Use the phase-specific sections below for granular progress, issues, decision notes, and action items. Do not merge those details into the Summary table—Summary remains high level.
+
+## Detailed phase tracking
+
+### Phase 1 – Error surface audit and UX contract
+
+- **Goal**: Identify which backend failures should be surfaced to end users, preserve pragmatic exception behavior, and produce an explicit approval list for any auth wording changes.
+- **Steps / detailed work items**
+  1. [x] Audit button entry points in `custom_components/choreops/button.py` around lines 344-1638 and classify each `except HomeAssistantError as e` branch as one of: re-raise to UI, keep log-only, or needs a small copy cleanup before surfacing.
+  2. [x] Audit service handlers in `custom_components/choreops/services.py` around lines 1172-1235, 1239-1408, 1959-2186, and 2222-2466 to identify which failures already raise correctly and which surfaced errors are likely acceptable as-is versus obviously too technical.
+  3. [x] Produce a **gated wording inventory** for approval before implementation begins on any auth copy changes. This inventory must list:
+     - the current surfaced auth/action strings,
+     - the exact proposed replacement text, if any,
+     - the files/constants involved,
+     - and a clear note when the recommendation is to keep the current identifier unchanged.
+  4. [x] Treat the auth wording inventory as a hard gate for Phase 2. If the approved list is empty, Phase 2 proceeds with propagation-only changes and no auth-label edits.
+  5. [x] Document scope boundaries in this plan: notification-action flows, background tasks, and purely diagnostic logs stay out unless they directly back a user action.
+- **Key issues**
+  - The current integration already has good logging; the real work is deciding which of those failures are user-actionable enough to surface.
+  - The goal is not perfect copy everywhere; the goal is avoiding obviously confusing surfaced text while keeping the scope small.
+  - A single audit pass should prevent one-off fixes from creating inconsistent UI behavior across similar button entities.
+
+### Phase 2 – Buttons and service-call propagation
+
+- **Goal**: Make user-triggered actions fail visibly in the UI when they already produce meaningful backend exceptions, with minimal behavioral risk and only approved copy changes.
+- **Steps / detailed work items**
+  1. [x] **Phase gate**: confirm the approved auth wording inventory from Phase 1 before changing any auth/action copy. If no wording changes are approved, explicitly record that Phase 2 is propagation-only.
+  2. [x] Update chore button handlers in `custom_components/choreops/button.py` around lines 388-405, 523-538, and 699-714 so authorization and actionable workflow errors are re-raised after logging instead of being swallowed.
+  3. [x] Update reward button handlers in `custom_components/choreops/button.py` around lines 843-857, 979-994, and 1151-1166 using the same propagation rule for redeem/approve/disapprove flows.
+  4. [x] Review bonus, penalty, and manual-points buttons in `custom_components/choreops/button.py` around lines 1297-1312, 1450-1465, and 1634-1649 to confirm whether the same propagation behavior should apply there; include them only if the errors are clearly actionable and useful in the UI.
+  5. [x] Keep service-layer changes pragmatic in `custom_components/choreops/services.py` around lines 1172-1235, 1959-2035, and 2222-2466: fix clearly user-facing auth/validation cases first, and do not expand into a repo-wide message-normalization effort.
+  6. [x] Only if explicitly approved in the wording gate, introduce the smallest possible action-label or auth-copy edits in `custom_components/choreops/const.py` and `custom_components/choreops/translations/en.json`; otherwise preserve existing identifiers such as `claim_chores`.
+  7. [x] Verify that service handlers invoked by automations still receive actionable exception text while preserving the project rule that services stay thin and manager-owned logic remains unchanged.
+- **Key issues**
+  - Re-raising all `HomeAssistantError` branches blindly may expose low-level text that should first be triaged, even if no wording changes are ultimately approved.
+  - Button and service flows should remain behaviorally equivalent aside from surfacing the failure to the user.
+  - This phase should avoid refactoring unrelated manager logic, exception taxonomies, or translation systems unless necessary for a specifically approved surfaced message.
+
+### Phase 3 – Kiosk and user-link discoverability
+
+- **Goal**: Warn users earlier when their configuration makes claim buttons fail on shared devices, with minimal friction and no authorization weakening.
+- **Steps / detailed work items**
+  1. [x] Update the user-form help text in `custom_components/choreops/translations/en.json` around lines 80-95, 563-578, and 994-1009 so the HA user link field more clearly explains the kiosk-mode/shared-device consequence. This should be a simple clarity improvement, not a large copy rewrite.
+  2. [x] Add a soft validation or attention-callout path in the add/edit user flow in `custom_components/choreops/options_flow.py` around lines 702-770 and 794-860 so a user profile with no linked HA user can be flagged when `CONF_KIOSK_MODE` is false.
+  3. [x] Introduce any needed helper logic in `custom_components/choreops/helpers/flow_helpers.py` around lines 341-460 and 3150-3215 to keep the warning criteria centralized and consistent with existing form normalization patterns.
+  4. [x] Add a dashboard generator warning/check in `custom_components/choreops/options_flow.py` around lines 4058-4308 and 4448-4505 so selected assignees without linked HA users are flagged when kiosk mode is disabled.
+  5. [x] Prefer integrating the dashboard-generator warning into the existing custom-card/dependency validation experience if implementation complexity remains reasonable, so users can acknowledge it with the same override pattern they already understand.
+  6. [x] The dashboard-generator warning must:
+  - identify the affected selected users,
+  - explain that claim/redeem actions may not work as expected on shared devices when kiosk mode is disabled,
+  - provide an override path rather than a hard blocker,
+  - and point users to access-control documentation.
+  7. [x] If the warning needs reusable data access, extend dashboard helper/schema support in `custom_components/choreops/helpers/dashboard_helpers.py` around lines 1882-2020 so assignee options can carry or validate HA-user-link state without leaking UI logic into unrelated builder code.
+  8. [x] Add only the narrowly needed constants/translation keys in `custom_components/choreops/const.py` and `custom_components/choreops/translations/en.json` for the user-link hint and dashboard-generator warning paths.
+- **Key issues**
+  - The warning should be high-value but not blocking for intentional kiosk-disabled setups where users only use services or admin flows.
+  - The dashboard generator check should explain the consequence clearly: claim buttons will not work for that user unless the dashboard is used by the linked HA account or kiosk mode is enabled.
+  - Keep the wording short enough for forms, but explicit enough that users do not repeat the same troubleshooting loop.
+  - Reuse of the existing override pattern is preferred, but not at the cost of introducing disproportionate flow complexity.
+
+### Phase 4 – Tests, docs, and rollout
+
+- **Goal**: Prove the UI-surfacing behavior is deliberate, add coverage for the new warnings, and document the user-visible behavior change.
+- **Steps / detailed work items**
+  1. [x] Extend `tests/test_kiosk_mode_buttons.py` with additional button cases so unauthorized and actionable failures are asserted as raised service-call errors for chore and reward buttons, not just claim.
+  2. [ ] Add or extend service-focused coverage in `tests/test_chore_services.py`, `tests/test_reward_services.py`, and related points/badge service tests for user-facing auth/validation error behavior.
+  3. [x] Add options-flow coverage for the unlinked-user warning path in `tests/test_ha_user_id_options_flow.py` or a dedicated new flow test module, using existing scenario fixtures and `mock_hass_users`.
+  4. [x] Add dashboard-generator validation coverage in `tests/test_options_flow_dashboard_release_selection.py` or a dedicated dashboard-generator test module for the unlinked-assignee plus kiosk-disabled warning/check.
+  5. [ ] Update user-facing documentation in `README.md`, relevant wiki pages, and release-note text to explain that button/service failures now surface in the UI and that unlinked users on non-kiosk setups receive proactive warnings. Note: README and release-note work intentionally deferred for now.
+  6. [x] Update the quick-start wiki at `/workspaces/choreops-wiki/Getting-Started:-Quick-Start.md` with a high-visibility warning near the top that ChoreOps has built-in access rights, linked Home Assistant users matter, and shared-device deployments must intentionally consider kiosk mode and access control.
+  7. [x] Ensure the quick-start warning points readers to `/workspaces/choreops-wiki/Advanced:-Access-Control.md` for the full access-control guidance.
+  8. [ ] Run and record required validation commands: `./utils/quick_lint.sh --fix`, `mypy custom_components/choreops/`, and `python -m pytest tests/ -v --tb=line`.
+- **Key issues**
+  - Tests should verify real service-call failure behavior, not only post-state assertions, because frontend toasts depend on the service returning an error.
+  - If standalone `mypy` still collides with the multi-root workspace, validation notes should explicitly separate code correctness from environment-specific interpreter issues.
+  - Documentation should describe kiosk mode as a deliberate shared-device workflow, not a hidden troubleshooting-only switch.
+
+## Testing & validation
+
+- Planned validation commands:
+  - `./utils/quick_lint.sh --fix`
+  - `mypy custom_components/choreops/`
+  - `python -m pytest tests/ -v --tb=line`
+  - Targeted suites expected during development:
+    - `python -m pytest tests/test_kiosk_mode_buttons.py -v --tb=line`
+    - `python -m pytest tests/test_chore_services.py -v --tb=line`
+    - `python -m pytest tests/test_reward_services.py -v --tb=line`
+    - `python -m pytest tests/test_ha_user_id_options_flow.py -v --tb=line`
+    - `python -m pytest tests/test_options_flow_dashboard_release_selection.py -v --tb=line`
+- Tests executed:
+  - `./utils/quick_lint.sh --fix`
+  - `python -m pytest tests/test_kiosk_mode_buttons.py -v --tb=line`
+  - `python -m pytest tests/test_chore_scheduling.py::TestDueWindowClaimLockBehavior::test_can_claim_blocks_before_window_then_allows_in_window tests/test_rotation_services.py::test_open_rotation_cycle_allows_one_claim_then_blocks_others tests/test_workflow_chores.py::TestSharedAllChores::test_secondary_assignee_enters_missed_when_strict_overdue_lock_enabled -v --tb=line`
+  - `python -m pytest tests/test_ha_user_id_options_flow.py tests/test_options_flow_dashboard_release_selection.py -v --tb=line`
+  - `python -m pytest tests/test_options_flow_entity_crud.py tests/test_ha_user_id_options_flow.py tests/test_options_flow_dashboard_release_selection.py -v --tb=line`
+  - `python -m pytest tests/ -v --tb=line`
+- Outstanding tests:
+  - Standalone `mypy custom_components/choreops/` remains blocked by the known multi-root environment collision with the separate Core checkout.
+  - README and release-note updates are intentionally deferred.
+
+## Notes & follow-up
+
+- **Recommended v1 outcome**: user-triggered actions return visible UI errors where the integration already knows the action failed and already has meaningful exception content.
+- **Auth wording policy for v1**:
+  - Default position: keep existing action identifiers if they are judged sufficiently helpful for troubleshooting.
+  - Only change auth wording if the Phase 1 approval gate produces a small, explicit approved list.
+  - No broad translation cleanup or comprehensive message rewrite is part of this initiative.
+- **Recommended kiosk UX scope for v1**:
+  - Add the inline hint on the HA user field.
+  - Add the soft warning for unlinked users when kiosk mode is disabled.
+  - Add a dashboard-generator warning/check for selected assignees with no linked HA user when kiosk mode is disabled, preferably through the same override pattern used for existing validation warnings.
+  - Do **not** add the first-time onboarding question in this initiative.
+- **Copy/translation scope for v1**:
+  - Existing auth templates may remain in place unchanged if approved.
+  - New keys should be limited to the user-link hint, unlinked-user non-kiosk warning, and dashboard-generator warning if those UI surfaces require dedicated copy.
+  - Friendly action-label keys are optional and require explicit approval through the Phase 1 wording gate.
+- **Non-goals for this initiative**:
+  - No storage migration or schema change.
+  - No kiosk-mode behavior expansion beyond current security posture.
+  - No attempt to surface every background/internal exception in the UI.
+  - No broad repo-wide translation or message-normalization campaign.
+
+> **Template usage notice:** Do **not** modify this template. Copy it for each new initiative and replace the placeholder content while keeping the structure intact. Save the copy under `docs/in-process/` with the suffix `_IN-PROCESS` (for example: `MY-INITIATIVE_PLAN_IN-PROCESS.md`). Once the work is complete, rename the document to `_COMPLETE` and move it to `docs/completed/`. The template itself must remain unchanged so we maintain consistency across planning documents.

--- a/docs/in-process/UI_ERROR_SURFACING_AND_KIOSK_DISCOVERABILITY_SUP_ISSUE_DRAFT.md
+++ b/docs/in-process/UI_ERROR_SURFACING_AND_KIOSK_DISCOVERABILITY_SUP_ISSUE_DRAFT.md
@@ -1,0 +1,65 @@
+# Proposed GitHub feature request
+
+- **Title**: `[REQ] Surface helpful backend errors in the UI and warn when unlinked users are used without kiosk mode`
+- **Suggested labels**: `enhancement`, `enh: feature`
+- **Feature area**: `Integration logic/state`
+
+## Form-ready draft
+
+### Problem or use case
+
+ChoreOps already does a good job logging failures, but many of those failures never make it back to the user in the Home Assistant UI.
+
+The immediate example is button-driven actions such as chore claim buttons. If the backend catches a meaningful authorization or validation error, logs it, and then returns cleanly, the frontend sees the action as successful and the user gets no toast or inline feedback. The log contains the explanation, but the person using the dashboard does not.
+
+This is especially confusing around kiosk mode and HA user linking. A common family setup is a shared or wall-mounted tablet. If a ChoreOps user has no linked Home Assistant user and kiosk mode is disabled, claim buttons can fail in a way that is easy to diagnose from logs but not obvious to the user.
+
+That combination created a long troubleshooting loop even though the underlying feature already exists and works well once it is discovered.
+
+### Proposed solution
+
+Improve user-facing error surfacing for actionable backend failures, with the first focus on buttons and service calls.
+
+Requested scope:
+
+1. When button actions fail with a meaningful backend exception, let that failure reach Home Assistant so the native frontend can show the user-facing error toast.
+2. Review service-call entry points and ensure user-actionable failures return helpful, translatable errors instead of log-only outcomes or overly technical wording.
+3. Keep the existing strong logging, but treat logs as support evidence rather than the only place a user can learn why an action failed.
+4. Improve kiosk-mode/user-link discoverability:
+   - Add an inline hint on the HA User field explaining that kiosk mode may be appropriate for shared or wall-mounted tablets.
+   - Add a soft warning when a user profile has no linked HA account and kiosk mode is disabled.
+   - Add a dashboard generator warning/check when the user selects an assignee who is not linked to an HA user while kiosk mode is disabled.
+
+I do **not** think this needs to include every possible onboarding or setup improvement right now. The highest-impact, lowest-effort piece appears to be the warning for `no linked HA user + kiosk mode disabled`, plus the dashboard generator check.
+
+### Expected outcome
+
+- Users see helpful feedback in the UI at the moment an action fails instead of having to inspect system logs.
+- Shared-tablet and wall-mounted dashboard setups become much easier to configure correctly.
+- Support burden drops because the most common kiosk-mode/user-linking mistake is explained proactively.
+- The existing backend logging remains useful for maintainers, while the UI becomes more self-explanatory for families using the system.
+
+### Alternatives considered
+
+- Relying on logs only: good for maintainers, but not for the person pressing the button.
+- Expanding onboarding/setup flow immediately: useful, but larger in scope than necessary for the main pain point.
+- Document-only solution: helpful, but weaker than showing the user the problem at the moment it happens.
+
+### Additional context
+
+- A recent claim-button proof of concept confirmed that simply allowing the existing translated auth exception to propagate causes the native frontend error toast to appear as expected.
+- This suggests there may be a broader opportunity across other buttons and service calls wherever ChoreOps already knows the action failed and already has meaningful error text.
+- Related kiosk-mode discoverability suggestions from user feedback:
+  - Inline hint in the user edit form
+  - Warning when HA user is `none` and kiosk mode is disabled
+  - Onboarding question during first-time setup
+- Of those, the second option appears to have the best impact-to-effort ratio.
+
+## Notes for triage
+
+- Primary value: better user-facing UX with minimal backend behavior change.
+- Secondary value: reduce kiosk-mode and HA-user-linking confusion before users hit broken claim-button behavior.
+- Good first implementation slices:
+  1. Audit and re-raise existing actionable button exceptions.
+  2. Normalize user-facing service-call errors.
+  3. Add the non-kiosk unlinked-user warning plus dashboard generator check.

--- a/docs/in-process/UI_ERROR_SURFACING_AUTH_WORDING_INVENTORY_IN-PROCESS.md
+++ b/docs/in-process/UI_ERROR_SURFACING_AUTH_WORDING_INVENTORY_IN-PROCESS.md
@@ -1,0 +1,107 @@
+# Auth wording inventory
+
+## Purpose
+
+This document is the Phase 1 approval gate for auth/action wording in the UI error surfacing initiative.
+
+It exists to answer one question before implementation changes any auth copy:
+
+- Do we keep the currently surfaced auth/action identifiers as-is, or do we approve a small, explicit replacement list?
+
+If the approved change list is empty, implementation proceeds with propagation-only behavior and no auth/action label changes.
+
+## Current auth templates
+
+Source:
+
+- [custom_components/choreops/translations/en.json](/workspaces/choreops/custom_components/choreops/translations/en.json#L5088)
+- [custom_components/choreops/const.py](/workspaces/choreops/custom_components/choreops/const.py#L3148)
+
+Current templates:
+
+- Assignee-scoped: `You are not authorized to {action} for this assignee.`
+- Global: `You are not authorized to {action}.`
+
+Current behavior:
+
+- The `{action}` placeholder is populated directly from the `ERROR_ACTION_*` constants.
+- That means surfaced messages currently use raw identifiers such as `claim_chores` and `adjust_points`.
+
+## Approval rule
+
+Approval options for each entry:
+
+- `KEEP` = keep the current identifier exactly as-is
+- `CHANGE` = replace with the explicitly listed new text
+- `DEFER` = do not change in this initiative; revisit later if needed
+
+Implementation rule:
+
+- Only entries explicitly marked `CHANGE` after review may be edited.
+- If no entries are marked `CHANGE`, no auth wording edits will be made in implementation.
+
+## Inventory
+
+| Action constant                   | Current value        | Current rendered message                                                                                             | Used by          | Usage locations                                                                                                                                                | Recommendation | Proposed replacement if approved | Notes                                                                |
+| --------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------- | -------------------------------------------------------------------- |
+| `ERROR_ACTION_CLAIM_CHORES`       | `claim_chores`       | `You are not authorized to claim_chores for this assignee.`                                                          | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L363), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L1214)  | `KEEP`         | None                             | This is understandable and directly searchable for troubleshooting.  |
+| `ERROR_ACTION_APPROVE_CHORES`     | `approve_chores`     | `You are not authorized to approve_chores.` or `You are not authorized to approve_chores for this assignee.`         | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L501), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L1310)  | `KEEP`         | None                             | Slightly technical, but still clear and low risk to leave unchanged. |
+| `ERROR_ACTION_DISAPPROVE_CHORES`  | `disapprove_chores`  | `You are not authorized to disapprove_chores.` or `You are not authorized to disapprove_chores for this assignee.`   | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L674), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L1384)  | `KEEP`         | None                             | Not elegant, but specific and operationally clear.                   |
+| `ERROR_ACTION_REDEEM_REWARDS`     | `redeem_rewards`     | `You are not authorized to redeem_rewards for this assignee.`                                                        | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L816), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2002)  | `KEEP`         | None                             | Good enough for v1; likely understandable to users and maintainers.  |
+| `ERROR_ACTION_APPROVE_REWARDS`    | `approve_rewards`    | `You are not authorized to approve_rewards.` or `You are not authorized to approve_rewards for this assignee.`       | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L954), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2111)  | `KEEP`         | None                             | Same rationale as chore approval.                                    |
+| `ERROR_ACTION_DISAPPROVE_REWARDS` | `disapprove_rewards` | `You are not authorized to disapprove_rewards.` or `You are not authorized to disapprove_rewards for this assignee.` | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L1126), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2190) | `KEEP`         | None                             | Same rationale as chore disapproval.                                 |
+| `ERROR_ACTION_APPLY_PENALTIES`    | `apply_penalties`    | `You are not authorized to apply_penalties.` or `You are not authorized to apply_penalties for this assignee.`       | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L1425), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2264) | `KEEP`         | None                             | Technical, but still precise.                                        |
+| `ERROR_ACTION_APPLY_BONUSES`      | `apply_bonuses`      | `You are not authorized to apply_bonuses.` or `You are not authorized to apply_bonuses for this assignee.`           | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L1274), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2338) | `KEEP`         | None                             | Same rationale as penalties.                                         |
+| `ERROR_ACTION_ADJUST_POINTS`      | `adjust_points`      | `You are not authorized to adjust_points.` or `You are not authorized to adjust_points for this assignee.`           | Button + service | [button.py](/workspaces/choreops/custom_components/choreops/button.py#L1603), [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2402) | `KEEP`         | None                             | Directly maps to the feature name and likely helps troubleshooting.  |
+| `ERROR_ACTION_REMOVE_BADGES`      | `remove_badges`      | `You are not authorized to remove_badges.`                                                                           | Service only     | [services.py](/workspaces/choreops/custom_components/choreops/services.py#L2469)                                                                               | `KEEP`         | None                             | Service-only path; low value to change now.                          |
+
+## Optional alternative replacements
+
+These are **not recommended by default**. They are listed only so approval can be explicit if preferences change.
+
+| Current value        | Possible replacement |
+| -------------------- | -------------------- |
+| `claim_chores`       | `claim chores`       |
+| `approve_chores`     | `approve chores`     |
+| `disapprove_chores`  | `disapprove chores`  |
+| `redeem_rewards`     | `redeem rewards`     |
+| `approve_rewards`    | `approve rewards`    |
+| `disapprove_rewards` | `disapprove rewards` |
+| `apply_penalties`    | `apply penalties`    |
+| `apply_bonuses`      | `apply bonuses`      |
+| `adjust_points`      | `adjust points`      |
+| `remove_badges`      | `remove badges`      |
+
+These replacements are intentionally minimal. They would preserve the same semantic meaning while removing underscores only.
+
+## Recommendation for approval
+
+Recommended approval set:
+
+- Mark **all entries `KEEP`** for v1.
+- Do **not** introduce friendly action-label keys in this initiative.
+- Focus implementation effort on error propagation, kiosk/user-link discoverability, and documentation.
+
+Reasoning:
+
+- The current identifiers are technical, but they are still understandable.
+- They are specific enough to help with troubleshooting.
+- Changing them adds scope without materially improving the core outcome of this initiative, which is surfacing the failure in the UI.
+
+## Explicit decision block
+
+Record approval here before Phase 2 implementation starts:
+
+- Approval date: `2026-03-19`
+- Reviewer: `User approval recorded in chat`
+- Decision:
+  - [x] Keep all current auth/action identifiers unchanged
+  - [ ] Change only the entries explicitly listed below
+
+Approved `CHANGE` list:
+
+| Action constant | Approved replacement |
+| --------------- | -------------------- |
+| _None yet_      |                      |
+
+If this table remains empty, implementation must not change the auth/action labels.

--- a/tests/helpers/flow_test_helpers.py
+++ b/tests/helpers/flow_test_helpers.py
@@ -20,6 +20,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant
 
+from custom_components.choreops import const
 from tests.helpers import (
     # Badge constants
     BADGE_TYPE_CUMULATIVE,
@@ -560,10 +561,23 @@ class FlowTestHelper:
         )
 
         # Submit form data
-        return await hass.config_entries.options.async_configure(
+        result = await hass.config_entries.options.async_configure(
             add_result["flow_id"],
             user_input=form_data,
         )
+
+        if result.get("step_id") == add_step and result.get(
+            "description_placeholders", {}
+        ).get(
+            const.PLACEHOLDER_USER_ACCESS_WARNING,
+            "",
+        ):
+            return await hass.config_entries.options.async_configure(
+                add_result["flow_id"],
+                user_input=form_data,
+            )
+
+        return result
 
     @staticmethod
     async def edit_entity_via_options_flow(
@@ -603,10 +617,23 @@ class FlowTestHelper:
         )
 
         # Submit updated form data
-        return await hass.config_entries.options.async_configure(
+        result = await hass.config_entries.options.async_configure(
             select_result["flow_id"],
             user_input=form_data,
         )
+
+        if result.get("step_id") == select_result.get("step_id") and result.get(
+            "description_placeholders", {}
+        ).get(
+            const.PLACEHOLDER_USER_ACCESS_WARNING,
+            "",
+        ):
+            return await hass.config_entries.options.async_configure(
+                select_result["flow_id"],
+                user_input=form_data,
+            )
+
+        return result
 
 
 # =========================================================================

--- a/tests/test_chore_scheduling.py
+++ b/tests/test_chore_scheduling.py
@@ -74,7 +74,9 @@ Coordinator method: _process_time_checks()
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import pytest
 
 from custom_components.choreops import const
@@ -125,6 +127,7 @@ from tests.helpers import (
     SetupResult,
     claim_chore,
     find_chore,
+    get_chore_buttons,
     get_dashboard_helper,
     setup_from_yaml,
 )
@@ -2986,19 +2989,22 @@ class TestDueWindowClaimLockBehavior:
             assignee_chore_data.get(DATA_USER_CHORE_DATA_STATE) == CHORE_STATE_PENDING
         )
 
-        blocked_claim = await claim_chore(
-            hass,
-            "zoe",
-            "Reset Due Date Once",
-            assignee_context,
-        )
-        assert blocked_claim.state_before == CHORE_STATE_WAITING
-        assert blocked_claim.state_after == CHORE_STATE_WAITING
-        assert blocked_claim.points_changed == 0.0
+        claim_button_eid = get_chore_buttons(hass, chore_before["eid"])["claim"]
+        assert claim_button_eid
+
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                BUTTON_DOMAIN,
+                SERVICE_PRESS,
+                {"entity_id": claim_button_eid},
+                blocking=True,
+                context=assignee_context,
+            )
 
         chore_sensor_after_block = hass.states.get(chore_before["eid"])
         assert chore_sensor_after_block is not None
         assert chore_sensor_after_block.state == CHORE_STATE_WAITING
+        assert chore_sensor_after_block.attributes.get(ATTR_CAN_CLAIM) is False
 
         # Move due date into active window: due in 1h with 2h window => claim now allowed
         await hass.services.async_call(

--- a/tests/test_ha_user_id_options_flow.py
+++ b/tests/test_ha_user_id_options_flow.py
@@ -25,6 +25,7 @@ from tests.helpers import (
     CFOF_USERS_INPUT_ENABLE_GAMIFICATION,
     # Common constants
     DATA_APPROVER_HA_USER_ID,
+    OPTIONS_FLOW_ACTIONS_ADD,
     OPTIONS_FLOW_ACTIONS_EDIT,
     OPTIONS_FLOW_INPUT_ENTITY_NAME,
     OPTIONS_FLOW_INPUT_MANAGE_ACTION,
@@ -191,6 +192,27 @@ class TestHaUserIdClearing:
                 },
             )
         assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == const.OPTIONS_FLOW_STEP_EDIT_USER
+
+        with patch(
+            "custom_components.choreops.helpers.translation_helpers.get_available_dashboard_languages",
+            return_value=["en"],
+        ):
+            result = await hass.config_entries.options.async_configure(
+                result.get("flow_id"),
+                user_input={
+                    CFOF_APPROVERS_INPUT_NAME: approver_name,
+                    CFOF_APPROVERS_INPUT_HA_USER: SENTINEL_NO_SELECTION,
+                    CFOF_USERS_INPUT_ASSOCIATED_USER_IDS: associated_assignees,
+                    CFOF_APPROVERS_INPUT_MOBILE_NOTIFY_SERVICE: SENTINEL_NO_SELECTION,
+                    CFOF_USERS_INPUT_CAN_BE_ASSIGNED: True,
+                    CFOF_USERS_INPUT_CAN_APPROVE: True,
+                    CFOF_USERS_INPUT_CAN_MANAGE: False,
+                    CFOF_USERS_INPUT_ENABLE_CHORE_WORKFLOW: False,
+                    CFOF_USERS_INPUT_ENABLE_GAMIFICATION: False,
+                },
+            )
+        assert result.get("type") == FlowResultType.FORM
         assert result.get("step_id") == OPTIONS_FLOW_STEP_INIT
 
         # Step 7: Verify user ID was cleared
@@ -282,3 +304,68 @@ class TestHaUserIdClearing:
 
         assert result.get("type") == FlowResultType.FORM
         assert result.get("step_id") == const.OPTIONS_FLOW_STEP_EDIT_USER
+
+    async def test_add_user_shows_non_kiosk_warning_before_saving_unlinked_assignee(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+    ) -> None:
+        """Add user flow pauses once to show the non-kiosk unlinked warning."""
+        config_entry = scenario_minimal.config_entry
+        coordinator = config_entry.runtime_data
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result.get("flow_id"),
+            user_input={OPTIONS_FLOW_INPUT_MENU_SELECTION: OPTIONS_FLOW_USERS},
+        )
+        result = await hass.config_entries.options.async_configure(
+            result.get("flow_id"),
+            user_input={OPTIONS_FLOW_INPUT_MANAGE_ACTION: OPTIONS_FLOW_ACTIONS_ADD},
+        )
+
+        flow_id = result["flow_id"]
+        new_user_input = {
+            const.CFOF_USERS_INPUT_NAME: "Tablet User",
+            const.CFOF_USERS_INPUT_HA_USER_ID: SENTINEL_NO_SELECTION,
+            const.CFOF_USERS_INPUT_ASSOCIATED_USER_IDS: [],
+            const.CFOF_USERS_INPUT_MOBILE_NOTIFY_SERVICE: SENTINEL_NO_SELECTION,
+            const.CFOF_USERS_INPUT_CAN_BE_ASSIGNED: True,
+            const.CFOF_USERS_INPUT_CAN_APPROVE: False,
+            const.CFOF_USERS_INPUT_CAN_MANAGE: False,
+            const.CFOF_USERS_INPUT_ENABLE_CHORE_WORKFLOW: True,
+            const.CFOF_USERS_INPUT_ENABLE_GAMIFICATION: True,
+            const.CFOF_USERS_INPUT_DASHBOARD_LANGUAGE: const.DEFAULT_DASHBOARD_LANGUAGE,
+        }
+
+        with patch(
+            "custom_components.choreops.helpers.translation_helpers.get_available_dashboard_languages",
+            return_value=["en"],
+        ):
+            result = await hass.config_entries.options.async_configure(
+                flow_id,
+                user_input=new_user_input,
+            )
+
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == const.OPTIONS_FLOW_STEP_ADD_USER
+        assert result.get("description_placeholders", {}).get(
+            const.PLACEHOLDER_USER_ACCESS_WARNING,
+            "",
+        )
+
+        with patch(
+            "custom_components.choreops.helpers.translation_helpers.get_available_dashboard_languages",
+            return_value=["en"],
+        ):
+            result = await hass.config_entries.options.async_configure(
+                flow_id,
+                user_input=new_user_input,
+            )
+
+        assert result.get("type") == FlowResultType.FORM
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_INIT
+        assert any(
+            user_data.get(const.DATA_USER_NAME) == "Tablet User"
+            for user_data in coordinator.users_data.values()
+        )

--- a/tests/test_kiosk_mode_buttons.py
+++ b/tests/test_kiosk_mode_buttons.py
@@ -18,6 +18,9 @@ from homeassistant.exceptions import HomeAssistantError
 import pytest
 
 from custom_components.choreops import const
+from custom_components.choreops.helpers.entity_helpers import (
+    get_points_adjustment_buttons,
+)
 from tests.helpers import (
     CHORE_STATE_CLAIMED,
     CHORE_STATE_PENDING,
@@ -26,11 +29,29 @@ from tests.helpers import (
     SetupResult,
     claim_chore,
     disapprove_chore,
+    find_bonus,
     find_chore,
+    find_penalty,
+    get_chore_buttons,
     get_dashboard_helper,
     setup_from_yaml,
 )
 from tests.helpers.workflows import find_reward, get_reward_buttons
+
+
+async def _press_button(
+    hass: HomeAssistant,
+    button_eid: str,
+    context: Context,
+) -> None:
+    """Press a button entity with explicit error propagation."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {"entity_id": button_eid},
+        blocking=True,
+        context=context,
+    )
 
 
 @pytest.fixture
@@ -66,20 +87,89 @@ async def test_kiosk_disabled_blocks_unauthorized_chore_claim_button(
 ) -> None:
     """Assignee claim button should enforce assignee auth when kiosk mode is disabled."""
     unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+    dashboard = get_dashboard_helper(hass, "zoe")
+    chore = find_chore(dashboard, "Make bed")
+    assert chore is not None
+
+    chore_state = hass.states.get(chore["eid"])
+    assert chore_state is not None
+
+    claim_button_eid = chore_state.attributes.get(
+        const.ATTR_CHORE_CLAIM_BUTTON_ENTITY_ID
+    )
+    assert claim_button_eid
 
     with patch(
         "custom_components.choreops.button.is_kiosk_mode_enabled", return_value=False
     ):
-        result = await claim_chore(
-            hass,
-            "zoe",
-            "Make bed",
-            context=unauthorized_context,
-        )
+        with pytest.raises(HomeAssistantError):
+            await hass.services.async_call(
+                BUTTON_DOMAIN,
+                SERVICE_PRESS,
+                {"entity_id": claim_button_eid},
+                blocking=True,
+                context=unauthorized_context,
+            )
 
-    assert result.success is True
-    assert result.state_before == CHORE_STATE_PENDING
-    assert result.state_after == CHORE_STATE_PENDING
+    chore_state = hass.states.get(chore["eid"])
+    assert chore_state is not None
+    assert chore_state.state == CHORE_STATE_PENDING
+
+
+async def test_kiosk_disabled_blocks_unauthorized_chore_approve_button(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Approver chore approve button should surface unauthorized failures."""
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+
+    claim_result = await claim_chore(hass, "zoe", "Make bed", context=assignee_context)
+    assert claim_result.success is True
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    chore = find_chore(dashboard, "Make bed")
+    assert chore is not None
+
+    buttons = get_chore_buttons(hass, chore["eid"])
+    approve_button_eid = buttons["approve"]
+    assert approve_button_eid
+
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, approve_button_eid, unauthorized_context)
+
+    chore_state = hass.states.get(chore["eid"])
+    assert chore_state is not None
+    assert chore_state.state == CHORE_STATE_CLAIMED
+
+
+async def test_kiosk_disabled_blocks_unauthorized_chore_disapprove_button(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Approver chore disapprove button should surface unauthorized failures."""
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+
+    claim_result = await claim_chore(hass, "zoe", "Make bed", context=assignee_context)
+    assert claim_result.success is True
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    chore = find_chore(dashboard, "Make bed")
+    assert chore is not None
+
+    buttons = get_chore_buttons(hass, chore["eid"])
+    disapprove_button_eid = buttons["disapprove"]
+    assert disapprove_button_eid
+
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, disapprove_button_eid, unauthorized_context)
+
+    chore_state = hass.states.get(chore["eid"])
+    assert chore_state is not None
+    assert chore_state.state == CHORE_STATE_CLAIMED
 
 
 async def test_kiosk_enabled_allows_unauthorized_chore_claim_button(
@@ -145,6 +235,171 @@ async def test_kiosk_enabled_skips_reward_assignee_auth_guard(
 
     mock_auth_for_assignee.assert_not_awaited()
     mock_redeem.assert_awaited_once()
+
+
+async def test_kiosk_disabled_blocks_unauthorized_reward_redeem_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Reward redeem button should surface unauthorized assignee failures."""
+    coordinator = scenario_full.coordinator
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    coordinator.users_data[assignee_id][const.DATA_USER_POINTS] = 100.0
+    await coordinator.async_refresh()
+
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+    dashboard = get_dashboard_helper(hass, "zoe")
+    reward = find_reward(dashboard, "Extra Screen Time")
+    assert reward is not None
+
+    buttons = get_reward_buttons(hass, reward["eid"])
+    claim_button_eid = buttons["claim"]
+    assert claim_button_eid
+
+    with patch(
+        "custom_components.choreops.button.is_kiosk_mode_enabled", return_value=False
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, claim_button_eid, unauthorized_context)
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+    assert reward_state.state == const.REWARD_STATE_AVAILABLE
+
+
+async def test_kiosk_disabled_blocks_unauthorized_reward_approve_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Reward approve button should surface unauthorized failures."""
+    coordinator = scenario_full.coordinator
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    coordinator.users_data[assignee_id][const.DATA_USER_POINTS] = 100.0
+    await coordinator.async_refresh()
+
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    reward = find_reward(dashboard, "Extra Screen Time")
+    assert reward is not None
+
+    claim_button_eid = get_reward_buttons(hass, reward["eid"])["claim"]
+    assert claim_button_eid
+
+    reward_claim_context = Context(user_id=mock_hass_users["assignee1"].id)
+    with patch.object(
+        coordinator.notification_manager, "notify_assignee", new=AsyncMock()
+    ):
+        await _press_button(hass, claim_button_eid, reward_claim_context)
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    reward = find_reward(dashboard, "Extra Screen Time")
+    assert reward is not None
+
+    buttons = get_reward_buttons(hass, reward["eid"])
+    approve_button_eid = buttons["approve"]
+    assert approve_button_eid
+
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, approve_button_eid, unauthorized_context)
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+    assert reward_state.state == const.REWARD_STATE_REQUESTED
+
+
+async def test_kiosk_disabled_blocks_unauthorized_reward_disapprove_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Reward disapprove button should surface unauthorized failures."""
+    coordinator = scenario_full.coordinator
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    coordinator.users_data[assignee_id][const.DATA_USER_POINTS] = 100.0
+    await coordinator.async_refresh()
+
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    reward = find_reward(dashboard, "Extra Screen Time")
+    assert reward is not None
+
+    claim_button_eid = get_reward_buttons(hass, reward["eid"])["claim"]
+    assert claim_button_eid
+
+    with patch.object(
+        coordinator.notification_manager, "notify_assignee", new=AsyncMock()
+    ):
+        await _press_button(hass, claim_button_eid, assignee_context)
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+
+    disapprove_button_eid = reward_state.attributes.get(
+        const.ATTR_REWARD_DISAPPROVE_BUTTON_ENTITY_ID
+    )
+    assert disapprove_button_eid
+
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, disapprove_button_eid, unauthorized_context)
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+    assert reward_state.state == const.REWARD_STATE_REQUESTED
+
+
+async def test_kiosk_disabled_blocks_unauthorized_bonus_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Bonus button should surface unauthorized management failures."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    bonus = find_bonus(dashboard, "Extra Effort")
+    assert bonus is not None
+
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, bonus["eid"], unauthorized_context)
+
+
+async def test_kiosk_disabled_blocks_unauthorized_penalty_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Penalty button should surface unauthorized management failures."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    penalty = find_penalty(dashboard, "Missed Chore")
+    assert penalty is not None
+
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, penalty["eid"], unauthorized_context)
+
+
+async def test_kiosk_disabled_blocks_unauthorized_points_adjust_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Manual points adjust button should surface unauthorized failures."""
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    buttons = get_points_adjustment_buttons(
+        hass,
+        scenario_full.config_entry.entry_id,
+        assignee_id,
+    )
+    assert buttons
+
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+    with pytest.raises(HomeAssistantError):
+        await _press_button(hass, str(buttons[0]["eid"]), unauthorized_context)
 
 
 async def test_options_flow_saves_kiosk_mode_toggle(

--- a/tests/test_options_flow_dashboard_release_selection.py
+++ b/tests/test_options_flow_dashboard_release_selection.py
@@ -388,25 +388,26 @@ async def _ack_template_details_if_needed(
         == const.OPTIONS_FLOW_STEP_DASHBOARD_MISSING_DEPENDENCIES
     ):
         schema_fields = _schema_field_names(result["data_schema"])
-        if const.CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS not in schema_fields:
-            return await hass.config_entries.options.async_configure(
-                flow_id,
-                user_input={},
+        submit_input: dict[str, Any] = {}
+
+        if const.CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS in schema_fields:
+            placeholders = result.get("description_placeholders", {})
+            missing_required_markdown = str(
+                placeholders.get(
+                    const.PLACEHOLDER_DASHBOARD_MISSING_REQUIRED_DEPENDENCIES,
+                    "- None",
+                )
+            ).strip()
+            submit_input[const.CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS] = (
+                missing_required_markdown != "- None"
             )
 
-        placeholders = result.get("description_placeholders", {})
-        missing_required_markdown = str(
-            placeholders.get(
-                const.PLACEHOLDER_DASHBOARD_MISSING_REQUIRED_DEPENDENCIES,
-                "- None",
-            )
-        ).strip()
-        bypass_required = missing_required_markdown != "- None"
+        if const.CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK in schema_fields:
+            submit_input[const.CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK] = True
+
         result = await hass.config_entries.options.async_configure(
             flow_id,
-            user_input={
-                const.CFOF_DASHBOARD_INPUT_DEPENDENCY_BYPASS: bypass_required,
-            },
+            user_input=submit_input,
         )
 
     return result
@@ -2153,3 +2154,109 @@ async def test_dashboard_configure_validation_no_assignees_and_no_admin(
     assert result.get("errors") == {
         const.CFOP_ERROR_BASE: const.TRANS_KEY_CFOF_DASHBOARD_NO_ASSIGNEES_WITHOUT_ADMIN
     }
+
+
+@pytest.mark.asyncio
+async def test_dashboard_create_requires_ack_for_unlinked_selected_users_when_kiosk_disabled(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+) -> None:
+    """Dashboard review step requires acknowledgement for unlinked selected users."""
+    config_entry = scenario_minimal.config_entry
+    coordinator = config_entry.runtime_data
+    mock_create_dashboard = AsyncMock(return_value="kcd-chores")
+
+    zoe_id = next(
+        user_id
+        for user_id, user_data in coordinator.assignees_data.items()
+        if user_data.get(const.DATA_USER_NAME) == "Zoë"
+    )
+    coordinator.user_manager.update_user(
+        zoe_id,
+        {const.DATA_USER_HA_USER_ID: ""},
+        immediate_persist=True,
+    )
+
+    with (
+        patch(
+            "custom_components.choreops.helpers.dashboard_builder.async_dedupe_choreops_dashboards",
+            return_value={},
+        ),
+        patch(
+            "custom_components.choreops.helpers.dashboard_builder.create_choreops_dashboard",
+            mock_create_dashboard,
+        ),
+    ):
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        flow_id = result["flow_id"]
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                const.OPTIONS_FLOW_INPUT_MENU_SELECTION: const.OPTIONS_FLOW_DASHBOARD_GENERATOR
+            },
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                const.CFOF_DASHBOARD_INPUT_ACTION: const.DASHBOARD_ACTION_CREATE,
+                const.CFOF_DASHBOARD_INPUT_CHECK_CARDS: False,
+            },
+        )
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={const.CFOF_DASHBOARD_INPUT_NAME: "Chores"},
+        )
+        assert result.get("step_id") == const.OPTIONS_FLOW_STEP_DASHBOARD_CONFIGURE
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={
+                const.CFOF_DASHBOARD_SECTION_ASSIGNEE_VIEWS: {
+                    const.CFOF_DASHBOARD_INPUT_TEMPLATE_PROFILE: DEFAULT_ASSIGNEE_TEMPLATE_ID,
+                    const.CFOF_DASHBOARD_INPUT_ASSIGNEE_SELECTION: ["Zoë"],
+                },
+                const.CFOF_DASHBOARD_SECTION_ADMIN_VIEWS: {
+                    const.CFOF_DASHBOARD_INPUT_ADMIN_MODE: const.DASHBOARD_ADMIN_MODE_NONE,
+                },
+                const.CFOF_DASHBOARD_SECTION_ACCESS_SIDEBAR: {
+                    const.CFOF_DASHBOARD_INPUT_ICON: "mdi:clipboard-list",
+                    const.CFOF_DASHBOARD_INPUT_REQUIRE_ADMIN: False,
+                    const.CFOF_DASHBOARD_INPUT_SHOW_IN_SIDEBAR: True,
+                },
+            },
+        )
+
+        assert (
+            result.get("step_id")
+            == const.OPTIONS_FLOW_STEP_DASHBOARD_MISSING_DEPENDENCIES
+        )
+        assert const.CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK in _schema_field_names(
+            result["data_schema"]
+        )
+        assert "Zoë" in str(
+            result.get("description_placeholders", {}).get(
+                const.PLACEHOLDER_DASHBOARD_ACCESS_WARNING,
+                "",
+            )
+        )
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={},
+        )
+        assert (
+            result.get("step_id")
+            == const.OPTIONS_FLOW_STEP_DASHBOARD_MISSING_DEPENDENCIES
+        )
+        assert result.get("errors", {}).get(const.CFOP_ERROR_BASE) == (
+            const.TRANS_KEY_CFOF_DASHBOARD_ACCESS_WARNING_ACK_REQUIRED
+        )
+
+        result = await hass.config_entries.options.async_configure(
+            flow_id,
+            user_input={const.CFOF_DASHBOARD_INPUT_ACCESS_WARNING_ACK: True},
+        )
+
+    assert result.get("step_id") == const.OPTIONS_FLOW_STEP_DASHBOARD_GENERATOR
+    assert mock_create_dashboard.await_count == 1

--- a/tests/test_rotation_services.py
+++ b/tests/test_rotation_services.py
@@ -10,7 +10,9 @@ These services allow manual rotation control for special circumstances.
 
 from typing import Any
 
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import pytest
 
 from custom_components.choreops import const
@@ -24,7 +26,12 @@ from tests.helpers.constants import (
     SERVICE_FIELD_USER_ID,
 )
 from tests.helpers.setup import SetupResult, setup_from_yaml
-from tests.helpers.workflows import claim_chore, find_chore, get_dashboard_helper
+from tests.helpers.workflows import (
+    claim_chore,
+    find_chore,
+    get_chore_buttons,
+    get_dashboard_helper,
+)
 from tests.test_badge_helpers import get_assignee_by_name, get_chore_by_name
 
 # =============================================================================
@@ -418,8 +425,6 @@ async def test_open_rotation_cycle_allows_one_claim_then_blocks_others(
         "Dishes Rotation",
         context=Context(user_id=second_claimer_user_id),
     )
-    assert second_claim.state_before == second_claim.state_after
-    assert second_claim.global_state_before == second_claim.global_state_after
 
     second_chore = find_chore(
         get_dashboard_helper(hass, second_claimer_slug),
@@ -428,6 +433,23 @@ async def test_open_rotation_cycle_allows_one_claim_then_blocks_others(
     assert second_chore is not None
     second_sensor = hass.states.get(second_chore["eid"])
     assert second_sensor is not None
+    assert second_sensor.state == "completed_by_other"
+
+    second_claim_button_eid = get_chore_buttons(hass, second_chore["eid"])["claim"]
+    assert second_claim_button_eid
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {"entity_id": second_claim_button_eid},
+            blocking=True,
+            context=Context(user_id=second_claimer_user_id),
+        )
+
+    second_sensor = hass.states.get(second_chore["eid"])
+    assert second_sensor is not None
+    assert second_sensor.state == "completed_by_other"
     assert second_sensor.attributes.get("can_claim") is False
 
 

--- a/tests/test_workflow_chores.py
+++ b/tests/test_workflow_chores.py
@@ -949,19 +949,23 @@ class TestSharedAllChores:
         chore_name = "Shared All Pending Hold"
         chore_id = scenario_shared.chore_ids[chore_name]
 
-        # Configure strict missed lock and past due
+        # Configure strict missed lock and keep the first claim valid.
         chore_info = coordinator.chores_data.get(chore_id, {})
         chore_info[const.DATA_CHORE_OVERDUE_HANDLING_TYPE] = (
             const.OVERDUE_HANDLING_AT_DUE_DATE_MARK_MISSED_AND_LOCK
         )
         chore_info[const.DATA_CHORE_DUE_DATE] = (
-            dt_now_utc() - timedelta(minutes=5)
+            dt_now_utc() + timedelta(days=2)
         ).isoformat()
 
         # Zoë claims first to ensure shared_all global remains in-part while Max hits missed
         assignee1_context = Context(user_id=mock_hass_users["assignee1"].id)
         claim_result = await claim_chore(hass, "zoe", chore_name, assignee1_context)
         assert claim_result.success, f"Claim failed: {claim_result.error}"
+
+        chore_info[const.DATA_CHORE_DUE_DATE] = (
+            dt_now_utc() - timedelta(minutes=5)
+        ).isoformat()
 
         await coordinator.chore_manager._on_periodic_update(now_utc=dt_now_utc())
         await hass.async_block_till_done()

--- a/utils/bundle_codebase.py
+++ b/utils/bundle_codebase.py
@@ -1,0 +1,92 @@
+# ruff: noqa: INP001
+from datetime import date
+import os
+from pathlib import Path
+
+# Get the ISO 8601 formatted date (e.g., "2026-03-20")
+CURRENT_DATE = date.today().isoformat()
+
+# Dynamically find paths based on where this script lives
+SCRIPT_DIR = Path(__file__).resolve().parent  # This is always choreops/utils/
+WORKSPACE_ROOT = (SCRIPT_DIR / ".." / "..").resolve()  # This is the workspace root
+
+
+def bundle_for_gem(
+    source_folder_name: str, output_filename: str, allowed_extensions: tuple[str, ...]
+) -> None:
+    """Walks a directory and concatenates files into a single LLM-friendly document."""
+    source_dir = WORKSPACE_ROOT / source_folder_name
+
+    # Check if the repo actually exists in the workspace
+    if not source_dir.exists():
+        print(f"⚠️ Warning: '{source_folder_name}' not found in workspace. Skipping.")  # noqa: T201
+        return
+
+    # Safely split the filename to inject the ISO date (e.g., name_2026-03-20.txt)
+    out_path_obj = Path(output_filename)
+    dated_filename = f"{out_path_obj.stem}_{CURRENT_DATE}{out_path_obj.suffix}"
+
+    # Target the centralized choreops/utils/exports/ folder
+    export_dir = SCRIPT_DIR / "exports"
+    export_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = export_dir / dated_filename
+
+    print(  # noqa: T201
+        f"📦 Bundling '{source_folder_name}' into 'choreops/utils/exports/{dated_filename}'..."
+    )
+
+    with output_path.open("w", encoding="utf-8") as outfile:
+        for root_str, dirs, files in os.walk(source_dir):
+            root = Path(root_str)
+
+            # Skip hidden dirs, Python caches, and our new central 'exports' directory!
+            dirs[:] = [
+                d
+                for d in dirs
+                if not d.startswith(".") and d not in ("__pycache__", "exports")
+            ]
+
+            for file in files:
+                if file.endswith(allowed_extensions):
+                    file_path = root / file
+                    rel_path = file_path.relative_to(WORKSPACE_ROOT)
+
+                    outfile.write(f"\n\n{'=' * 80}\n")
+                    outfile.write(f"FILE PATH: {rel_path}\n")
+                    outfile.write(f"{'=' * 80}\n\n")
+
+                    try:
+                        with file_path.open(encoding="utf-8") as infile:
+                            outfile.write(infile.read())
+                    except Exception as e:
+                        outfile.write(f"[Error reading file: {e}]\n")
+                        print(f"❌ Skipped {rel_path} due to read error.")  # noqa: T201
+
+
+# --- EXECUTION ---
+if __name__ == "__main__":
+    print(f"🚀 Starting Knowledge Base Bundler in Workspace: {WORKSPACE_ROOT}\n")  # noqa: T201
+
+    # 1. Bundle the Core Integration
+    bundle_for_gem(
+        source_folder_name="choreops",
+        output_filename="gem_choreops_backend.txt",
+        allowed_extensions=(".py", ".yaml", ".json"),
+    )
+
+    # 2. Bundle the Dashboards
+    bundle_for_gem(
+        source_folder_name="choreops-dashboards",
+        output_filename="gem_choreops_dashboards.txt",
+        allowed_extensions=(".yaml", ".js", ".json", ".html"),
+    )
+
+    # 3. Bundle the Wiki
+    bundle_for_gem(
+        source_folder_name="choreops-wiki",
+        output_filename="gem_choreops_wiki.txt",
+        allowed_extensions=(".md",),
+    )
+
+    print("\n✅ Bundling complete! Check the 'choreops/utils/exports/' folder.")  # noqa: T201


### PR DESCRIPTION
## Summary

- Fix action errors so users see helpful feedback in the UI
- Add earlier warnings for unlinked users when kiosk mode is off
- Improve dashboard review warnings for shared-device setups
- Restore the translation sync workflow
- Add a support utility for exporting the codebase to text bundles

## What users will notice

- Buttons that fail now surface clearer feedback instead of failing silently
- Shared-tablet and wall-dashboard setups get earlier warnings when user linking or kiosk settings need attention
- Dashboard generation now warns before applying changes that may cause claim or redeem issues
- Translation sync is working again for branch testing and review

## Additional updates

- Added regression coverage for surfaced action failures and warning flows
- Updated quick-start, access-control, and FAQ guidance
- Added a utility for support tooling and ignored generated export files

## Validation

- Ran `python -m pytest tests/ -v --tb=line`
- Verified targeted regression tests during development
- Verified translation sync end-to-end, including l10n branch updates and PR creation
- Verified translated files on the branch and confirmed testing looked good

Closes #68
