### PR TITLE
Add dashboard filters for unscheduled and future chores

### DIFF
--- a/custom_components/choreops/dashboards/dashboard_registry.json
+++ b/custom_components/choreops/dashboards/dashboard_registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_version": "1.0.3",
+  "release_version": "1.0.4",
   "repo": "ccpk1/ChoreOps-Dashboards",
   "title": "ChoreOps Dashboard Registry",
   "description": "Registry manifest for ChoreOps dashboard templates",

--- a/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
@@ -62,6 +62,17 @@
   - Example: `['completed', 'completed_by_other', 'not_my_turn', 'missed']`.
   - Allowed: array of lowercase state strings.
 
+- `pref_exclude_nonrecurring_no_due_date` (default: `false`)
+  - Hides chores that are both non-recurring and missing a due date.
+  - Daily chores without a due date are not affected.
+  - Allowed: `true`, `false`.
+
+- `pref_max_due_date_days` (default: `0`)
+  - Hides chores whose due date is more than this many days ahead.
+  - Applies only to chores that have a due date.
+  - `0` disables the filter.
+  - Allowed: `0` or a positive integer.
+
 - `pref_exclude_group_list` (default: `[]`)
   - Excludes one or more rendered chore groups from the card.
   - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
@@ -114,6 +125,8 @@
 
 - Keep it minimal: set only `pref_column_count`, leave everything else as default.
 - Hide done chores: add `completed` to `pref_exclude_states` (for example `['completed']`).
+- Hide unscheduled one-off chores: set `pref_exclude_nonrecurring_no_due_date: true`.
+- Hide long-range future chores: set `pref_max_due_date_days: 7`.
 - Hide Later chores: set `pref_exclude_group_list: ['later']`.
 - Build a label board: set `pref_use_label_grouping: true` and define `pref_label_display_order`.
 - Prioritize urgent work: keep `pref_use_overdue_grouping: true` and use `pref_sort_within_groups: by_state_and_date`.

--- a/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
@@ -62,6 +62,15 @@
   - Example: `['completed', 'completed_by_other', 'not_my_turn', 'missed']`.
   - Allowed: array of lowercase state strings.
 
+- `pref_exclude_group_list` (default: `[]`)
+  - Excludes one or more rendered chore groups from the card.
+  - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
+  - Exclusions apply after the dashboard resolves which groups exist.
+  - If a listed group does not exist in the current configuration, it is ignored.
+  - Example: `['later']` hides the Later bucket.
+  - Example: `['later', 'this_week']` hides the Later and Due This Week buckets.
+  - When `pref_use_today_grouping` is `true`, exclude both `today_morning` and `today` to hide all today chores.
+
 - `pref_use_label_grouping` (default: `false`)
   - Groups chores by labels instead of time buckets.
   - Allowed: `true`, `false`.
@@ -105,6 +114,7 @@
 
 - Keep it minimal: set only `pref_column_count`, leave everything else as default.
 - Hide done chores: add `completed` to `pref_exclude_states` (for example `['completed']`).
+- Hide Later chores: set `pref_exclude_group_list: ['later']`.
 - Build a label board: set `pref_use_label_grouping: true` and define `pref_label_display_order`.
 - Prioritize urgent work: keep `pref_use_overdue_grouping: true` and use `pref_sort_within_groups: by_state_and_date`.
 

--- a/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
@@ -59,6 +59,17 @@
 - `pref_exclude_states` (default: `[]`)
   - Excludes chores by state.
 
+- `pref_exclude_nonrecurring_no_due_date` (default: `false`)
+  - Hides chores that are both non-recurring and missing a due date.
+  - Daily chores without a due date are not affected.
+  - Allowed: `true`, `false`.
+
+- `pref_max_due_date_days` (default: `0`)
+  - Hides chores whose due date is more than this many days ahead.
+  - Applies only to chores that have a due date.
+  - `0` disables the filter.
+  - Allowed: `0` or a positive integer.
+
 - `pref_exclude_group_list` (default: `[]`)
   - Excludes one or more rendered chore groups from the card.
   - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
@@ -116,5 +127,7 @@ The lite profile uses one tap action per reward tile.
 - Keep the light default behavior: change nothing and let the helper-provided sorting do the work.
 - Hide completed chores: set `pref_exclude_completed: true`.
 - Hide blocked-result chores on shared/rotation heavy installs: set `pref_exclude_blocked: true`.
+- Hide unscheduled one-off chores: set `pref_exclude_nonrecurring_no_due_date: true`.
+- Hide long-range future chores: set `pref_max_due_date_days: 7`.
 - Hide the Later section: set `pref_exclude_group_list: ['later']`.
 - Prefer label buckets over time buckets: set `pref_use_label_grouping: true` and provide `pref_label_display_order`.

--- a/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
@@ -59,6 +59,15 @@
 - `pref_exclude_states` (default: `[]`)
   - Excludes chores by state.
 
+- `pref_exclude_group_list` (default: `[]`)
+  - Excludes one or more rendered chore groups from the card.
+  - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
+  - Exclusions apply after the dashboard resolves which groups exist.
+  - If a listed group does not exist in the current configuration, it is ignored.
+  - Example: `['later']` hides the Later bucket.
+  - Example: `['later', 'this_week']` hides the Later and Due This Week buckets.
+  - In `today_morning` mode, excluding `today` hides only the later-today bucket. Exclude both `today_morning` and `today` to hide all today chores.
+
 - `pref_use_label_grouping` (default: `false`)
   - Groups chores by labels instead of time buckets.
 
@@ -107,4 +116,5 @@ The lite profile uses one tap action per reward tile.
 - Keep the light default behavior: change nothing and let the helper-provided sorting do the work.
 - Hide completed chores: set `pref_exclude_completed: true`.
 - Hide blocked-result chores on shared/rotation heavy installs: set `pref_exclude_blocked: true`.
+- Hide the Later section: set `pref_exclude_group_list: ['later']`.
 - Prefer label buckets over time buckets: set `pref_use_label_grouping: true` and provide `pref_label_display_order`.

--- a/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
@@ -96,6 +96,15 @@
   - Example: `['completed', 'completed_by_other', 'not_my_turn', 'missed']`.
   - Allowed: array of lowercase state strings.
 
+- `pref_exclude_group_list` (default: `[]`)
+  - Excludes one or more rendered chore groups from the card.
+  - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
+  - Exclusions apply after the dashboard resolves which groups exist.
+  - If a listed group does not exist in the current configuration, it is ignored.
+  - Example: `['later']` hides the Later bucket.
+  - Example: `['later', 'this_week']` hides the Later and Due This Week buckets.
+  - In `today_morning` mode, excluding `today` hides only the later-today bucket. Exclude both `today_morning` and `today` to hide all today chores.
+
 - `pref_use_label_grouping` (default: `false`)
   - Groups chores by labels instead of time buckets.
   - Allowed: `true`, `false`.
@@ -197,5 +206,7 @@
 - Keep it minimal: set only the variant-specific column preferences you care about, leave everything else as default.
 - Switch to the kid-friendly tile presentation: set `pref_chore_row_variant: kids` and keep the auto-selected column defaults unless you want a denser or sparser grid.
 - Hide done chores: add `completed` to `pref_exclude_states` (for example `['completed']`).
+- Hide the Later group: add `later` to `pref_exclude_group_list` (for example `['later']`).
+- Build a due-focused card: add `later` and `this_week` to `pref_exclude_group_list`.
 - Build a label board: set `pref_use_label_grouping: true` and define `pref_label_display_order`.
 - Prioritize urgent work: keep `pref_use_overdue_grouping: true` and use `pref_sort_within_groups: by_state_and_date`.

--- a/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
@@ -96,6 +96,17 @@
   - Example: `['completed', 'completed_by_other', 'not_my_turn', 'missed']`.
   - Allowed: array of lowercase state strings.
 
+- `pref_exclude_nonrecurring_no_due_date` (default: `false`)
+  - Hides chores that are both non-recurring and missing a due date.
+  - Daily chores without a due date are not affected.
+  - Allowed: `true`, `false`.
+
+- `pref_max_due_date_days` (default: `0`)
+  - Hides chores whose due date is more than this many days ahead.
+  - Applies only to chores that have a due date.
+  - `0` disables the filter.
+  - Allowed: `0` or a positive integer.
+
 - `pref_exclude_group_list` (default: `[]`)
   - Excludes one or more rendered chore groups from the card.
   - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
@@ -206,6 +217,8 @@
 - Keep it minimal: set only the variant-specific column preferences you care about, leave everything else as default.
 - Switch to the kid-friendly tile presentation: set `pref_chore_row_variant: kids` and keep the auto-selected column defaults unless you want a denser or sparser grid.
 - Hide done chores: add `completed` to `pref_exclude_states` (for example `['completed']`).
+- Hide unscheduled one-off chores: set `pref_exclude_nonrecurring_no_due_date: true`.
+- Hide long-range future chores: set `pref_max_due_date_days: 7`.
 - Hide the Later group: add `later` to `pref_exclude_group_list` (for example `['later']`).
 - Build a due-focused card: add `later` and `this_week` to `pref_exclude_group_list`.
 - Build a label board: set `pref_use_label_grouping: true` and define `pref_label_display_order`.

--- a/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
@@ -115,6 +115,15 @@ Recommended ranges:
   - Example: `['completed', 'completed_by_other', 'not_my_turn', 'missed']`.
   - Allowed: array of lowercase state strings.
 
+- `pref_exclude_group_list` (default: `[]`)
+  - Excludes one or more rendered chore groups from the card.
+  - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
+  - Exclusions apply after the dashboard resolves which groups exist.
+  - If a listed group does not exist in the current configuration, it is ignored.
+  - Example: `['later']` hides the Later bucket.
+  - Example: `['later', 'this_week']` hides the Later and Due This Week buckets.
+  - In `today_morning` mode, excluding `today` hides only the later-today bucket. Exclude both `today_morning` and `today` to hide all today chores.
+
 - `pref_use_label_grouping` (default: `false`)
   - Groups chores by labels instead of time buckets.
   - Allowed: `true`, `false`.

--- a/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
@@ -115,6 +115,17 @@ Recommended ranges:
   - Example: `['completed', 'completed_by_other', 'not_my_turn', 'missed']`.
   - Allowed: array of lowercase state strings.
 
+- `pref_exclude_nonrecurring_no_due_date` (default: `false`)
+  - Hides chores that are both non-recurring and missing a due date.
+  - Daily chores without a due date are not affected.
+  - Allowed: `true`, `false`.
+
+- `pref_max_due_date_days` (default: `0`)
+  - Hides chores whose due date is more than this many days ahead.
+  - Applies only to chores that have a due date.
+  - `0` disables the filter.
+  - Allowed: `0` or a positive integer.
+
 - `pref_exclude_group_list` (default: `[]`)
   - Excludes one or more rendered chore groups from the card.
   - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.

--- a/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
@@ -34,6 +34,15 @@
 - `pref_exclude_completed` (default: `false`)
   - Hide completed chores from the display.
   - Allowed: `true`, `false`.
+- `pref_exclude_nonrecurring_no_due_date` (default: `false`)
+  - Hide chores that are both non-recurring and missing a due date.
+  - Daily chores without a due date are not affected.
+  - Allowed: `true`, `false`.
+- `pref_max_due_date_days` (default: `0`)
+  - Hide chores whose due date is more than this many days ahead.
+  - Applies only to chores that have a due date.
+  - `0` disables the filter.
+  - Allowed: `0` or a positive integer.
 - `pref_exclude_group_list` (default: `[]`)
   - Exclude one or more rendered chore groups from the card.
   - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.

--- a/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
@@ -34,6 +34,14 @@
 - `pref_exclude_completed` (default: `false`)
   - Hide completed chores from the display.
   - Allowed: `true`, `false`.
+- `pref_exclude_group_list` (default: `[]`)
+  - Exclude one or more rendered chore groups from the card.
+  - Allowed values: `overdue`, `today_morning`, `today`, `this_week`, `later`.
+  - Exclusions apply after the dashboard resolves which groups exist.
+  - If a listed group does not exist in the current configuration, it is ignored.
+  - Example: `['later']` hides the Later bucket.
+  - Example: `['later', 'this_week']` hides the Later and Due This Week buckets.
+  - When `pref_use_today_grouping` is `true`, exclude both `today_morning` and `today` to hide all today chores.
 - `pref_use_label_grouping` (default: `false`)
   - Group chores by labels.
   - Allowed: `true`, `false`.

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
@@ -55,6 +55,15 @@
 {%- set pref_exclude_completed = (pref_exclude_completed | default(false, true) | string | lower) == 'true' -%}
 {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable and pref_exclude_states is not string else [] -%}
 {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
+{%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
+{%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
+{%- set ns_valid_exclude_groups = namespace(items=[]) -%}
+{%- for group_id in pref_exclude_group_list -%}
+  {%- if group_id in ['overdue', 'today_morning', 'today', 'this_week', 'later'] and group_id not in ns_valid_exclude_groups.items -%}
+    {%- set ns_valid_exclude_groups.items = ns_valid_exclude_groups.items + [group_id] -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- set pref_exclude_group_list = ns_valid_exclude_groups.items -%}
 {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
   {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
 {%- endif -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
@@ -55,6 +55,11 @@
 {%- set pref_exclude_completed = (pref_exclude_completed | default(false, true) | string | lower) == 'true' -%}
 {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable and pref_exclude_states is not string else [] -%}
 {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
+{%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+{%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
+{%- if pref_max_due_date_days < 0 -%}
+  {%- set pref_max_due_date_days = 0 -%}
+{%- endif -%}
 {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
 {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
 {%- set ns_valid_exclude_groups = namespace(items=[]) -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
@@ -5,6 +5,8 @@
 	{%- set chore_labels = chore.labels if chore is mapping else state_attr(chore_sensor_id, 'labels') | default([], true) -%}
 	{%- set chore_primary_group = chore.primary_group if chore is mapping else state_attr(chore_sensor_id, 'primary_group') | default('other') -%}
 	{%- set chore_is_today_am = chore.is_today_am if chore is mapping else state_attr(chore_sensor_id, 'is_today_am') -%}
+	{%- set chore_due_date = state_attr(chore_sensor_id, 'due_date') -%}
+	{%- set chore_recurring_frequency = state_attr(chore_sensor_id, 'recurring_frequency') | default('', true) | string | lower -%}
 
 	{#-- Step 1: Skip if chore labels match exclude list --#}
 	{%- if not (chore_labels | select('in', pref_exclude_label_list) | list | count > 0) -%}
@@ -12,6 +14,14 @@
 		{#-- Step 2: Skip chores by excluded states preference --#}
 		{%- if chore_status in effective_exclude_states -%}
 			{#-- Skip this chore --#}
+
+		{#-- Step 2b: Skip non-recurring chores with no due date when configured --#}
+		{%- elif pref_exclude_nonrecurring_no_due_date and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency in ['', 'none'] -%}
+			{#-- Skip unscheduled one-off chore --#}
+
+		{#-- Step 2c: Skip chores beyond the due-date horizon when configured --#}
+		{%- elif pref_max_due_date_days > 0 and chore_due_date not in [none, 'unknown', 'unavailable'] and ((as_timestamp(chore_due_date) | default(0, true)) - (as_timestamp(now()) | default(0, true))) > (pref_max_due_date_days * 86400) -%}
+			{#-- Skip far-future due-dated chore --#}
 
 		{#-- Step 3: Handle overdue chores (highest priority) --#}
 		{%- elif chore_status == 'overdue' and effective_use_overdue_grouping -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
@@ -74,7 +74,7 @@
 				{%- endif -%}
 			{%- endfor -%}
 			{%- if ns.temp_label_buttons | length > 0 -%}
-				{%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
+				{%- set ns.label_button_groups = ns.label_button_groups + [{'id': none, 'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
 			{%- endif -%}
 		{%- endif -%}
 	{%- endfor -%}
@@ -92,7 +92,7 @@
 					{%- endif -%}
 				{%- endfor -%}
 				{%- if ns.temp_label_buttons | length > 0 -%}
-					{%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
+					{%- set ns.label_button_groups = ns.label_button_groups + [{'id': none, 'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
 				{%- endif -%}
 			{%- endif -%}
 		{%- endfor -%}
@@ -101,10 +101,10 @@
 
 {#-- Build the button groups --#}
 {%- set button_groups = [
-		{'name': "!!!!!!!!!!! " ~ ui.get('overdue', 'err-overdue') ~ " !!!!!!!!!!!", 'buttons': ns.overdue_buttons, 'icon': 'mdi:alert-octagon'},
-		{'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons, 'icon': 'mdi:alarm'},
-		{'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons, 'icon': 'mdi:calendar-today'},
-		{'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons, 'icon': 'mdi:calendar-week'}
+		{'id': 'overdue', 'name': "!!!!!!!!!!! " ~ ui.get('overdue', 'err-overdue') ~ " !!!!!!!!!!!", 'buttons': ns.overdue_buttons, 'icon': 'mdi:alert-octagon'},
+		{'id': 'today_morning', 'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons, 'icon': 'mdi:alarm'},
+		{'id': 'today', 'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons, 'icon': 'mdi:calendar-today'},
+		{'id': 'this_week', 'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons, 'icon': 'mdi:calendar-week'}
 ] -%}
 
 {#-- Insert label-based groups --#}
@@ -112,8 +112,13 @@
 
 {#-- Continue with bonus group --#}
 {%- set button_groups = button_groups + [
-		{'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons, 'icon': 'mdi:calendar-clock'}
+		{'id': 'later', 'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons, 'icon': 'mdi:calendar-clock'}
 ] -%}
+
+{#-- Exclude rendered groups by stable group id after grouping is resolved --#}
+{%- if pref_exclude_group_list | length > 0 -%}
+	{%- set button_groups = button_groups | rejectattr('id', 'in', pref_exclude_group_list) | list -%}
+{%- endif -%}
 
 {#-- Sort chores within each group based on preference --#}
 {%- if effective_sort_within_groups != 'default' -%}
@@ -134,7 +139,7 @@
 				{%- endif -%}
 				{#-- Extract just the entity IDs --#}
 				{%- set sorted_buttons = sorted_list | map('last') | list -%}
-				{%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+				{%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
 			{%- elif effective_sort_within_groups in ['date_asc', 'date_desc'] -%}
 				{#-- Build list of (due_date_timestamp, eid) tuples for sorting --#}
 				{%- set ns.temp_list = [] -%}
@@ -154,7 +159,7 @@
 				{%- endif -%}
 				{#-- Extract just the entity IDs --#}
 				{%- set sorted_buttons = sorted_list | map('last') | list -%}
-				{%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+				{%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
 			{%- elif effective_sort_within_groups == 'by_state_and_date' -%}
 				{#-- Actionability sort: overdue, due, pending, waiting, claimed, completed, completed_by_other, not_my_turn, missed --#}
 				{%- set ns.temp_list = [] -%}
@@ -192,7 +197,7 @@
 				{%- endfor -%}
 				{%- set sorted_list = ns.temp_list | sort -%}
 				{%- set sorted_buttons = sorted_list | map('last') | list -%}
-				{%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+				{%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
 			{%- else -%}
 				{%- set ns.sorted_groups = ns.sorted_groups + [group] -%}
 			{%- endif -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
@@ -208,6 +208,8 @@ views:
 
                   {%- set pref_exclude_states = [] -%}  {#-- Example: ['completed', 'completed_by_other', 'not_my_turn', 'missed'] --#}
 
+                  {%- set pref_exclude_group_list = [] -%}  {#-- Example: ['later', 'this_week'] --#}
+
                   {%- set pref_use_label_grouping = false -%}
 
                   {%- set pref_exclude_label_list = [] -%}  {#-- Example: ['junk_label', 'skip_this'] --#}
@@ -240,6 +242,15 @@ views:
                   {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
                     {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
                   {%- endif -%}
+                  {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
+                  {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
+                  {%- set ns_group_filter = namespace(valid=[]) -%}
+                  {%- for group_id in pref_exclude_group_list -%}
+                    {%- if group_id in ['overdue', 'today_morning', 'today', 'this_week', 'later'] and group_id not in ns_group_filter.valid -%}
+                      {%- set ns_group_filter.valid = ns_group_filter.valid + [group_id] -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                  {%- set pref_exclude_group_list = ns_group_filter.valid -%}
                   {%- set pref_use_label_grouping = pref_use_label_grouping | default(false, true) -%}
                   {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable else [] -%}
                   {%- set pref_label_display_order = pref_label_display_order if pref_label_display_order is iterable else [] -%}
@@ -351,7 +362,7 @@ views:
                             {%- endif -%}
                           {%- endfor -%}
                           {%- if ns.temp_label_buttons | length > 0 -%}
-                            {%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
+                            {%- set ns.label_button_groups = ns.label_button_groups + [{'id': 'none', 'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
                           {%- endif -%}
                         {%- endif -%}
                       {%- endfor -%}
@@ -369,7 +380,7 @@ views:
                               {%- endif -%}
                             {%- endfor -%}
                             {%- if ns.temp_label_buttons | length > 0 -%}
-                              {%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
+                              {%- set ns.label_button_groups = ns.label_button_groups + [{'id': 'none', 'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
                             {%- endif -%}
                           {%- endif -%}
                         {%- endfor -%}
@@ -378,10 +389,10 @@ views:
 
                     {#-- Build the button groups --#}
                     {%- set button_groups = [
-                        {'name': "!!!!!!!!!!! " ~ ui.get('overdue', 'err-overdue') ~ " !!!!!!!!!!!", 'buttons': ns.overdue_buttons, 'icon': 'mdi:alert-octagon'},
-                        {'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons, 'icon': 'mdi:alarm'},
-                        {'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons, 'icon': 'mdi:calendar-today'},
-                        {'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons, 'icon': 'mdi:calendar-week'}
+                      {'id': 'overdue', 'name': "!!!!!!!!!!! " ~ ui.get('overdue', 'err-overdue') ~ " !!!!!!!!!!!", 'buttons': ns.overdue_buttons, 'icon': 'mdi:alert-octagon'},
+                      {'id': 'today_morning', 'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons, 'icon': 'mdi:alarm'},
+                      {'id': 'today', 'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons, 'icon': 'mdi:calendar-today'},
+                      {'id': 'this_week', 'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons, 'icon': 'mdi:calendar-week'}
                     ] -%}
 
                     {#-- Insert label-based groups --#}
@@ -389,8 +400,12 @@ views:
 
                     {#-- Continue with bonus group --#}
                     {%- set button_groups = button_groups + [
-                        {'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons, 'icon': 'mdi:calendar-clock'}
+                        {'id': 'later', 'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons, 'icon': 'mdi:calendar-clock'}
                     ] -%}
+
+                    {%- if pref_exclude_group_list | length > 0 -%}
+                      {%- set button_groups = button_groups | rejectattr('id', 'in', pref_exclude_group_list) | list -%}
+                    {%- endif -%}
 
                     {#-- Sort chores within each group based on preference --#}
                     {%- if pref_sort_within_groups != 'default' -%}
@@ -411,7 +426,7 @@ views:
                             {%- endif -%}
                             {#-- Extract just the entity IDs --#}
                             {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                            {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+                            {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
                           {%- elif pref_sort_within_groups in ['date_asc', 'date_desc'] -%}
                             {#-- Build list of (due_date_timestamp, eid) tuples for sorting --#}
                             {%- set ns.temp_list = [] -%}
@@ -431,7 +446,7 @@ views:
                             {%- endif -%}
                             {#-- Extract just the entity IDs --#}
                             {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                            {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+                            {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
                           {%- elif pref_sort_within_groups == 'by_state_and_date' -%}
                             {#-- Actionability sort: overdue, due, pending, waiting, claimed, completed, completed_by_other, not_my_turn, missed --#}
                             {%- set ns.temp_list = [] -%}
@@ -469,7 +484,7 @@ views:
                             {%- endfor -%}
                             {%- set sorted_list = ns.temp_list | sort -%}
                             {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                            {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+                            {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
                           {%- else -%}
                             {%- set ns.sorted_groups = ns.sorted_groups + [group] -%}
                           {%- endif -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
@@ -208,6 +208,10 @@ views:
 
                   {%- set pref_exclude_states = [] -%}  {#-- Example: ['completed', 'completed_by_other', 'not_my_turn', 'missed'] --#}
 
+                  {%- set pref_exclude_nonrecurring_no_due_date = false -%}
+
+                  {%- set pref_max_due_date_days = 0 -%}  {#-- 0 disables; positive integer hides chores due beyond this many days ahead. --#}
+
                   {%- set pref_exclude_group_list = [] -%}  {#-- Example: ['later', 'this_week'] --#}
 
                   {%- set pref_use_label_grouping = false -%}
@@ -241,6 +245,11 @@ views:
                   {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
                   {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
                     {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
+                  {%- endif -%}
+                  {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+                  {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
+                  {%- if pref_max_due_date_days < 0 -%}
+                    {%- set pref_max_due_date_days = 0 -%}
                   {%- endif -%}
                   {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
                   {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
@@ -293,6 +302,8 @@ views:
                       {%- set chore_labels = chore.labels if chore is mapping else state_attr(chore_sensor_id, 'labels') | default([], true) -%}
                       {%- set chore_primary_group = chore.primary_group if chore is mapping else state_attr(chore_sensor_id, 'primary_group') | default('other') -%}
                       {%- set chore_is_today_am = chore.is_today_am if chore is mapping else state_attr(chore_sensor_id, 'is_today_am') -%}
+                      {%- set chore_due_date = state_attr(chore_sensor_id, 'due_date') -%}
+                      {%- set chore_recurring_frequency = state_attr(chore_sensor_id, 'recurring_frequency') | default('', true) | string | lower -%}
 
                       {#-- Step 1: Skip if chore labels match exclude list --#}
                       {%- if not (chore_labels | select('in', pref_exclude_label_list) | list | count > 0) -%}
@@ -300,6 +311,14 @@ views:
                         {#-- Step 2: Skip chores by excluded states preference --#}
                         {%- if chore_status in pref_exclude_states -%}
                           {#-- Skip this chore --#}
+
+                        {#-- Step 2b: Skip non-recurring chores with no due date when configured --#}
+                        {%- elif pref_exclude_nonrecurring_no_due_date and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency in ['', 'none'] -%}
+                          {#-- Skip unscheduled one-off chore --#}
+
+                        {#-- Step 2c: Skip chores beyond the due-date horizon when configured --#}
+                        {%- elif pref_max_due_date_days > 0 and chore_due_date not in [none, 'unknown', 'unavailable'] and ((as_timestamp(chore_due_date) | default(0, true)) - (as_timestamp(now()) | default(0, true))) > (pref_max_due_date_days * 86400) -%}
+                          {#-- Skip far-future due-dated chore --#}
 
                         {#-- Step 3: Handle overdue chores (highest priority) --#}
                         {%- elif chore_status == 'overdue' and pref_use_overdue_grouping -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -160,6 +160,8 @@ views:
 
                     {%- set pref_exclude_states = [] -%}
 
+                    {%- set pref_exclude_group_list = [] -%}
+
                     {%- set pref_use_label_grouping = false -%}
 
                     {%- set pref_exclude_label_list = [] -%}
@@ -189,6 +191,15 @@ views:
                         {%- endif -%}
                       {%- endfor -%}
                     {%- endif -%}
+                    {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
+                    {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
+                    {%- set ns_group_filter = namespace(valid=[]) -%}
+                    {%- for group_id in pref_exclude_group_list -%}
+                      {%- if group_id in ['overdue', 'today_morning', 'today', 'this_week', 'later'] and group_id not in ns_group_filter.valid -%}
+                        {%- set ns_group_filter.valid = ns_group_filter.valid + [group_id] -%}
+                      {%- endif -%}
+                    {%- endfor -%}
+                    {%- set pref_exclude_group_list = ns_group_filter.valid -%}
                     {%- set pref_use_label_grouping = pref_use_label_grouping | default(false, true) -%}
                     {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable else [] -%}
                     {%- set pref_label_display_order = pref_label_display_order if pref_label_display_order is iterable else [] -%}
@@ -272,20 +283,24 @@ views:
                               {%- endif -%}
                             {%- endfor -%}
                             {%- if ns.temp_label_buttons | length > 0 -%}
-                              {%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons}] -%}
+                              {%- set ns.label_button_groups = ns.label_button_groups + [{'id': 'none', 'name': label, 'buttons': ns.temp_label_buttons}] -%}
                             {%- endif -%}
                           {%- endif -%}
                         {%- endfor -%}
                       {%- endif -%}
 
                       {%- set button_groups = [
-                        {'name': ui.get('overdue', 'err-overdue'), 'buttons': ns.overdue_buttons},
-                        {'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons},
-                        {'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons},
-                        {'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons}
+                        {'id': 'overdue', 'name': ui.get('overdue', 'err-overdue'), 'buttons': ns.overdue_buttons},
+                        {'id': 'today_morning', 'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons},
+                        {'id': 'today', 'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons},
+                        {'id': 'this_week', 'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons}
                       ] -%}
                       {%- set button_groups = button_groups + ns.label_button_groups -%}
-                      {%- set button_groups = button_groups + [{'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons}] -%}
+                      {%- set button_groups = button_groups + [{'id': 'later', 'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons}] -%}
+
+                      {%- if pref_exclude_group_list | length > 0 -%}
+                        {%- set button_groups = button_groups | rejectattr('id', 'in', pref_exclude_group_list) | list -%}
+                      {%- endif -%}
 
                       {%- if pref_sort_within_groups != 'default' -%}
                         {%- set ns.sorted_groups = [] -%}
@@ -302,7 +317,7 @@ views:
                                 {%- set sorted_list = sorted_list | reverse | list -%}
                               {%- endif -%}
                               {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                              {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons}] -%}
+                              {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons}] -%}
                             {%- elif pref_sort_within_groups in ['date_asc', 'date_desc'] -%}
                               {%- set ns.temp_list = [] -%}
                               {%- for eid in group.buttons -%}
@@ -319,7 +334,7 @@ views:
                                 {%- set sorted_list = sorted_list | reverse | list -%}
                               {%- endif -%}
                               {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                              {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons}] -%}
+                              {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons}] -%}
                             {%- else -%}
                               {%- set ns.temp_list = [] -%}
                               {%- for eid in group.buttons -%}
@@ -356,7 +371,7 @@ views:
                               {%- endfor -%}
                               {%- set sorted_list = ns.temp_list | sort -%}
                               {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                              {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons}] -%}
+                              {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons}] -%}
                             {%- endif -%}
                           {%- else -%}
                             {%- set ns.sorted_groups = ns.sorted_groups + [group] -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -160,6 +160,10 @@ views:
 
                     {%- set pref_exclude_states = [] -%}
 
+                    {%- set pref_exclude_nonrecurring_no_due_date = false -%}
+
+                    {%- set pref_max_due_date_days = 0 -%}
+
                     {%- set pref_exclude_group_list = [] -%}
 
                     {%- set pref_use_label_grouping = false -%}
@@ -190,6 +194,11 @@ views:
                           {%- set pref_exclude_states = pref_exclude_states + [blocked_state] -%}
                         {%- endif -%}
                       {%- endfor -%}
+                    {%- endif -%}
+                    {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+                    {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
+                    {%- if pref_max_due_date_days < 0 -%}
+                      {%- set pref_max_due_date_days = 0 -%}
                     {%- endif -%}
                     {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
                     {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
@@ -238,9 +247,13 @@ views:
                         {%- set chore_labels = chore.labels if chore is mapping else state_attr(chore_sensor_id, 'labels') | default([], true) -%}
                         {%- set chore_primary_group = chore.primary_group if chore is mapping else state_attr(chore_sensor_id, 'primary_group') | default('other') -%}
                         {%- set chore_is_today_am = chore.is_today_am if chore is mapping else state_attr(chore_sensor_id, 'is_today_am') -%}
+                        {%- set chore_due_date = state_attr(chore_sensor_id, 'due_date') -%}
+                        {%- set chore_recurring_frequency = state_attr(chore_sensor_id, 'recurring_frequency') | default('', true) | string | lower -%}
 
                         {%- if not (chore_labels | select('in', pref_exclude_label_list) | list | count > 0) -%}
                           {%- if chore_status in pref_exclude_states -%}
+                          {%- elif pref_exclude_nonrecurring_no_due_date and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency in ['', 'none'] -%}
+                          {%- elif pref_max_due_date_days > 0 and chore_due_date not in [none, 'unknown', 'unavailable'] and ((as_timestamp(chore_due_date) | default(0, true)) - (as_timestamp(now()) | default(0, true))) > (pref_max_due_date_days * 86400) -%}
                           {%- elif chore_status == 'overdue' and pref_use_overdue_grouping -%}
                             {%- set ns.overdue_buttons = ns.overdue_buttons + [chore_sensor_id] -%}
                             {%- set ns.visible_count = ns.visible_count + 1 -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
@@ -253,6 +253,10 @@ views:
 
                   {%- set pref_exclude_states = [] -%}  {#-- Example: ['completed', 'completed_by_other', 'not_my_turn', 'missed'] --#}
 
+                  {%- set pref_exclude_nonrecurring_no_due_date = false -%}
+
+                  {%- set pref_max_due_date_days = 0 -%}  {#-- 0 disables; positive integer hides chores due beyond this many days ahead. --#}
+
                   {%- set pref_exclude_group_list = [] -%}  {#-- Example: ['later', 'this_week'] --#}
 
                   {%- set pref_use_label_grouping = false -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
@@ -253,6 +253,8 @@ views:
 
                   {%- set pref_exclude_states = [] -%}  {#-- Example: ['completed', 'completed_by_other', 'not_my_turn', 'missed'] --#}
 
+                  {%- set pref_exclude_group_list = [] -%}  {#-- Example: ['later', 'this_week'] --#}
+
                   {%- set pref_use_label_grouping = false -%}
 
                   {%- set pref_exclude_label_list = [] -%}  {#-- Example: ['junk_label', 'skip_this'] --#}

--- a/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
@@ -251,6 +251,10 @@ views:
 
                   {%- set pref_exclude_states = [] -%}  {#-- Example: ['completed', 'completed_by_other', 'not_my_turn', 'missed'] --#}
 
+                  {%- set pref_exclude_nonrecurring_no_due_date = false -%}
+
+                  {%- set pref_max_due_date_days = 0 -%}  {#-- 0 disables; positive integer hides chores due beyond this many days ahead. --#}
+
                   {%- set pref_exclude_group_list = [] -%}  {#-- Example: ['later', 'this_week'] --#}
 
                   {%- set pref_use_label_grouping = false -%}

--- a/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
@@ -251,6 +251,8 @@ views:
 
                   {%- set pref_exclude_states = [] -%}  {#-- Example: ['completed', 'completed_by_other', 'not_my_turn', 'missed'] --#}
 
+                  {%- set pref_exclude_group_list = [] -%}  {#-- Example: ['later', 'this_week'] --#}
+
                   {%- set pref_use_label_grouping = false -%}
 
                   {%- set pref_exclude_label_list = [] -%}  {#-- Example: ['junk_label', 'skip_this'] --#}

--- a/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
@@ -155,6 +155,8 @@ views:
 
                   {%- set pref_exclude_completed = false -%}
 
+                  {%- set pref_exclude_group_list = [] -%}
+
                   {%- set pref_use_label_grouping = false -%}
 
                   {%- set pref_exclude_label_list = [] -%}  {#-- Example: ['junk_label', 'skip_this'] --#}
@@ -172,6 +174,15 @@ views:
                   {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
                   {%- set pref_include_weekly_recurring_in_this_week = (pref_include_weekly_recurring_in_this_week | default('true') | string | lower) == 'true' -%}
                   {%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
+                  {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
+                  {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
+                  {%- set ns_group_filter = namespace(valid=[]) -%}
+                  {%- for group_id in pref_exclude_group_list -%}
+                    {%- if group_id in ['overdue', 'today_morning', 'today', 'this_week', 'later'] and group_id not in ns_group_filter.valid -%}
+                      {%- set ns_group_filter.valid = ns_group_filter.valid + [group_id] -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                  {%- set pref_exclude_group_list = ns_group_filter.valid -%}
                   {%- set pref_use_label_grouping = (pref_use_label_grouping | default('false') | string | lower) == 'true' -%}
                   {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable and pref_exclude_label_list is not string else [] -%}
                   {%- set pref_label_display_order = pref_label_display_order if pref_label_display_order is iterable and pref_label_display_order is not string else [] -%}
@@ -283,7 +294,7 @@ views:
                             {%- endif -%}
                           {%- endfor -%}
                           {%- if ns.temp_label_buttons | length > 0 -%}
-                            {%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
+                            {%- set ns.label_button_groups = ns.label_button_groups + [{'id': 'none', 'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
                           {%- endif -%}
                         {%- endif -%}
                       {%- endfor -%}
@@ -301,7 +312,7 @@ views:
                               {%- endif -%}
                             {%- endfor -%}
                             {%- if ns.temp_label_buttons | length > 0 -%}
-                              {%- set ns.label_button_groups = ns.label_button_groups + [{'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
+                              {%- set ns.label_button_groups = ns.label_button_groups + [{'id': 'none', 'name': label, 'buttons': ns.temp_label_buttons, 'icon': 'mdi:label'}] -%}
                             {%- endif -%}
                           {%- endif -%}
                         {%- endfor -%}
@@ -310,10 +321,10 @@ views:
 
                     {#-- Build the button groups --#}
                     {%- set button_groups = [
-                        {'name': "!!!!!!!!!!! " ~ ui.get('overdue', 'err-overdue') ~ " !!!!!!!!!!!", 'buttons': ns.overdue_buttons, 'icon': 'mdi:alert-octagon'},
-                        {'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons, 'icon': 'mdi:alarm'},
-                        {'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons, 'icon': 'mdi:calendar-today'},
-                        {'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons, 'icon': 'mdi:calendar-week'}
+                      {'id': 'overdue', 'name': "!!!!!!!!!!! " ~ ui.get('overdue', 'err-overdue') ~ " !!!!!!!!!!!", 'buttons': ns.overdue_buttons, 'icon': 'mdi:alert-octagon'},
+                      {'id': 'today_morning', 'name': ui.get('due_this_morning', 'err-due_this_morning'), 'buttons': ns.am_buttons, 'icon': 'mdi:alarm'},
+                      {'id': 'today', 'name': ui.get('due_today', 'err-due_today'), 'buttons': ns.today_buttons, 'icon': 'mdi:calendar-today'},
+                      {'id': 'this_week', 'name': ui.get('due_this_week', 'err-due_this_week'), 'buttons': ns.this_week_buttons, 'icon': 'mdi:calendar-week'}
                     ] -%}
 
                     {#-- Insert label-based groups --#}
@@ -321,8 +332,12 @@ views:
 
                     {#-- Continue with bonus group --#}
                     {%- set button_groups = button_groups + [
-                        {'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons, 'icon': 'mdi:calendar-clock'}
+                        {'id': 'later', 'name': ui.get('upcoming_bonus', 'err-upcoming_bonus'), 'buttons': ns.other_buttons, 'icon': 'mdi:calendar-clock'}
                     ] -%}
+
+                    {%- if pref_exclude_group_list | length > 0 -%}
+                      {%- set button_groups = button_groups | rejectattr('id', 'in', pref_exclude_group_list) | list -%}
+                    {%- endif -%}
 
                     {#-- Sort chores within each group based on preference --#}
                     {%- if pref_sort_within_groups != 'default' -%}
@@ -343,7 +358,7 @@ views:
                             {%- endif -%}
                             {#-- Extract just the entity IDs --#}
                             {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                            {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+                            {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
                           {%- elif pref_sort_within_groups in ['date_asc', 'date_desc'] -%}
                             {#-- Build list of (due_date_timestamp, eid) tuples for sorting --#}
                             {%- set ns.temp_list = [] -%}
@@ -363,7 +378,7 @@ views:
                             {%- endif -%}
                             {#-- Extract just the entity IDs --#}
                             {%- set sorted_buttons = sorted_list | map('last') | list -%}
-                            {%- set ns.sorted_groups = ns.sorted_groups + [{'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
+                            {%- set ns.sorted_groups = ns.sorted_groups + [{'id': group.id, 'name': group.name, 'buttons': sorted_buttons, 'icon': group.icon}] -%}
                           {%- else -%}
                             {%- set ns.sorted_groups = ns.sorted_groups + [group] -%}
                           {%- endif -%}

--- a/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
@@ -155,6 +155,10 @@ views:
 
                   {%- set pref_exclude_completed = false -%}
 
+                  {%- set pref_exclude_nonrecurring_no_due_date = false -%}
+
+                  {%- set pref_max_due_date_days = 0 -%}
+
                   {%- set pref_exclude_group_list = [] -%}
 
                   {%- set pref_use_label_grouping = false -%}
@@ -174,6 +178,11 @@ views:
                   {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
                   {%- set pref_include_weekly_recurring_in_this_week = (pref_include_weekly_recurring_in_this_week | default('true') | string | lower) == 'true' -%}
                   {%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
+                  {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+                  {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
+                  {%- if pref_max_due_date_days < 0 -%}
+                    {%- set pref_max_due_date_days = 0 -%}
+                  {%- endif -%}
                   {%- set pref_exclude_group_list = pref_exclude_group_list if pref_exclude_group_list is iterable and pref_exclude_group_list is not string else [] -%}
                   {%- set pref_exclude_group_list = pref_exclude_group_list | map('lower') | list -%}
                   {%- set ns_group_filter = namespace(valid=[]) -%}
@@ -225,6 +234,8 @@ views:
                       {%- set chore_labels = chore.labels if chore is mapping else state_attr(chore_sensor_id, 'labels') | default([], true) -%}
                       {%- set chore_primary_group = chore.primary_group if chore is mapping else state_attr(chore_sensor_id, 'primary_group') | default('other') -%}
                       {%- set chore_is_today_am = chore.is_today_am if chore is mapping else state_attr(chore_sensor_id, 'is_today_am') -%}
+                      {%- set chore_due_date = state_attr(chore_sensor_id, 'due_date') -%}
+                      {%- set chore_recurring_frequency = state_attr(chore_sensor_id, 'recurring_frequency') | default('', true) | string | lower -%}
 
                       {#-- Step 1: Skip if chore labels match exclude list --#}
                       {%- if not (chore_labels | select('in', pref_exclude_label_list) | list | count > 0) -%}
@@ -232,6 +243,14 @@ views:
                         {#-- Step 2: Skip completed chores if preference set --#}
                         {%- if chore_status == 'completed' and pref_exclude_completed -%}
                           {#-- Skip this chore --#}
+
+                        {#-- Step 2b: Skip non-recurring chores with no due date when configured --#}
+                        {%- elif pref_exclude_nonrecurring_no_due_date and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency in ['', 'none'] -%}
+                          {#-- Skip unscheduled one-off chore --#}
+
+                        {#-- Step 2c: Skip chores beyond the due-date horizon when configured --#}
+                        {%- elif pref_max_due_date_days > 0 and chore_due_date not in [none, 'unknown', 'unavailable'] and ((as_timestamp(chore_due_date) | default(0, true)) - (as_timestamp(now()) | default(0, true))) > (pref_max_due_date_days * 86400) -%}
+                          {#-- Skip far-future due-dated chore --#}
 
                         {#-- Step 3: Handle overdue chores (highest priority) --#}
                         {%- elif chore_status == 'overdue' and pref_use_overdue_grouping -%}


### PR DESCRIPTION
## Summary

Adds the dashboard runtime asset sync for the Issue 24 filtering update:
- hide non-recurring chores that do not have a due date
- hide chores that are too far in the future
- hide selected rendered groups such as Later or This Week
- keep the bundled dashboard registry release pinned at 1.0.4

Closes #24

## Change type

- [x] Dashboard runtime asset sync
- [ ] Translation asset sync
- [ ] Core integration logic change
- [ ] Documentation only

## Release notes

Adds dashboard filters so families can hide unscheduled chores, far-future chores, or entire rendered chore groups.

## Validation

- [x] Combined release-candidate validation completed on the release-ready working tree:
  - `./utils/quick_lint.sh --fix`
  - `python -m pytest tests/ -v --tb=line`
- [x] Dashboard translation sync is intentionally handled in a separate companion PR
