### PR TITLE
fix: render custom interval fields in chore schedule form

### DIFF
--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -935,7 +935,7 @@ def build_chore_schema(
         ): selector.BooleanSelector(),
         vol.Optional(
             const.CFOF_CHORES_INPUT_CUSTOM_INTERVAL,
-            default=default.get(const.CFOF_CHORES_INPUT_CUSTOM_INTERVAL, None),
+            default=default.get(const.CFOF_CHORES_INPUT_CUSTOM_INTERVAL, 1),
         ): vol.Any(
             None,
             selector.NumberSelector(
@@ -946,7 +946,10 @@ def build_chore_schema(
         ),
         vol.Optional(
             const.CFOF_CHORES_INPUT_CUSTOM_INTERVAL_UNIT,
-            default=default.get(const.CFOF_CHORES_INPUT_CUSTOM_INTERVAL_UNIT, None),
+            default=default.get(
+                const.CFOF_CHORES_INPUT_CUSTOM_INTERVAL_UNIT,
+                const.TIME_UNIT_DAYS,
+            ),
         ): vol.Any(
             None,
             selector.SelectSelector(


### PR DESCRIPTION
Fixes #97\n\nHome Assistant skips rendering optional form fields when their default value is None. The custom interval and custom interval unit fields were both initialized with None, so they never appeared in the chore schedule form.\n\nThis change sets non-null fallbacks (interval=1, unit=days) so both fields render and can be edited when using custom frequencies.\n\nGreetings, saschabuehrle