### PR TITLE
Fix recurring chore due-date validation for 1.0.6

### DIFF
--- a/custom_components/choreops/data_builders.py
+++ b/custom_components/choreops/data_builders.py
@@ -1288,12 +1288,35 @@ def validate_chore_data(
         2. Name not duplicate
         3. At least one assignee assigned (create only)
         4. Points >= 0 (if provided)
-        5. Due date not in past (if provided)
+        5. Effective due dates not in past and parseable
         6. DAILY_MULTI + reset type combination
         7. Overdue + reset type combination
-        8. DAILY_MULTI requires due_date (unless INDEPENDENT multi-assignee)
-        9. AT_DUE_DATE_* reset types require due_date
+        8. DAILY_MULTI requires due dates
+        9. AT_DUE_DATE_* reset types require due dates
     """
+
+    def _uses_chore_level_due_date(completion_criteria: str) -> bool:
+        """Return whether this chore mode stores a single chore-level due date."""
+        return completion_criteria in (
+            const.COMPLETION_CRITERIA_SHARED,
+            const.COMPLETION_CRITERIA_SHARED_FIRST,
+            const.COMPLETION_CRITERIA_ROTATION_SIMPLE,
+            const.COMPLETION_CRITERIA_ROTATION_SMART,
+        )
+
+    def _validate_due_date_value(raw_value: Any) -> str | None:
+        """Validate one due date value and return a translation key on error."""
+        parsed = dt_parse(
+            raw_value,
+            default_tzinfo=const.DEFAULT_TIME_ZONE,
+            return_type=const.HELPER_RETURN_DATETIME_UTC,
+        )
+        if not parsed or not isinstance(parsed, datetime.datetime):
+            return const.TRANS_KEY_CFOF_INVALID_DUE_DATE
+        if parsed < dt_now_utc():
+            return const.TRANS_KEY_CFOF_DUE_DATE_IN_PAST
+        return None
+
     errors: dict[str, str] = {}
 
     # === 1. Name validation ===
@@ -1341,28 +1364,6 @@ def validate_chore_data(
             errors[const.CFOP_ERROR_CHORE_POINTS] = const.TRANS_KEY_CFOF_INVALID_POINTS
             return errors
 
-    # === 5. Due date not in past ===
-    due_date_raw = data.get(const.DATA_CHORE_DUE_DATE)
-    due_dt: datetime.datetime | None = None
-    if due_date_raw:
-        try:
-            parsed = dt_parse(
-                due_date_raw,
-                default_tzinfo=const.DEFAULT_TIME_ZONE,
-                return_type=const.HELPER_RETURN_DATETIME_UTC,
-            )
-            # Type guard: ensure we got a datetime
-            if parsed and isinstance(parsed, datetime.datetime):
-                due_dt = parsed
-            if due_dt and due_dt < dt_now_utc():
-                errors[const.CFOP_ERROR_DUE_DATE] = (
-                    const.TRANS_KEY_CFOF_DUE_DATE_IN_PAST
-                )
-                return errors
-        except (ValueError, TypeError, AttributeError):
-            errors[const.CFOP_ERROR_DUE_DATE] = const.TRANS_KEY_CFOF_INVALID_DUE_DATE
-            return errors
-
     # === Extract config for combination validations ===
     recurring_frequency = data.get(
         const.DATA_CHORE_RECURRING_FREQUENCY, const.FREQUENCY_NONE
@@ -1376,6 +1377,28 @@ def validate_chore_data(
     completion_criteria = data.get(
         const.DATA_CHORE_COMPLETION_CRITERIA, const.COMPLETION_CRITERIA_INDEPENDENT
     )
+    due_date_raw = data.get(const.DATA_CHORE_DUE_DATE)
+    per_assignee_due_dates = _normalize_dict_field(
+        data.get(const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES, {})
+    )
+
+    # === 5. Effective due dates must be valid and not in the past ===
+    if _uses_chore_level_due_date(completion_criteria):
+        if due_date_raw:
+            if due_date_error := _validate_due_date_value(due_date_raw):
+                errors[const.CFOP_ERROR_DUE_DATE] = due_date_error
+                return errors
+        missing_required_due_date = not due_date_raw
+    else:
+        missing_required_due_date = False
+        for assignee_id in assigned_assignees:
+            assignee_due_date = per_assignee_due_dates.get(str(assignee_id))
+            if assignee_due_date in (None, const.SENTINEL_EMPTY):
+                missing_required_due_date = True
+                continue
+            if due_date_error := _validate_due_date_value(assignee_due_date):
+                errors[const.CFOP_ERROR_DUE_DATE] = due_date_error
+                return errors
 
     # === 6. DAILY_MULTI + reset type validation ===
     if recurring_frequency == const.FREQUENCY_DAILY_MULTI:
@@ -1402,26 +1425,26 @@ def validate_chore_data(
             )
             return errors
 
-    # === 8. DAILY_MULTI requires due_date ===
-    if recurring_frequency == const.FREQUENCY_DAILY_MULTI and not due_date_raw:
+    # === 8. DAILY_MULTI requires due dates ===
+    if recurring_frequency == const.FREQUENCY_DAILY_MULTI and missing_required_due_date:
         errors[const.CFOP_ERROR_DAILY_MULTI_DUE_DATE] = (
             const.TRANS_KEY_CFOF_ERROR_DAILY_MULTI_DUE_DATE_REQUIRED
         )
         return errors
 
-    # === 9. AT_DUE_DATE_* reset types require due_date ===
+    # === 9. AT_DUE_DATE_* reset types require due dates ===
     if approval_reset in (
         const.APPROVAL_RESET_AT_DUE_DATE_ONCE,
         const.APPROVAL_RESET_AT_DUE_DATE_MULTI,
     ):
-        if not due_date_raw:
+        if missing_required_due_date:
             errors[const.CFOP_ERROR_AT_DUE_DATE_RESET_REQUIRES_DUE_DATE] = (
                 const.TRANS_KEY_CFOF_ERROR_AT_DUE_DATE_RESET_REQUIRES_DUE_DATE
             )
             return errors
 
-    # === 10. Only NONE and DAILY may omit due_date ===
-    if not due_date_raw and recurring_frequency not in (
+    # === 10. Only NONE and DAILY may omit due dates ===
+    if missing_required_due_date and recurring_frequency not in (
         const.FREQUENCY_NONE,
         const.FREQUENCY_DAILY,
     ):
@@ -1448,7 +1471,7 @@ def validate_chore_data(
         if (
             completion_criteria not in rotation_criteria
             or approval_reset != const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
-            or not due_date_raw
+            or missing_required_due_date
         ):
             errors[const.CFOP_ERROR_OVERDUE_RESET_COMBO] = (
                 const.TRANS_KEY_CFOF_ERROR_ALLOW_STEAL_INCOMPATIBLE

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -1194,6 +1194,32 @@ def validate_chores_inputs(
     if due_date_str:
         data_dict[const.DATA_CHORE_DUE_DATE] = due_date_str
 
+    if (
+        data_dict[const.DATA_CHORE_COMPLETION_CRITERIA]
+        == const.COMPLETION_CRITERIA_INDEPENDENT
+    ):
+        if clear_due_date:
+            data_dict[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = dict.fromkeys(
+                assigned_user_ids
+            )
+            data_dict.pop(const.DATA_CHORE_DUE_DATE, None)
+        elif due_date_str:
+            data_dict[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = dict.fromkeys(
+                assigned_user_ids, due_date_str
+            )
+            data_dict.pop(const.DATA_CHORE_DUE_DATE, None)
+        elif existing_chore is not None:
+            existing_per_assignee_due_dates = existing_chore.get(
+                const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
+                {},
+            )
+            if isinstance(existing_per_assignee_due_dates, dict):
+                data_dict[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {
+                    assignee_id: existing_per_assignee_due_dates.get(assignee_id)
+                    for assignee_id in assigned_user_ids
+                }
+                data_dict.pop(const.DATA_CHORE_DUE_DATE, None)
+
     # Include points if provided
     if const.CFOF_CHORES_INPUT_DEFAULT_POINTS in user_input:
         data_dict[const.DATA_CHORE_DEFAULT_POINTS] = user_input[

--- a/custom_components/choreops/manifest.json
+++ b/custom_components/choreops/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ccpk1/choreops/issues",
   "quality_scale": "platinum",
   "requirements": ["python-dateutil>=2.9.0"],
-  "version": "1.0.5"
+  "version": "1.0.6"
 }

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -1948,23 +1948,22 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                                 const.TRANS_KEY_CFOF_INVALID_DUE_DATE
                             )
 
-            # Validate: If ALL dates are cleared, only none/daily may remain date-less
-            if not errors and not per_assignee_due_dates:
-                stored_chore = coordinator.chores_data.get(internal_id, {})
-                recurring_frequency = stored_chore.get(
-                    const.DATA_CHORE_RECURRING_FREQUENCY, const.FREQUENCY_NONE
+            if not errors:
+                validation_data = dict(stored_chore)
+                validation_data[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = (
+                    per_assignee_due_dates
                 )
-                if recurring_frequency not in (
-                    const.FREQUENCY_NONE,
-                    const.FREQUENCY_DAILY,
-                ):
-                    errors[const.CFOP_ERROR_BASE] = (
-                        const.TRANS_KEY_CFOF_DATE_REQUIRED_FOR_FREQUENCY
-                    )
-                    const.LOGGER.debug(
-                        "Cannot clear all dates: frequency '%s' requires due dates",
-                        recurring_frequency,
-                    )
+                validation_data[const.DATA_CHORE_DUE_DATE] = None
+
+                validation_errors = db.validate_chore_data(
+                    validation_data,
+                    coordinator.chores_data,
+                    is_update=True,
+                    current_chore_id=str(internal_id),
+                )
+                if validation_errors:
+                    _error_field, error_key = next(iter(validation_errors.items()))
+                    errors[const.CFOP_ERROR_BASE] = error_key
 
             if not errors:
                 # Update the chore's per_assignee_due_dates using Manager CRUD
@@ -2235,15 +2234,7 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                                 return_type=const.HELPER_RETURN_DATETIME_UTC,
                             )
                             if utc_dt and isinstance(utc_dt, datetime):
-                                # Validate that due date is not in the past
-                                if utc_dt < dt_now_utc():
-                                    errors[const.CFOP_ERROR_BASE] = (
-                                        const.TRANS_KEY_CFOF_DUE_DATE_IN_PAST
-                                    )
-                                else:
-                                    per_assignee_due_dates[assignee_id] = (
-                                        utc_dt.isoformat()
-                                    )
+                                per_assignee_due_dates[assignee_id] = utc_dt.isoformat()
                         except (ValueError, TypeError):
                             errors[const.CFOP_ERROR_BASE] = (
                                 const.TRANS_KEY_CFOF_INVALID_DUE_DATE
@@ -2291,6 +2282,17 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 if is_daily_multi:
                     chore_data[const.DATA_CHORE_DAILY_MULTI_TIMES] = None
 
+                validation_errors = db.validate_chore_data(
+                    chore_data,
+                    coordinator.chores_data,
+                    is_update=True,
+                    current_chore_id=str(internal_id),
+                )
+                if validation_errors:
+                    _error_field, error_key = next(iter(validation_errors.items()))
+                    errors[const.CFOP_ERROR_BASE] = error_key
+
+            if not errors:
                 # Use Manager-owned CRUD (handles badge recalc and orphan cleanup)
                 coordinator.chore_manager.update_chore(
                     str(internal_id), chore_data, immediate_persist=True

--- a/custom_components/choreops/services.py
+++ b/custom_components/choreops/services.py
@@ -216,6 +216,81 @@ def _validate_non_zero_integer_amount(value: Any) -> int:
     return amount
 
 
+def _service_uses_chore_level_due_date(chore_data: dict[str, Any]) -> bool:
+    """Return whether the provided chore data uses a shared chore-level due date."""
+    completion_criteria = chore_data.get(
+        const.DATA_CHORE_COMPLETION_CRITERIA,
+        const.COMPLETION_CRITERIA_INDEPENDENT,
+    )
+    return completion_criteria in (
+        const.COMPLETION_CRITERIA_SHARED,
+        const.COMPLETION_CRITERIA_SHARED_FIRST,
+        const.COMPLETION_CRITERIA_ROTATION_SIMPLE,
+        const.COMPLETION_CRITERIA_ROTATION_SMART,
+    )
+
+
+def _normalize_service_due_date_input(due_date_input: Any) -> str | None:
+    """Normalize a service due date payload to UTC ISO format for validation."""
+    parsed_due_date = dt_parse(
+        due_date_input,
+        default_tzinfo=const.DEFAULT_TIME_ZONE,
+        return_type=const.HELPER_RETURN_DATETIME_UTC,
+    )
+    if not parsed_due_date or not isinstance(parsed_due_date, datetime):
+        return None
+    return parsed_due_date.isoformat()
+
+
+def _build_service_chore_validation_data(
+    data_input: dict[str, Any],
+    assigned_assignee_ids: list[str],
+    *,
+    due_date_iso: str | None,
+    existing_chore: "ChoreData | dict[str, Any] | None" = None,
+) -> dict[str, Any]:
+    """Build normalized chore data for shared validation.
+
+    Services update partial payloads, so validation must merge the effective
+    due-date state from storage before calling the shared validator.
+    """
+    validation_data = dict(data_input)
+
+    if const.DATA_CHORE_ASSIGNED_USER_IDS not in validation_data:
+        validation_data[const.DATA_CHORE_ASSIGNED_USER_IDS] = assigned_assignee_ids
+
+    if existing_chore is not None:
+        for key in (
+            const.DATA_CHORE_RECURRING_FREQUENCY,
+            const.DATA_CHORE_APPROVAL_RESET_TYPE,
+            const.DATA_CHORE_OVERDUE_HANDLING_TYPE,
+            const.DATA_CHORE_COMPLETION_CRITERIA,
+        ):
+            if key not in validation_data:
+                validation_data[key] = existing_chore.get(key)
+
+    if _service_uses_chore_level_due_date(validation_data):
+        if due_date_iso is not None:
+            validation_data[const.DATA_CHORE_DUE_DATE] = due_date_iso
+        elif existing_chore is not None:
+            existing_due_date = existing_chore.get(const.DATA_CHORE_DUE_DATE)
+            if existing_due_date is not None:
+                validation_data[const.DATA_CHORE_DUE_DATE] = existing_due_date
+        return validation_data
+
+    if due_date_iso is not None:
+        validation_data[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = dict.fromkeys(
+            assigned_assignee_ids, due_date_iso
+        )
+    elif existing_chore is not None:
+        validation_data[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = dict(
+            existing_chore.get(const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES, {})
+        )
+
+    validation_data.pop(const.DATA_CHORE_DUE_DATE, None)
+    return validation_data
+
+
 # --- Service Schemas ---
 
 # Common schema base patterns for DRY principle
@@ -862,14 +937,17 @@ def async_setup_services(hass: HomeAssistant):
 
         # Extract due_date for special handling (not passed to build_chore)
         due_date_input = call.data.get(const.SERVICE_FIELD_CHORE_CRUD_DUE_DATE)
+        due_date_iso = _normalize_service_due_date_input(due_date_input)
 
-        # Include due_date in validation if provided
-        if due_date_input:
-            data_input[const.DATA_CHORE_DUE_DATE] = due_date_input
+        validation_data = _build_service_chore_validation_data(
+            data_input,
+            assignee_ids,
+            due_date_iso=due_date_iso,
+        )
 
         # Validate using shared validation (single source of truth)
         validation_errors = db.validate_chore_data(
-            data_input,
+            validation_data,
             coordinator.chores_data,
             is_update=False,
             current_chore_id=None,
@@ -889,7 +967,7 @@ def async_setup_services(hass: HomeAssistant):
 
             # Handle due_date via chore_manager (respects SHARED/INDEPENDENT)
             # Note: set_due_date handles its own persist
-            if due_date_input:
+            if due_date_input is not None:
                 await coordinator.chore_manager.set_due_date(
                     internal_id, due_date_input, assignee_id=None
                 )
@@ -1035,27 +1113,21 @@ def async_setup_services(hass: HomeAssistant):
 
         # Extract due_date for special handling
         due_date_input = call.data.get(const.SERVICE_FIELD_CHORE_CRUD_DUE_DATE)
+        due_date_iso = _normalize_service_due_date_input(due_date_input)
 
-        # Include due_date in validation if provided
-        if due_date_input is not None:
-            data_input[const.DATA_CHORE_DUE_DATE] = due_date_input
-
-        # For update: merge with existing data for accurate validation
-        # (assigned_user_ids may not be in data_input if not being updated)
-        validation_data = dict(data_input)
-        if const.DATA_CHORE_ASSIGNED_USER_IDS not in validation_data:
-            validation_data[const.DATA_CHORE_ASSIGNED_USER_IDS] = existing_chore.get(
-                const.DATA_CHORE_ASSIGNED_USER_IDS, []
+        assigned_assignee_ids = list(
+            data_input.get(
+                const.DATA_CHORE_ASSIGNED_USER_IDS,
+                existing_chore.get(const.DATA_CHORE_ASSIGNED_USER_IDS, []),
             )
-        # Similarly for other fields needed for combination validation
-        for key in (
-            const.DATA_CHORE_RECURRING_FREQUENCY,
-            const.DATA_CHORE_APPROVAL_RESET_TYPE,
-            const.DATA_CHORE_OVERDUE_HANDLING_TYPE,
-            const.DATA_CHORE_COMPLETION_CRITERIA,
-        ):
-            if key not in validation_data:
-                validation_data[key] = existing_chore.get(key)
+        )
+
+        validation_data = _build_service_chore_validation_data(
+            data_input,
+            assigned_assignee_ids,
+            due_date_iso=due_date_iso,
+            existing_chore=existing_chore,
+        )
 
         # Validate using shared validation (single source of truth)
         validation_errors = db.validate_chore_data(
@@ -1533,7 +1605,30 @@ def async_setup_services(hass: HomeAssistant):
                 "ChoreData", coordinator.chores_data.get(chore_id, {})
             )
             validation_data = dict(existing_chore_info)
-            validation_data[const.DATA_CHORE_DUE_DATE] = None
+
+            if ChoreEngine.uses_chore_level_due_date(existing_chore_info):
+                validation_data[const.DATA_CHORE_DUE_DATE] = None
+            else:
+                per_assignee_due_dates = dict(
+                    existing_chore_info.get(
+                        const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
+                        {},
+                    )
+                )
+                if assignee_id:
+                    per_assignee_due_dates[assignee_id] = None
+                else:
+                    for assigned_user_id in existing_chore_info.get(
+                        const.DATA_CHORE_ASSIGNED_USER_IDS,
+                        [],
+                    ):
+                        per_assignee_due_dates[assigned_user_id] = None
+
+                validation_data[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = (
+                    per_assignee_due_dates
+                )
+                validation_data[const.DATA_CHORE_DUE_DATE] = None
+
             validation_errors = db.validate_chore_data(
                 validation_data,
                 coordinator.chores_data,

--- a/tests/test_chore_crud_services.py
+++ b/tests/test_chore_crud_services.py
@@ -19,6 +19,7 @@ See tests/AGENT_TEST_CREATION_INSTRUCTIONS.md for patterns used.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +27,7 @@ from homeassistant.exceptions import HomeAssistantError
 import pytest
 import voluptuous as vol
 
+from custom_components.choreops import const
 from tests.helpers import (
     DOMAIN,
     SERVICE_CREATE_CHORE,
@@ -346,6 +348,53 @@ class TestCreateChoreEndToEnd:
         assert chore_sensor.attributes["completion_criteria"] == "shared_first"
         assert chore_sensor.attributes["recurring_frequency"] == "weekly"
 
+    @pytest.mark.asyncio
+    async def test_create_independent_weekly_uses_per_assignee_due_dates_only(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Test service create stores independent recurring due dates per assignee only."""
+        new_due_date = datetime(2099, 1, 1, 9, 0, tzinfo=UTC)
+
+        with patch.object(scenario_full.coordinator, "_persist", new=MagicMock()):
+            response = await hass.services.async_call(
+                DOMAIN,
+                SERVICE_CREATE_CHORE,
+                {
+                    "name": "Independent Weekly Service Test",
+                    "assigned_user_names": ["Zoë", "Max!"],
+                    "points": 25,
+                    "frequency": "weekly",
+                    "completion_criteria": "independent",
+                    "due_date": new_due_date,
+                },
+                blocking=True,
+                return_response=True,
+            )
+
+        assert response is not None
+        chore_id = response.get("id")
+        assert isinstance(chore_id, str)
+
+        created_chore = scenario_full.coordinator.chores_data[chore_id]
+        assert created_chore.get(const.DATA_CHORE_DUE_DATE) is None
+
+        per_assignee_due_dates = created_chore.get(
+            const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
+            {},
+        )
+        assert set(per_assignee_due_dates) == {
+            scenario_full.assignee_ids["Zoë"],
+            scenario_full.assignee_ids["Max!"],
+        }
+
+        expected_due_date = new_due_date.isoformat()
+        assert all(
+            due_date == expected_due_date
+            for due_date in per_assignee_due_dates.values()
+        )
+
 
 # ============================================================================
 # UPDATE CHORE - SCHEMA VALIDATION TESTS
@@ -427,6 +476,40 @@ class TestUpdateChoreSchemaValidation:
         assert response is not None
         assert "id" in response
 
+    @pytest.mark.asyncio
+    async def test_update_weekly_independent_without_due_date_preserves_existing_dates(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Test updating a weekly independent chore succeeds without resending due_date."""
+        chore_id = scenario_full.chore_ids["Ørgänize Bookshelf"]
+        existing_chore = scenario_full.coordinator.chores_data[chore_id]
+        existing_per_assignee_due_dates = dict(
+            existing_chore.get(const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES, {})
+        )
+
+        with patch.object(scenario_full.coordinator, "_persist", new=MagicMock()):
+            response = await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_CHORE,
+                {
+                    "id": chore_id,
+                    "points": 42,
+                },
+                blocking=True,
+                return_response=True,
+            )
+
+        assert response is not None
+        updated_chore = scenario_full.coordinator.chores_data[chore_id]
+        assert updated_chore[const.DATA_CHORE_DEFAULT_POINTS] == 42
+        assert updated_chore.get(const.DATA_CHORE_DUE_DATE) is None
+        assert (
+            updated_chore.get(const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES, {})
+            == existing_per_assignee_due_dates
+        )
+
 
 # ============================================================================
 # UPDATE CHORE - E2E TESTS
@@ -470,6 +553,44 @@ class TestUpdateChoreEndToEnd:
         chore_sensor = hass.states.get(chore["eid"])
         assert chore_sensor is not None
         assert chore_sensor.attributes["default_points"] == 888
+
+    @pytest.mark.asyncio
+    async def test_update_independent_weekly_due_date_applies_to_all_assignees(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Test update service applies one independent due date to every assigned assignee."""
+        chore_id = scenario_full.chore_ids["Ørgänize Bookshelf"]
+        new_due_date = datetime(2099, 2, 1, 10, 30, tzinfo=UTC)
+
+        with patch.object(scenario_full.coordinator, "_persist", new=MagicMock()):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_CHORE,
+                {
+                    "id": chore_id,
+                    "due_date": new_due_date,
+                },
+                blocking=True,
+                return_response=True,
+            )
+
+        updated_chore = scenario_full.coordinator.chores_data[chore_id]
+        assert updated_chore.get(const.DATA_CHORE_DUE_DATE) is None
+
+        per_assignee_due_dates = updated_chore.get(
+            const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
+            {},
+        )
+        assert set(per_assignee_due_dates) == {
+            scenario_full.assignee_ids["Zoë"],
+            scenario_full.assignee_ids["Lila"],
+        }
+        assert all(
+            due_date == new_due_date.isoformat()
+            for due_date in per_assignee_due_dates.values()
+        )
 
 
 # ============================================================================

--- a/tests/test_frequency_validation.py
+++ b/tests/test_frequency_validation.py
@@ -21,6 +21,7 @@ from homeassistant.core import HomeAssistant
 import pytest
 
 from custom_components.choreops import const
+from custom_components.choreops.data_builders import validate_chore_data
 from custom_components.choreops.helpers import flow_helpers
 from custom_components.choreops.utils.dt_utils import parse_daily_multi_times
 from tests.helpers import (
@@ -235,6 +236,57 @@ class TestDailyMultiValidation:
         """V-12: Empty times string is rejected."""
         errors = flow_helpers.validate_daily_multi_times("")
         assert errors != {}
+
+
+class TestEffectiveDueDateValidation:
+    """Tests for shared effective due-date validation across chore modes."""
+
+    def test_independent_weekly_missing_assignee_due_date_rejected(self) -> None:
+        """Independent recurring chores require a due date for every assigned assignee."""
+        errors = validate_chore_data(
+            {
+                const.DATA_CHORE_NAME: "Validator Weekly Missing",
+                const.DATA_CHORE_ASSIGNED_USER_IDS: ["assignee-1", "assignee-2"],
+                const.DATA_CHORE_RECURRING_FREQUENCY: const.FREQUENCY_WEEKLY,
+                const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_INDEPENDENT,
+                const.DATA_CHORE_APPROVAL_RESET_TYPE: const.DEFAULT_APPROVAL_RESET_TYPE,
+                const.DATA_CHORE_OVERDUE_HANDLING_TYPE: const.DEFAULT_OVERDUE_HANDLING_TYPE,
+                const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES: {
+                    "assignee-1": "2099-01-01T09:00:00+00:00",
+                    "assignee-2": None,
+                },
+            },
+            is_update=True,
+            current_chore_id="validator-chore",
+        )
+
+        assert errors == {
+            const.CFOP_ERROR_DUE_DATE: const.TRANS_KEY_CFOF_DATE_REQUIRED_FOR_FREQUENCY
+        }
+
+    def test_independent_assignee_past_due_date_rejected(self) -> None:
+        """Independent per-assignee due dates cannot be in the past."""
+        past_due_date = datetime(2024, 1, 1, 9, 0, tzinfo=UTC).isoformat()
+
+        errors = validate_chore_data(
+            {
+                const.DATA_CHORE_NAME: "Validator Past Due",
+                const.DATA_CHORE_ASSIGNED_USER_IDS: ["assignee-1"],
+                const.DATA_CHORE_RECURRING_FREQUENCY: const.FREQUENCY_DAILY,
+                const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_INDEPENDENT,
+                const.DATA_CHORE_APPROVAL_RESET_TYPE: const.DEFAULT_APPROVAL_RESET_TYPE,
+                const.DATA_CHORE_OVERDUE_HANDLING_TYPE: const.DEFAULT_OVERDUE_HANDLING_TYPE,
+                const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES: {
+                    "assignee-1": past_due_date,
+                },
+            },
+            is_update=True,
+            current_chore_id="validator-chore",
+        )
+
+        assert errors == {
+            const.CFOP_ERROR_DUE_DATE: const.TRANS_KEY_CFOF_DUE_DATE_IN_PAST
+        }
 
 
 # =============================================================================

--- a/tests/test_options_flow_per_kid_helper.py
+++ b/tests/test_options_flow_per_kid_helper.py
@@ -737,6 +737,57 @@ class TestPerAssigneeHelperEdit:
         assert len(date_values) == 2
         assert date_values[0] != date_values[1], "Assignees should have different dates"
 
+    async def test_pkh09b_edit_independent_weekly_rejects_missing_assignee_date(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Weekly independent helper rejects merged per-assignee dates with blanks."""
+        config_entry = scenario_full.config_entry
+        coordinator = scenario_full.coordinator
+
+        chore_name = "Ørgänize Bookshelf"
+        chore_id = scenario_full.chore_ids[chore_name]
+        chore_data = coordinator.chores_data[chore_id]
+        assigned_assignee_ids = chore_data.get(DATA_CHORE_ASSIGNED_USER_IDS, [])
+        assigned_assignees = [
+            coordinator.assignees_data[assignee_id]["name"]
+            for assignee_id in assigned_assignee_ids
+        ]
+
+        result = await navigate_to_edit_chore(hass, config_entry.entry_id, chore_name)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                CFOF_CHORES_INPUT_NAME: chore_name,
+                CFOF_CHORES_INPUT_DEFAULT_POINTS: 18.0,
+                CFOF_CHORES_INPUT_ICON: "mdi:bookshelf",
+                CFOF_CHORES_INPUT_DESCRIPTION: "",
+                CFOF_CHORES_INPUT_ASSIGNED_USER_IDS: assigned_assignees,
+                CFOF_CHORES_INPUT_RECURRING_FREQUENCY: "weekly",
+                CFOF_CHORES_INPUT_COMPLETION_CRITERIA: COMPLETION_CRITERIA_INDEPENDENT,
+            },
+        )
+
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_EDIT_CHORE_PER_USER_DETAILS
+
+        per_assignee_input: dict[str, Any] = {
+            f"applicable_days_{assigned_assignees[0]}": ["sat", "sun"],
+            f"applicable_days_{assigned_assignees[1]}": ["sat", "sun"],
+            f"clear_due_date_{assigned_assignees[0]}": True,
+        }
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input=per_assignee_input,
+        )
+
+        assert result.get("step_id") == OPTIONS_FLOW_STEP_EDIT_CHORE_PER_USER_DETAILS
+        assert result.get("errors") == {
+            const.CFOP_ERROR_BASE: const.TRANS_KEY_CFOF_DATE_REQUIRED_FOR_FREQUENCY
+        }
+
     async def test_pkh10_edit_independent_different_days_per_assignee(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary

- Fix recurring chore service validation when effective due dates are stored in the existing chore state instead of the incoming payload.
- Reuse the shared chore validator across CRUD services and per-assignee helper flow paths.
- Bump the integration manifest version to `1.0.6` as the first change set for that release.

## Linked issue

- Closes #73

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [x] Correct release-note label is applied for `.github/release.yml` categorization
- [x] Excluded triage or status labels have been removed before merge
- [x] PR title is suitable for generated release notes

## Change type

- [x] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Integration logic/state
- [ ] Dashboard/template behavior
- [x] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/ -v --tb=line` (or targeted suite with rationale)

Validation details:
- `./utils/quick_lint.sh --fix`
- Full pytest coverage run in four 25% slices per request:
  - quarter 1: 444 passed
  - quarter 2: 442 passed, 2 skipped
  - quarter 3: 442 passed, 2 skipped
  - quarter 4: 441 passed

## Documentation impact

- [x] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

## Release notes

- [ ] No release notes needed
- [x] Release notes needed (summarize user-visible changes below)

- Release note summary:
  - Fixed `choreops.update_chore` and related due-date edit paths so recurring chores validate against their effective stored due dates, including independent chores that store dates per assignee.

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)
