### PR TITLE
fix(services): sync reassigned chore entities

### DIFF
--- a/custom_components/choreops/services.py
+++ b/custom_components/choreops/services.py
@@ -1136,6 +1136,9 @@ def async_setup_services(hass: HomeAssistant):
                 existing_chore.get(const.DATA_CHORE_ASSIGNED_USER_IDS, []),
             )
         )
+        assignments_changed = const.DATA_CHORE_ASSIGNED_USER_IDS in data_input and set(
+            assigned_assignee_ids
+        ) != set(existing_chore.get(const.DATA_CHORE_ASSIGNED_USER_IDS, []))
 
         validation_data = _build_service_chore_validation_data(
             data_input,
@@ -1175,6 +1178,9 @@ def async_setup_services(hass: HomeAssistant):
                 chore_dict[const.DATA_CHORE_NAME],
                 chore_id,
             )
+
+            if assignments_changed:
+                await coordinator.async_sync_entities_after_service_create()
 
             return {const.SERVICE_FIELD_CHORE_CRUD_ID: chore_id}
 

--- a/tests/test_chore_crud_services.py
+++ b/tests/test_chore_crud_services.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.exceptions import HomeAssistantError
 import pytest
@@ -607,6 +607,36 @@ class TestUpdateChoreSchemaValidation:
 
 class TestUpdateChoreEndToEnd:
     """Test update_chore end-to-end functionality via dashboard helper."""
+
+    @pytest.mark.asyncio
+    async def test_assignment_change_triggers_entity_sync(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Test assignment changes trigger runtime entity synchronization."""
+        chore_id = scenario_full.chore_ids["Täke Öut Trash"]
+
+        with (
+            patch.object(scenario_full.coordinator, "_persist", new=MagicMock()),
+            patch.object(
+                scenario_full.coordinator,
+                "async_sync_entities_after_service_create",
+                new=AsyncMock(),
+            ) as mock_sync,
+        ):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_CHORE,
+                {
+                    "id": chore_id,
+                    "assigned_user_names": ["Max!"],
+                },
+                blocking=True,
+                return_response=True,
+            )
+
+        mock_sync.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_updated_points_reflects_in_dashboard_helper(


### PR DESCRIPTION
Closes #96

## Summary
- sync runtime entities after `choreops.update_chore` changes assigned users
- keep service behavior aligned with the existing assignment-change reload path used by the options flow
- add regression coverage for service-triggered entity synchronization

## Why
Updating a chore assignment through the service updated storage correctly, but could leave the runtime entity graph stale until a reload path ran later. That caused the dashboard to appear empty or inconsistent after reassignment.

## Validation
- `python -m pytest tests/test_chore_crud_services.py -k "assignment_change_triggers_entity_sync or updated_points_reflects_in_dashboard_helper" -v --tb=line`
- `./utils/quick_lint.sh --fix`
