### PR TITLE
Add a service to reschedule chores after a date

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -2717,6 +2717,7 @@ SERVICE_RESET_CHORES_TO_PENDING_STATE: Final = (
 # Superseded by SERVICE_RESET_TRANSACTIONAL_DATA with scope="assignee" or "global" and item_type filter
 SERVICE_RESET_OVERDUE_CHORES: Final = "reset_overdue_chores"
 SERVICE_RESET_TRANSACTIONAL_DATA: Final = "reset_transactional_data"
+SERVICE_RESCHEDULE_CHORES_AFTER: Final = "reschedule_chores_after"
 SERVICE_SET_CHORE_DUE_DATE: Final = "set_chore_due_date"
 SERVICE_SKIP_CHORE_DUE_DATE: Final = "skip_chore_due_date"
 # Rotation management services
@@ -2772,6 +2773,8 @@ SERVICE_FIELD_CONFIG_ENTRY_ID: Final = "config_entry_id"
 SERVICE_FIELD_CONFIG_ENTRY_TITLE: Final = "config_entry_title"
 SERVICE_FIELD_USER_NAME: Final = "user_name"
 SERVICE_FIELD_USER_ID: Final = "user_id"
+SERVICE_FIELD_USER_NAMES: Final = "user_names"
+SERVICE_FIELD_USER_IDS: Final = "user_ids"
 SERVICE_FIELD_UI_CONTROL_TARGET: Final = "ui_control_target"
 UI_CONTROL_KEY_PATH_DELIMITER: Final = "/"
 SERVICE_FIELD_UI_CONTROL_ACTION: Final = "ui_control_action"
@@ -2799,6 +2802,11 @@ UI_CONTROL_TARGETS: Final = (
 # Chore service fields (workflow)
 SERVICE_FIELD_CHORE_NAME: Final = "chore_name"
 SERVICE_FIELD_CHORE_ID: Final = "chore_id"
+SERVICE_FIELD_CHORE_NAMES: Final = "chore_names"
+SERVICE_FIELD_CHORE_IDS: Final = "chore_ids"
+SERVICE_FIELD_AFTER: Final = "after"
+SERVICE_FIELD_RESCHEDULE_SHARED: Final = "reschedule_shared"
+SERVICE_FIELD_SKIP_NON_RECURRING: Final = "skip_non_recurring"
 SERVICE_FIELD_MARK_AS_MISSED: Final = "mark_as_missed"
 
 # Chore service fields (CRUD) - user-friendly names for service calls

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -5724,46 +5724,10 @@ class ChoreManager(BaseManager):
         use_current_due_as_reference: bool = False,
     ) -> None:
         """Reschedule chore's next due date (chore-level for SHARED chores)."""
-        due_date_str = chore_info.get(const.DATA_CHORE_DUE_DATE)
-        if not due_date_str:
-            const.LOGGER.debug(
-                "Chore Due Date - Reschedule: Skipping (no due date for %s)",
-                chore_info.get(const.DATA_CHORE_NAME),
-            )
-            return
-
-        # Parse current due date
-        original_due_utc = dt_to_utc(due_date_str)
-        if not original_due_utc:
-            const.LOGGER.debug(
-                "Chore Due Date - Reschedule: Unable to parse due date for %s",
-                chore_info.get(const.DATA_CHORE_NAME),
-            )
-            return
-
-        # Extract completion timestamp for CUSTOM_FROM_COMPLETE
-        completion_utc = None
-        last_completed_str = chore_info.get(const.DATA_CHORE_LAST_COMPLETED)
-        if last_completed_str:
-            completion_utc = dt_to_utc(last_completed_str)
-
-        reference_time = dt_util.utcnow()
-        if (
-            use_current_due_as_reference
-            and chore_info.get(
-                const.DATA_CHORE_RECURRING_FREQUENCY,
-                const.FREQUENCY_NONE,
-            )
-            == const.FREQUENCY_DAILY_MULTI
-        ):
-            reference_time = original_due_utc
-
-        # Use schedule engine for calculation
-        next_due_utc = calculate_next_due_date_from_chore_info(
-            original_due_utc,
+        original_due_utc = dt_to_utc(chore_info.get(const.DATA_CHORE_DUE_DATE))
+        next_due_utc = self._calculate_next_due_date_for_chore(
             chore_info,
-            completion_timestamp=completion_utc,
-            reference_time=reference_time,
+            use_current_due_as_reference=use_current_due_as_reference,
         )
         if not next_due_utc:
             const.LOGGER.warning(
@@ -5790,8 +5754,57 @@ class ChoreManager(BaseManager):
         const.LOGGER.info(
             "Chore Due Date - Rescheduled (SHARED): %s, from %s to %s",
             chore_info.get(const.DATA_CHORE_NAME),
-            dt_util.as_local(original_due_utc).isoformat(),
+            dt_util.as_local(original_due_utc).isoformat()
+            if original_due_utc is not None
+            else "unknown",
             dt_util.as_local(next_due_utc).isoformat(),
+        )
+
+    def _calculate_next_due_date_for_chore(
+        self,
+        chore_info: ChoreData,
+        *,
+        reference_time: datetime | None = None,
+        use_current_due_as_reference: bool = False,
+    ) -> datetime | None:
+        """Calculate the next chore-level due date without mutating storage."""
+        due_date_str = chore_info.get(const.DATA_CHORE_DUE_DATE)
+        if not due_date_str:
+            const.LOGGER.debug(
+                "Chore Due Date - Reschedule: Skipping (no due date for %s)",
+                chore_info.get(const.DATA_CHORE_NAME),
+            )
+            return None
+
+        original_due_utc = dt_to_utc(due_date_str)
+        if not original_due_utc:
+            const.LOGGER.debug(
+                "Chore Due Date - Reschedule: Unable to parse due date for %s",
+                chore_info.get(const.DATA_CHORE_NAME),
+            )
+            return None
+
+        completion_utc = None
+        last_completed_str = chore_info.get(const.DATA_CHORE_LAST_COMPLETED)
+        if last_completed_str:
+            completion_utc = dt_to_utc(last_completed_str)
+
+        effective_reference_time = reference_time or dt_util.utcnow()
+        if (
+            use_current_due_as_reference
+            and chore_info.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+            == const.FREQUENCY_DAILY_MULTI
+        ):
+            effective_reference_time = original_due_utc
+
+        return calculate_next_due_date_from_chore_info(
+            original_due_utc,
+            chore_info,
+            completion_timestamp=completion_utc,
+            reference_time=effective_reference_time,
         )
 
     def _reschedule_chore_next_due_date_for_assignee(
@@ -5810,91 +5823,14 @@ class ChoreManager(BaseManager):
         assignee_info: UserData | dict[str, Any] = self._coordinator.assignees_data.get(
             assignee_id, {}
         )
-
-        # Get per-assignee current due date
         per_assignee_due_dates = chore_info.get(
             const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES, {}
         )
-        current_due_str = per_assignee_due_dates.get(assignee_id)
-
-        if not current_due_str:
-            const.LOGGER.debug(
-                "Chore Due Date - No due date for chore %s, assignee %s; preserving None",
-                chore_info.get(const.DATA_CHORE_NAME),
-                assignee_id,
-            )
-            if assignee_id in per_assignee_due_dates:
-                del per_assignee_due_dates[assignee_id]
-            chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = per_assignee_due_dates
-            return
-
-        # Parse current due date
-        try:
-            original_due_utc = dt_to_utc(current_due_str)
-        except (ValueError, TypeError, AttributeError):
-            const.LOGGER.debug(
-                "Chore Due Date - Reschedule: Unable to parse due date for %s, assignee %s",
-                chore_info.get(const.DATA_CHORE_NAME),
-                assignee_id,
-            )
-            if assignee_id in per_assignee_due_dates:
-                del per_assignee_due_dates[assignee_id]
-            chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = per_assignee_due_dates
-            return
-
-        # Extract per-assignee completion timestamp (Phase 5: use last_claimed for work date)
-        # Fallback hierarchy: last_claimed → last_approved (backward compat)
-        completion_utc = None
-        assignee_chore_data = assignee_info.get(const.DATA_USER_CHORE_DATA, {}).get(
-            chore_id, {}
-        )
-        last_claimed_str = assignee_chore_data.get(
-            const.DATA_USER_CHORE_DATA_LAST_CLAIMED
-        )
-        if last_claimed_str:
-            completion_utc = dt_to_utc(last_claimed_str)
-        else:
-            # Backward compat: fall back to last_approved for legacy data
-            last_approved_str = assignee_chore_data.get(
-                const.DATA_USER_CHORE_DATA_LAST_APPROVED
-            )
-            if last_approved_str:
-                completion_utc = dt_to_utc(last_approved_str)
-
-        # Build chore info for calculation with per-assignee overrides
-        chore_info_for_calc = dict(chore_info)
-        per_assignee_applicable_days = chore_info.get(
-            const.DATA_CHORE_PER_ASSIGNEE_APPLICABLE_DAYS, {}
-        )
-        if assignee_id in per_assignee_applicable_days:
-            chore_info_for_calc[const.DATA_CHORE_APPLICABLE_DAYS] = (
-                per_assignee_applicable_days[assignee_id]
-            )
-        per_assignee_times = chore_info.get(
-            const.DATA_CHORE_PER_ASSIGNEE_DAILY_MULTI_TIMES, {}
-        )
-        if assignee_id in per_assignee_times:
-            chore_info_for_calc[const.DATA_CHORE_DAILY_MULTI_TIMES] = (
-                per_assignee_times[assignee_id]
-            )
-
-        reference_time = dt_util.utcnow()
-        if (
-            use_current_due_as_reference
-            and chore_info_for_calc.get(
-                const.DATA_CHORE_RECURRING_FREQUENCY,
-                const.FREQUENCY_NONE,
-            )
-            == const.FREQUENCY_DAILY_MULTI
-        ):
-            reference_time = original_due_utc
-
-        # Use schedule engine
-        next_due_utc = calculate_next_due_date_from_chore_info(
-            original_due_utc,
-            cast("ChoreData", chore_info_for_calc),
-            completion_timestamp=completion_utc,
-            reference_time=reference_time,
+        next_due_utc = self._calculate_next_due_date_for_assignee(
+            chore_info,
+            chore_id,
+            assignee_id,
+            use_current_due_as_reference=use_current_due_as_reference,
         )
         if not next_due_utc:
             const.LOGGER.warning(
@@ -5918,6 +5854,382 @@ class ChoreManager(BaseManager):
             assignee_info.get(const.DATA_USER_NAME),
             dt_util.as_local(next_due_utc).isoformat() if next_due_utc else "None",
         )
+
+    def _calculate_next_due_date_for_assignee(
+        self,
+        chore_info: ChoreData,
+        chore_id: str,
+        assignee_id: str,
+        *,
+        reference_time: datetime | None = None,
+        use_current_due_as_reference: bool = False,
+    ) -> datetime | None:
+        """Calculate the next per-assignee due date without mutating storage."""
+        assignee_info: UserData | dict[str, Any] = self._coordinator.assignees_data.get(
+            assignee_id, {}
+        )
+        per_assignee_due_dates = chore_info.get(
+            const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES, {}
+        )
+        current_due_str = per_assignee_due_dates.get(assignee_id)
+
+        if not current_due_str:
+            const.LOGGER.debug(
+                "Chore Due Date - No due date for chore %s, assignee %s; preserving None",
+                chore_info.get(const.DATA_CHORE_NAME),
+                assignee_id,
+            )
+            return None
+
+        original_due_utc = dt_to_utc(current_due_str)
+        if not original_due_utc:
+            const.LOGGER.debug(
+                "Chore Due Date - Reschedule: Unable to parse due date for %s, assignee %s",
+                chore_info.get(const.DATA_CHORE_NAME),
+                assignee_id,
+            )
+            return None
+
+        completion_utc = None
+        assignee_chore_data = assignee_info.get(const.DATA_USER_CHORE_DATA, {}).get(
+            chore_id, {}
+        )
+        last_claimed_str = assignee_chore_data.get(
+            const.DATA_USER_CHORE_DATA_LAST_CLAIMED
+        )
+        if last_claimed_str:
+            completion_utc = dt_to_utc(last_claimed_str)
+        else:
+            last_approved_str = assignee_chore_data.get(
+                const.DATA_USER_CHORE_DATA_LAST_APPROVED
+            )
+            if last_approved_str:
+                completion_utc = dt_to_utc(last_approved_str)
+
+        chore_info_for_calc = dict(chore_info)
+        per_assignee_applicable_days = chore_info.get(
+            const.DATA_CHORE_PER_ASSIGNEE_APPLICABLE_DAYS, {}
+        )
+        if assignee_id in per_assignee_applicable_days:
+            chore_info_for_calc[const.DATA_CHORE_APPLICABLE_DAYS] = (
+                per_assignee_applicable_days[assignee_id]
+            )
+        per_assignee_times = chore_info.get(
+            const.DATA_CHORE_PER_ASSIGNEE_DAILY_MULTI_TIMES, {}
+        )
+        if assignee_id in per_assignee_times:
+            chore_info_for_calc[const.DATA_CHORE_DAILY_MULTI_TIMES] = (
+                per_assignee_times[assignee_id]
+            )
+
+        effective_reference_time = reference_time or dt_util.utcnow()
+        if (
+            use_current_due_as_reference
+            and chore_info_for_calc.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+            == const.FREQUENCY_DAILY_MULTI
+        ):
+            effective_reference_time = original_due_utc
+
+        return calculate_next_due_date_from_chore_info(
+            original_due_utc,
+            cast("ChoreData", chore_info_for_calc),
+            completion_timestamp=completion_utc,
+            reference_time=effective_reference_time,
+        )
+
+    async def reschedule_chores_after(
+        self,
+        after_dt: datetime,
+        *,
+        chore_ids: list[str] | None = None,
+        assignee_ids: list[str] | None = None,
+        reschedule_shared: bool = False,
+        skip_non_recurring: bool = False,
+    ) -> dict[str, Any]:
+        """Reschedule chore due dates so they fall after the supplied datetime."""
+        after_utc = dt_util.as_utc(after_dt)
+        chore_filter = set(chore_ids or [])
+        assignee_filter = set(assignee_ids or [])
+        updated: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        reset_events: set[tuple[str, str, str]] = set()
+
+        for chore_id, chore_info_raw in self._coordinator.chores_data.items():
+            if chore_filter and chore_id not in chore_filter:
+                continue
+
+            chore_info = chore_info_raw
+            chore_name = str(chore_info.get(const.DATA_CHORE_NAME, chore_id))
+            assigned_assignee_ids = [
+                assignee_id
+                for assignee_id in chore_info.get(
+                    const.DATA_CHORE_ASSIGNED_USER_IDS, []
+                )
+                if assignee_id in self._coordinator.assignees_data
+            ]
+            if not assigned_assignee_ids:
+                continue
+
+            frequency = chore_info.get(
+                const.DATA_CHORE_RECURRING_FREQUENCY,
+                const.FREQUENCY_NONE,
+            )
+
+            if ChoreEngine.uses_chore_level_due_date(chore_info):
+                if assignee_filter and not any(
+                    assignee_id in assigned_assignee_ids
+                    for assignee_id in assignee_filter
+                ):
+                    continue
+
+                if not reschedule_shared:
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "reason": "shared_not_enabled",
+                        }
+                    )
+                    continue
+
+                due_dt = self.get_due_date(chore_id)
+                if due_dt is None:
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "reason": "no_due_date",
+                        }
+                    )
+                    continue
+
+                if due_dt > after_utc:
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "old_due_date": due_dt.isoformat(),
+                            "reason": "already_after_boundary",
+                        }
+                    )
+                    continue
+
+                global_state = self.get_global_chore_state_context(chore_id)[
+                    "persisted_state"
+                ]
+                if global_state in (
+                    const.CHORE_STATE_CLAIMED,
+                    const.CHORE_STATE_APPROVED,
+                    const.CHORE_STATE_APPROVED_IN_PART,
+                ):
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "old_due_date": due_dt.isoformat(),
+                            "reason": "in_flight_state",
+                            "state": global_state,
+                        }
+                    )
+                    continue
+
+                if frequency == const.FREQUENCY_NONE:
+                    if skip_non_recurring:
+                        skipped.append(
+                            {
+                                "chore_id": chore_id,
+                                "chore_name": chore_name,
+                                "old_due_date": due_dt.isoformat(),
+                                "reason": "non_recurring_skipped",
+                            }
+                        )
+                        continue
+                    next_due_dt = after_utc
+                else:
+                    next_due_dt = self._calculate_next_due_date_for_chore(
+                        chore_info,
+                        reference_time=after_utc,
+                    )
+                    if next_due_dt is None or next_due_dt <= after_utc:
+                        skipped.append(
+                            {
+                                "chore_id": chore_id,
+                                "chore_name": chore_name,
+                                "old_due_date": due_dt.isoformat(),
+                                "reason": "schedule_calculation_failed",
+                            }
+                        )
+                        continue
+
+                chore_info[const.DATA_CHORE_DUE_DATE] = next_due_dt.isoformat()
+                for assigned_assignee_id in assigned_assignee_ids:
+                    self._transition_chore_state(
+                        assigned_assignee_id,
+                        chore_id,
+                        const.CHORE_STATE_PENDING,
+                        reset_approval_period=True,
+                        clear_ownership=True,
+                        persist=False,
+                    )
+                    reset_events.add((assigned_assignee_id, chore_id, chore_name))
+
+                updated.append(
+                    {
+                        "chore_id": chore_id,
+                        "chore_name": chore_name,
+                        "old_due_date": due_dt.isoformat(),
+                        "new_due_date": next_due_dt.isoformat(),
+                        "affected_user_ids": assigned_assignee_ids,
+                        "shared": True,
+                    }
+                )
+                continue
+
+            target_assignee_ids = assigned_assignee_ids
+            if assignee_filter:
+                target_assignee_ids = [
+                    assignee_id
+                    for assignee_id in assigned_assignee_ids
+                    if assignee_id in assignee_filter
+                ]
+                for filtered_assignee_id in assignee_filter:
+                    if filtered_assignee_id not in assigned_assignee_ids:
+                        skipped.append(
+                            {
+                                "chore_id": chore_id,
+                                "chore_name": chore_name,
+                                "user_id": filtered_assignee_id,
+                                "reason": "user_not_assigned",
+                            }
+                        )
+
+            for assignee_id in target_assignee_ids:
+                due_dt = self.get_due_date(chore_id, assignee_id)
+                if due_dt is None:
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "user_id": assignee_id,
+                            "reason": "no_due_date",
+                        }
+                    )
+                    continue
+
+                if due_dt > after_utc:
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "user_id": assignee_id,
+                            "old_due_date": due_dt.isoformat(),
+                            "reason": "already_after_boundary",
+                        }
+                    )
+                    continue
+
+                assignee_chore_data = self._get_assignee_chore_data(
+                    assignee_id, chore_id
+                )
+                assignee_state = cast(
+                    "str",
+                    assignee_chore_data.get(
+                        const.DATA_USER_CHORE_DATA_STATE,
+                        const.CHORE_STATE_PENDING,
+                    ),
+                )
+                if assignee_chore_data.get(
+                    const.DATA_USER_CHORE_DATA_PENDING_CLAIM_COUNT,
+                    const.DEFAULT_ZERO,
+                ) or assignee_state in (
+                    const.CHORE_STATE_CLAIMED,
+                    const.CHORE_STATE_APPROVED,
+                    const.CHORE_STATE_APPROVED_IN_PART,
+                ):
+                    skipped.append(
+                        {
+                            "chore_id": chore_id,
+                            "chore_name": chore_name,
+                            "user_id": assignee_id,
+                            "old_due_date": due_dt.isoformat(),
+                            "reason": "in_flight_state",
+                            "state": assignee_state,
+                        }
+                    )
+                    continue
+
+                if frequency == const.FREQUENCY_NONE:
+                    if skip_non_recurring:
+                        skipped.append(
+                            {
+                                "chore_id": chore_id,
+                                "chore_name": chore_name,
+                                "user_id": assignee_id,
+                                "old_due_date": due_dt.isoformat(),
+                                "reason": "non_recurring_skipped",
+                            }
+                        )
+                        continue
+                    next_due_dt = after_utc
+                else:
+                    next_due_dt = self._calculate_next_due_date_for_assignee(
+                        chore_info,
+                        chore_id,
+                        assignee_id,
+                        reference_time=after_utc,
+                    )
+                    if next_due_dt is None or next_due_dt <= after_utc:
+                        skipped.append(
+                            {
+                                "chore_id": chore_id,
+                                "chore_name": chore_name,
+                                "user_id": assignee_id,
+                                "old_due_date": due_dt.isoformat(),
+                                "reason": "schedule_calculation_failed",
+                            }
+                        )
+                        continue
+
+                per_assignee_due_dates = chore_info.setdefault(
+                    const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
+                    {},
+                )
+                per_assignee_due_dates[assignee_id] = next_due_dt.isoformat()
+                self._transition_chore_state(
+                    assignee_id,
+                    chore_id,
+                    const.CHORE_STATE_PENDING,
+                    reset_approval_period=True,
+                    clear_ownership=True,
+                    persist=False,
+                )
+                reset_events.add((assignee_id, chore_id, chore_name))
+                updated.append(
+                    {
+                        "chore_id": chore_id,
+                        "chore_name": chore_name,
+                        "user_id": assignee_id,
+                        "old_due_date": due_dt.isoformat(),
+                        "new_due_date": next_due_dt.isoformat(),
+                        "shared": False,
+                    }
+                )
+
+        if reset_events:
+            self._coordinator._persist()
+            self._emit_reset_events(reset_events)
+            self._coordinator.async_set_updated_data(self._coordinator._data)
+
+        return {
+            "after": after_utc.isoformat(),
+            "updated_count": len(updated),
+            "skipped_count": len(skipped),
+            "updated": updated,
+            "skipped": skipped,
+        }
 
     # =========================================================================
     # DATA RESET - Transactional Data Reset for Chores Domain

--- a/custom_components/choreops/services.py
+++ b/custom_components/choreops/services.py
@@ -231,6 +231,102 @@ def _normalize_service_due_date_input(due_date_input: Any) -> str | None:
     return parsed_due_date.isoformat()
 
 
+def _normalize_service_datetime_input(value: Any) -> datetime | None:
+    """Normalize a service datetime payload to a UTC datetime."""
+    parsed_datetime = dt_parse(
+        value,
+        default_tzinfo=const.DEFAULT_TIME_ZONE,
+        return_type=const.HELPER_RETURN_DATETIME_UTC,
+    )
+    if not parsed_datetime or not isinstance(parsed_datetime, datetime):
+        return None
+    return parsed_datetime
+
+
+def _dedupe_service_string_list(values: list[str] | None) -> list[str]:
+    """Return de-duplicated string values while preserving order."""
+    deduped_values: list[str] = []
+    seen_values: set[str] = set()
+
+    for value in values or []:
+        normalized_value = str(value)
+        if normalized_value in seen_values:
+            continue
+        seen_values.add(normalized_value)
+        deduped_values.append(normalized_value)
+
+    return deduped_values
+
+
+def _resolve_service_chore_ids(
+    coordinator: "ChoreOpsDataCoordinator",
+    call_data: dict[str, Any],
+) -> list[str]:
+    """Resolve optional chore filters from IDs first, then names."""
+    chore_ids = _dedupe_service_string_list(
+        cast("list[str] | None", call_data.get(const.SERVICE_FIELD_CHORE_IDS))
+    )
+    if chore_ids:
+        for chore_id in chore_ids:
+            if chore_id not in coordinator.chores_data:
+                raise HomeAssistantError(
+                    translation_domain=const.DOMAIN,
+                    translation_key=const.TRANS_KEY_ERROR_NOT_FOUND,
+                    translation_placeholders={
+                        "entity_type": const.LABEL_CHORE,
+                        "name": chore_id,
+                    },
+                )
+        return chore_ids
+
+    chore_names = _dedupe_service_string_list(
+        cast("list[str] | None", call_data.get(const.SERVICE_FIELD_CHORE_NAMES))
+    )
+    resolved_chore_ids: list[str] = []
+    for chore_name in chore_names:
+        resolved_chore_ids.append(
+            get_item_id_or_raise(coordinator, const.ITEM_TYPE_CHORE, chore_name)
+        )
+    return resolved_chore_ids
+
+
+def _resolve_service_user_ids(
+    coordinator: "ChoreOpsDataCoordinator",
+    call_data: dict[str, Any],
+) -> list[str]:
+    """Resolve optional assignee filters from IDs first, then names."""
+    user_ids = _dedupe_service_string_list(
+        cast("list[str] | None", call_data.get(const.SERVICE_FIELD_USER_IDS))
+    )
+    if user_ids:
+        for user_id in user_ids:
+            if user_id not in coordinator.assignees_data:
+                raise HomeAssistantError(
+                    translation_domain=const.DOMAIN,
+                    translation_key=const.TRANS_KEY_ERROR_NOT_FOUND,
+                    translation_placeholders={
+                        "entity_type": const.LABEL_ASSIGNEE,
+                        "name": user_id,
+                    },
+                )
+        return user_ids
+
+    user_names = _dedupe_service_string_list(
+        cast("list[str] | None", call_data.get(const.SERVICE_FIELD_USER_NAMES))
+    )
+    resolved_user_ids: list[str] = []
+    for user_name in user_names:
+        resolved_user_ids.append(
+            get_item_id_or_raise(
+                coordinator,
+                const.ITEM_TYPE_USER,
+                user_name,
+                role=const.ROLE_ASSIGNEE,
+            )
+        )
+    return resolved_user_ids
+
+
 def _build_service_chore_validation_data(
     data_input: dict[str, Any],
     assigned_assignee_ids: list[str],
@@ -477,6 +573,34 @@ SKIP_CHORE_DUE_DATE_SCHEMA = vol.Schema(
             vol.Optional(const.SERVICE_FIELD_USER_NAME): cv.string,
             vol.Optional(const.SERVICE_FIELD_USER_ID): cv.string,
             vol.Optional(const.SERVICE_FIELD_MARK_AS_MISSED, default=False): cv.boolean,
+        }
+    )
+)
+
+RESCHEDULE_CHORES_AFTER_SCHEMA = vol.Schema(
+    _with_service_target_fields(
+        {
+            vol.Required(const.SERVICE_FIELD_AFTER): cv.datetime,
+            vol.Optional(const.SERVICE_FIELD_CHORE_IDS): vol.All(
+                cv.ensure_list, [cv.string]
+            ),
+            vol.Optional(const.SERVICE_FIELD_CHORE_NAMES): vol.All(
+                cv.ensure_list, [cv.string]
+            ),
+            vol.Optional(const.SERVICE_FIELD_USER_IDS): vol.All(
+                cv.ensure_list, [cv.string]
+            ),
+            vol.Optional(const.SERVICE_FIELD_USER_NAMES): vol.All(
+                cv.ensure_list, [cv.string]
+            ),
+            vol.Optional(
+                const.SERVICE_FIELD_RESCHEDULE_SHARED,
+                default=False,
+            ): cv.boolean,
+            vol.Optional(
+                const.SERVICE_FIELD_SKIP_NON_RECURRING,
+                default=False,
+            ): cv.boolean,
         }
     )
 )
@@ -1800,6 +1924,61 @@ def async_setup_services(hass: HomeAssistant):
         const.SERVICE_SKIP_CHORE_DUE_DATE,
         handle_skip_chore_due_date,
         schema=SKIP_CHORE_DUE_DATE_SCHEMA,
+    )
+
+    async def handle_reschedule_chores_after(call: ServiceCall) -> dict[str, Any]:
+        """Handle rescheduling multiple chores to occur after a boundary datetime."""
+        entry_id = _resolve_target_entry_id(hass, dict(call.data))
+        if not entry_id:
+            raise HomeAssistantError(
+                translation_domain=const.DOMAIN,
+                translation_key=const.TRANS_KEY_ERROR_MSG_NO_ENTRY_FOUND,
+            )
+
+        coordinator = _get_coordinator_by_entry_id(hass, entry_id)
+        after_dt = _normalize_service_datetime_input(
+            call.data[const.SERVICE_FIELD_AFTER]
+        )
+        if after_dt is None:
+            raise HomeAssistantError(
+                translation_domain=const.DOMAIN,
+                translation_key=const.TRANS_KEY_ERROR_INVALID_DATE_FORMAT,
+            )
+        if after_dt < dt_util.utcnow():
+            raise HomeAssistantError(
+                translation_domain=const.DOMAIN,
+                translation_key=const.TRANS_KEY_ERROR_DATE_IN_PAST,
+            )
+
+        chore_ids = _resolve_service_chore_ids(coordinator, dict(call.data))
+        user_ids = _resolve_service_user_ids(coordinator, dict(call.data))
+        response_payload = await coordinator.chore_manager.reschedule_chores_after(
+            after_dt,
+            chore_ids=chore_ids,
+            assignee_ids=user_ids,
+            reschedule_shared=bool(
+                call.data.get(const.SERVICE_FIELD_RESCHEDULE_SHARED, False)
+            ),
+            skip_non_recurring=bool(
+                call.data.get(const.SERVICE_FIELD_SKIP_NON_RECURRING, False)
+            ),
+        )
+
+        const.LOGGER.info(
+            "Rescheduled chores after %s (updated=%s skipped=%s)",
+            after_dt.isoformat(),
+            response_payload["updated_count"],
+            response_payload["skipped_count"],
+        )
+        await coordinator.async_request_refresh()
+        return response_payload
+
+    hass.services.async_register(
+        const.DOMAIN,
+        const.SERVICE_RESCHEDULE_CHORES_AFTER,
+        handle_reschedule_chores_after,
+        schema=RESCHEDULE_CHORES_AFTER_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     # ==========================================================================

--- a/custom_components/choreops/services.yaml
+++ b/custom_components/choreops/services.yaml
@@ -787,10 +787,91 @@ skip_chore_due_date:
     mark_as_missed:
       name: "Mark as Missed"
       description: >
-        When true, records this skip as a missed chore in the assignee's statistics.
-        Useful for tracking intentional skips separately from automated overdue resets.
+        If enabled, record the skipped due date as a missed occurrence before
+        rescheduling. For shared chores, all assigned users are marked missed.
       required: false
-      default: false
+      example: false
+      selector:
+        boolean:
+
+reschedule_chores_after:
+  name: "Reschedule Chores After"
+  description: >
+    Reschedule one or more chores so their next due date falls after the specified
+    date and time. Recurring chores advance to the next scheduled occurrence after
+    the boundary. Non-recurring chores due on or before the boundary move to the
+    boundary unless skip_non_recurring is enabled. Shared chores are skipped unless
+    reschedule_shared is enabled.
+  fields:
+    config_entry_id:
+      name: "Config Entry ID (Optional)"
+      description: "Use this if you have more than one ChoreOps setup. It targets one specific setup."
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+    config_entry_title:
+      name: "Config Entry Name (Optional)"
+      description: "Use this if you have more than one ChoreOps setup and they each have unique names. If names repeat, use Config Entry ID."
+      required: false
+      example: "Family Chores"
+      selector:
+        text:
+    after:
+      name: "After"
+      description: "Boundary date and time. Chores due on or before this value are considered for rescheduling."
+      required: true
+      example: "2026-07-14T18:00:00Z"
+      selector:
+        datetime: {}
+    chore_ids:
+      name: "Chore IDs"
+      description: "Optional list of chore IDs to target. If provided, these IDs take precedence over chore_names."
+      required: false
+      example:
+        - "abc123"
+        - "def456"
+      selector:
+        object:
+    chore_names:
+      name: "Chore Names"
+      description: "Optional list of chore names to target when chore_ids are not provided."
+      required: false
+      example:
+        - "Take Out Trash"
+        - "Feed Cat"
+      selector:
+        object:
+    user_ids:
+      name: "User IDs"
+      description: "Optional list of assignee IDs to limit independent chore updates. If provided, these IDs take precedence over user_names."
+      required: false
+      example:
+        - "user-abc123"
+        - "user-def456"
+      selector:
+        object:
+    user_names:
+      name: "User Names"
+      description: "Optional list of assignee names to limit independent chore updates when user_ids are not provided."
+      required: false
+      example:
+        - "Alice"
+        - "Bob"
+      selector:
+        object:
+    reschedule_shared:
+      name: "Reschedule Shared Chores"
+      description: "Enable this to allow shared and rotation chores to be rescheduled. This affects all assignees on those chores."
+      required: false
+      example: false
+      selector:
+        boolean:
+    skip_non_recurring:
+      name: "Skip Non-Recurring Chores"
+      description: "Enable this to leave non-recurring chores unchanged instead of moving their due date to the boundary."
+      required: false
+      example: false
       selector:
         boolean:
 

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -3052,6 +3052,53 @@
         }
       }
     },
+    "reschedule_chores_after": {
+      "name": "Reschedule Chores After",
+      "description": "Reschedule one or more chores so their next due date falls after the specified date and time. Recurring chores advance to the next scheduled occurrence after the boundary. Non-recurring chores due on or before the boundary move to the boundary unless skip_non_recurring is enabled. Shared chores are skipped unless reschedule_shared is enabled.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config Entry ID (Optional)",
+          "description": "Use this if you have more than one ChoreOps setup. It targets one specific setup.",
+          "example": "abc123def456"
+        },
+        "config_entry_title": {
+          "name": "Config Entry Name (Optional)",
+          "description": "Use this if you have more than one ChoreOps setup and they each have unique names. If names repeat, use Config Entry ID.",
+          "example": "Family Chores"
+        },
+        "after": {
+          "name": "After",
+          "description": "Boundary date and time. Chores due on or before this value are considered for rescheduling.",
+          "example": "2026-07-14T18:00:00Z"
+        },
+        "chore_ids": {
+          "name": "Chore IDs",
+          "description": "Optional list of chore IDs to target. If provided, these IDs take precedence over chore_names."
+        },
+        "chore_names": {
+          "name": "Chore Names",
+          "description": "Optional list of chore names to target when chore_ids are not provided."
+        },
+        "user_ids": {
+          "name": "User IDs",
+          "description": "Optional list of assignee IDs to limit independent chore updates. If provided, these IDs take precedence over user_names."
+        },
+        "user_names": {
+          "name": "User Names",
+          "description": "Optional list of assignee names to limit independent chore updates when user_ids are not provided."
+        },
+        "reschedule_shared": {
+          "name": "Reschedule Shared Chores",
+          "description": "Enable this to allow shared and rotation chores to be rescheduled. This affects all assignees on those chores.",
+          "example": "false"
+        },
+        "skip_non_recurring": {
+          "name": "Skip Non-Recurring Chores",
+          "description": "Enable this to leave non-recurring chores unchanged instead of moving their due date to the boundary.",
+          "example": "false"
+        }
+      }
+    },
     "skip_chore_due_date": {
       "name": "Skip Chore Due Date",
       "description": "Skip the current due date of a recurring chore. This service immediately reschedules the chore's due date based on its recurring frequency and resets its state to pending. Any pending claims or approvals will be removed. For independent chores, optionally provide a user_name to skip only for that user.",

--- a/tests/test_chore_services.py
+++ b/tests/test_chore_services.py
@@ -980,9 +980,171 @@ class TestResetAllChoresService:
             get_assignee_state_for_chore(coordinator, zoe_id, shared_first_chore)
             == CHORE_STATE_PENDING
         )
+
+
+# ============================================================================
+# TEST CLASS: Reschedule Chores After Service
+# ============================================================================
+
+
+class TestRescheduleChoresAfterService:
+    """Test reschedule_chores_after service behavior and targeting rules."""
+
+    @pytest.mark.asyncio
+    async def test_reschedule_chores_after_prefers_chore_ids_over_names(
+        self,
+        hass: HomeAssistant,
+        setup_chore_services_scenario: SetupResult,
+    ) -> None:
+        """Explicit chore_ids should take precedence over chore_names filters."""
+        coordinator = setup_chore_services_scenario.coordinator
+        zoe_id = setup_chore_services_scenario.assignee_ids["Zoë"]
+        independent_chore_id = setup_chore_services_scenario.chore_ids[
+            "Independent Daily Task"
+        ]
+        shared_chore_id = setup_chore_services_scenario.chore_ids[
+            "Shared All Daily Task"
+        ]
+
+        original_independent_due = get_assignee_due_date_for_chore(
+            coordinator, independent_chore_id, zoe_id
+        )
+        original_shared_due = get_chore_due_date(coordinator, shared_chore_id)
+        assert original_independent_due is not None
+        assert original_shared_due is not None
+
+        boundary = dt_util.utcnow() + timedelta(days=3)
+        response = await hass.services.async_call(
+            const.DOMAIN,
+            const.SERVICE_RESCHEDULE_CHORES_AFTER,
+            {
+                const.SERVICE_FIELD_AFTER: boundary,
+                const.SERVICE_FIELD_CHORE_IDS: [independent_chore_id],
+                const.SERVICE_FIELD_CHORE_NAMES: ["Shared All Daily Task"],
+                const.SERVICE_FIELD_USER_NAMES: ["Zoë"],
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+        assert response["updated_count"] == 1
+        assert response["skipped_count"] == 0
+        assert response["updated"][0]["chore_id"] == independent_chore_id
+        assert response["updated"][0]["user_id"] == zoe_id
+
+        new_independent_due = get_assignee_due_date_for_chore(
+            coordinator, independent_chore_id, zoe_id
+        )
+        assert new_independent_due is not None
+        assert datetime.fromisoformat(new_independent_due) > boundary
+        assert new_independent_due != original_independent_due
+        assert get_chore_due_date(coordinator, shared_chore_id) == original_shared_due
+
+    @pytest.mark.asyncio
+    async def test_reschedule_chores_after_shared_requires_opt_in(
+        self,
+        hass: HomeAssistant,
+        setup_chore_services_scenario: SetupResult,
+    ) -> None:
+        """Shared chores should only reschedule when reschedule_shared is enabled."""
+        coordinator = setup_chore_services_scenario.coordinator
+        shared_chore_id = setup_chore_services_scenario.chore_ids[
+            "Shared All Daily Task"
+        ]
+        original_due = get_chore_due_date(coordinator, shared_chore_id)
+        assert original_due is not None
+
+        boundary = dt_util.utcnow() + timedelta(days=3)
+        skipped_response = await hass.services.async_call(
+            const.DOMAIN,
+            const.SERVICE_RESCHEDULE_CHORES_AFTER,
+            {
+                const.SERVICE_FIELD_AFTER: boundary,
+                const.SERVICE_FIELD_CHORE_NAMES: ["Shared All Daily Task"],
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+        assert skipped_response["updated_count"] == 0
+        assert skipped_response["skipped_count"] == 1
+        assert skipped_response["skipped"][0]["reason"] == "shared_not_enabled"
+        assert get_chore_due_date(coordinator, shared_chore_id) == original_due
+
+        updated_response = await hass.services.async_call(
+            const.DOMAIN,
+            const.SERVICE_RESCHEDULE_CHORES_AFTER,
+            {
+                const.SERVICE_FIELD_AFTER: boundary,
+                const.SERVICE_FIELD_CHORE_NAMES: ["Shared All Daily Task"],
+                const.SERVICE_FIELD_RESCHEDULE_SHARED: True,
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+        assert updated_response["updated_count"] == 1
+        assert updated_response["skipped_count"] == 0
+        assert updated_response["updated"][0]["shared"] is True
+
+        new_due = get_chore_due_date(coordinator, shared_chore_id)
+        assert new_due is not None
+        assert datetime.fromisoformat(new_due) > boundary
+        assert new_due != original_due
+
+    @pytest.mark.asyncio
+    async def test_reschedule_chores_after_skip_non_recurring_leaves_due_date(
+        self,
+        hass: HomeAssistant,
+        setup_chore_services_scenario: SetupResult,
+    ) -> None:
+        """skip_non_recurring should leave non-recurring chores unchanged."""
+        coordinator = setup_chore_services_scenario.coordinator
+        zoe_id = setup_chore_services_scenario.assignee_ids["Zoë"]
+
+        chore_response = await hass.services.async_call(
+            const.DOMAIN,
+            const.SERVICE_ADD_CHORE,
+            {
+                const.SERVICE_FIELD_NAME: "Vacation Manual Review Task",
+                const.SERVICE_FIELD_ASSIGNED_USER_IDS: ["Zoë"],
+                const.SERVICE_FIELD_FREQUENCY: const.FREQUENCY_NONE,
+                const.SERVICE_FIELD_POINTS: 5,
+                const.SERVICE_FIELD_APPROVAL_RESET_TYPE: const.APPROVAL_RESET_AT_MIDNIGHT_ONCE,
+                const.SERVICE_FIELD_OVERDUE_HANDLING: const.OVERDUE_HANDLING_AT_DUE_DATE,
+            },
+            blocking=True,
+            return_response=True,
+        )
+        chore_id = chore_response[const.SERVICE_FIELD_CHORE_CRUD_ID]
+        due_dt = dt_util.utcnow() + timedelta(days=1)
+        await coordinator.chore_manager.set_due_date(
+            chore_id, due_dt, assignee_id=zoe_id
+        )
+
+        original_due = get_assignee_due_date_for_chore(coordinator, chore_id, zoe_id)
+        assert original_due is not None
+
+        boundary = dt_util.utcnow() + timedelta(days=3)
+        response = await hass.services.async_call(
+            const.DOMAIN,
+            const.SERVICE_RESCHEDULE_CHORES_AFTER,
+            {
+                const.SERVICE_FIELD_AFTER: boundary,
+                const.SERVICE_FIELD_CHORE_IDS: [chore_id],
+                const.SERVICE_FIELD_USER_IDS: [zoe_id],
+                const.SERVICE_FIELD_SKIP_NON_RECURRING: True,
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+        assert response["updated_count"] == 0
+        assert response["skipped_count"] == 1
+        assert response["skipped"][0]["reason"] == "non_recurring_skipped"
         assert (
-            get_assignee_state_for_chore(coordinator, max_id, shared_first_chore)
-            == CHORE_STATE_PENDING
+            get_assignee_due_date_for_chore(coordinator, chore_id, zoe_id)
+            == original_due
         )
 
 


### PR DESCRIPTION
## Summary

Adds a new `reschedule_chores_after` service so families can bulk move chores that fall before a cutoff date:
- target chores by ID or name, with IDs taking precedence
- target users by ID or name, with IDs taking precedence
- require explicit opt-in before changing shared chores
- optionally leave non-recurring chores untouched instead of moving them

Refs #99

## Change type

- [ ] Dashboard runtime asset sync
- [ ] Translation asset sync
- [x] Core integration logic change
- [ ] Documentation only

## Release notes

Adds a new service that can bulk reschedule chores after a chosen date, which is useful for temporary schedule disruptions such as travel or school breaks.

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/test_chore_services.py -v --tb=line`
- [x] Full release-candidate validation had already passed earlier on the combined release-ready working tree:
  - `python -m pytest tests/ -v --tb=line`
