### PR TITLE
feat(dashboard): add universal points precision setting

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -791,6 +791,7 @@ OPTIONS_FLOW_MENU_MANAGE_PREFIX: Final = "manage_"
 
 # Global Settings
 CONF_CALENDAR_SHOW_PERIOD: Final = "calendar_show_period"
+CONF_DASHBOARD_POINTS_PRECISION: Final = "dashboard_points_precision"
 CONF_DEFAULT_CHORE_POINTS: Final = "default_chore_points"
 CONF_POINTS_ADJUST_VALUES: Final = "points_adjust_values"
 CONF_POINTS_ICON: Final = "points_icon"
@@ -820,6 +821,7 @@ BACKUP_TAG_MANUAL: Final = "manual"  # User-initiated (never deleted)
 # System settings (ConfigFlow & OptionsFlow)
 CFOF_SYSTEM_INPUT_POINTS_LABEL: Final = "points_label"
 CFOF_SYSTEM_INPUT_POINTS_ICON: Final = "points_icon"
+CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION: Final = "dashboard_points_precision"
 CFOF_SYSTEM_INPUT_DEFAULT_CHORE_POINTS: Final = "default_chore_points"
 CFOF_SYSTEM_INPUT_UPDATE_INTERVAL: Final = "update_interval"
 CFOF_SYSTEM_INPUT_CALENDAR_SHOW_PERIOD: Final = "calendar_show_period"
@@ -931,6 +933,18 @@ NOTIFICATION_EVENT: Final = "mobile_app_notification_action"
 CONF_SHOW_LEGACY_ENTITIES: Final = "show_legacy_entities"
 CONF_KIOSK_MODE: Final = "kiosk_mode"
 CONF_ADMIN_APPROVAL_BYPASS: Final = "admin_approval_bypass"
+
+# Dashboard display settings
+DASHBOARD_POINTS_PRECISION_FIXED_0: Final = "fixed_0"
+DASHBOARD_POINTS_PRECISION_ADAPTIVE: Final = "adaptive"
+DASHBOARD_POINTS_PRECISION_FIXED_1: Final = "fixed_1"
+DASHBOARD_POINTS_PRECISION_FIXED_2: Final = "fixed_2"
+DASHBOARD_POINTS_PRECISION_OPTIONS: Final = [
+    DASHBOARD_POINTS_PRECISION_FIXED_0,
+    DASHBOARD_POINTS_PRECISION_ADAPTIVE,
+    DASHBOARD_POINTS_PRECISION_FIXED_1,
+    DASHBOARD_POINTS_PRECISION_FIXED_2,
+]
 
 # Badge Types
 BADGE_TYPE_ACHIEVEMENT_LINKED: Final = "achievement_linked"
@@ -1721,6 +1735,7 @@ DEFAULT_ASSIGNEE_POINTS_MULTIPLIER: Final = 1
 DEFAULT_SHOW_LEGACY_ENTITIES: Final = False
 DEFAULT_KIOSK_MODE: Final = False
 DEFAULT_ADMIN_APPROVAL_BYPASS: Final = True
+DEFAULT_DASHBOARD_POINTS_PRECISION: Final = DASHBOARD_POINTS_PRECISION_FIXED_0
 DEFAULT_NOTIFY_ON_APPROVAL = True
 DEFAULT_NOTIFY_ON_CLAIM = True
 DEFAULT_NOTIFY_ON_DISAPPROVAL = True
@@ -1746,6 +1761,7 @@ DEFAULT_ZERO: Final = 0
 DEFAULT_SYSTEM_SETTINGS: Final = {
     CONF_POINTS_LABEL: DEFAULT_POINTS_LABEL,
     CONF_POINTS_ICON: DEFAULT_POINTS_ICON,
+    CONF_DASHBOARD_POINTS_PRECISION: DEFAULT_DASHBOARD_POINTS_PRECISION,
     CONF_DEFAULT_CHORE_POINTS: DEFAULT_CHORE_POINTS,
     CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
     CONF_CALENDAR_SHOW_PERIOD: DEFAULT_CALENDAR_SHOW_PERIOD,
@@ -2528,6 +2544,7 @@ ATTR_HELPER_CONTRACT_VERSION: Final = "helper_contract_version"
 ATTR_CHORE_IS_TODAY_AM: Final = "is_today_am"
 ATTR_CHORE_LABELS: Final = "labels"
 ATTR_CHORE_PRIMARY_GROUP: Final = "primary_group"
+ATTR_DASHBOARD_CONFIG: Final = "dashboard_config"
 ATTR_SHARD_COUNT: Final = "shard_count"
 ATTR_SHARD_INDEX: Final = "shard_index"
 ATTR_SHARD_RUNTIME: Final = "shard_runtime"
@@ -2535,6 +2552,7 @@ ATTR_UI_CONTROL: Final = "ui_control"
 ATTR_UI_ROOT: Final = "ui_root"
 ATTR_UI_ROOT_SHARED_ADMIN: Final = "shared_admin"
 ATTR_UI_ROOT_SELECTED_USER: Final = "selected_user"
+ATTR_POINTS_PRECISION: Final = "points_precision"
 
 # Rotation and availability dashboard attributes
 ATTR_CHORE_CLAIM_MODE: Final = "claim_mode"
@@ -3323,6 +3341,7 @@ TRANS_KEY_CFOF_DATA_RECOVERY_SELECTION: Final = "data_recovery_selection"
 
 # Backup Management
 TRANS_KEY_CFOF_BACKUP_ACTIONS_MENU: Final = "backup_actions_menu"
+TRANS_KEY_CFOF_DASHBOARD_POINTS_PRECISION: Final = "dashboard_points_precision"
 TRANS_KEY_CFOF_SELECT_BACKUP_TO_DELETE: Final = "select_backup_to_delete"
 TRANS_KEY_CFOF_SELECT_BACKUP_TO_RESTORE: Final = "select_backup_to_restore"
 

--- a/custom_components/choreops/dashboards/preferences/admin-peruser-kidschores-classic.md
+++ b/custom_components/choreops/dashboards/preferences/admin-peruser-kidschores-classic.md
@@ -8,13 +8,10 @@ This template has configurable `pref_*` values in approval action layout.
 - It is intended for smaller households, roughly in the same `20-40` chores-per-user range as the other inline-only classic layouts.
 - It is not a shard-aware high-density admin template.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in classic admin summary and chore-value displays.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the selected dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Approval actions
 

--- a/custom_components/choreops/dashboards/preferences/admin-peruser-v1.md
+++ b/custom_components/choreops/dashboards/preferences/admin-peruser-v1.md
@@ -10,14 +10,10 @@ This template has configurable `pref_*` values across the Approval Center and do
 - Home Assistant theme variables remain the default source for colors.
 - The accent preference below is an intentional product-specific exception for approval and claimed-state emphasis and is declared as a template variable for easier long-term maintenance.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in admin economy surfaces.
-  - Applies to available points totals, weekly/average point metrics, point action chips, and bonus/penalty values.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the selected dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Approval Center
 

--- a/custom_components/choreops/dashboards/preferences/admin-shared-kidschores-classic.md
+++ b/custom_components/choreops/dashboards/preferences/admin-shared-kidschores-classic.md
@@ -8,13 +8,10 @@ This template has configurable `pref_*` values in approval action layout.
 - It is intended for smaller households, roughly in the same `20-40` chores-per-user range as the other inline-only classic layouts.
 - It is not a shard-aware high-density admin template.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in classic admin summary and chore-value displays.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the selected dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Approval actions
 

--- a/custom_components/choreops/dashboards/preferences/admin-shared-v1.md
+++ b/custom_components/choreops/dashboards/preferences/admin-shared-v1.md
@@ -18,14 +18,10 @@
 - Home Assistant theme variables remain the default source for colors.
 - The accent preference below is an intentional product-specific exception for approval and claimed-state emphasis and is declared as a template variable for easier long-term maintenance.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in admin economy and chore-value surfaces.
-  - Applies to available points totals, weekly/average point metrics, point action chips, and bonus/penalty values.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the selected dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Approval Center
 

--- a/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
@@ -22,13 +22,10 @@
 - Home Assistant theme variables remain the default source for colors.
 - The accent preferences below are intentional product-specific exceptions for chore-state semantics and are declared as template variables for easier long-term maintenance.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in the welcome card.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the assignee dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Chores
 

--- a/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
@@ -29,13 +29,10 @@
 - Includes chore-oriented summary counts such as overdue and due today.
 - Shows points only when gamification is enabled.
 - Does **not** include reward status or reward summary counts.
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in the header.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the assignee dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Chores
 

--- a/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
@@ -16,13 +16,10 @@
 - Home Assistant theme variables remain the default source for colors.
 - The accent preferences below are intentional product-specific exceptions for chore-state semantics and are declared as template variables for easier long-term maintenance.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how the welcome-card points balance is formatted.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the assignee dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 - `pref_chore_row_variant` (default: `standard`)
   - Selects which shared chore row template the Chores card uses.

--- a/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
@@ -19,13 +19,10 @@
 
 ## Header tint preference
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted in the welcome card.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the assignee dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 - `pref_primary_tint_mix_pct` (default: `14`)
   - Controls the percent of `var(--primary-color)` mixed into the background fill when header background fill is enabled.

--- a/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
@@ -8,14 +8,10 @@
 - It is intended for roughly `20-40` chores per user.
 - It is not a shard-aware high-density template and should not be used as the scale target for larger chore lists.
 
-- `pref_points_precision` (default: `fixed_0`)
-  - Controls how point values are formatted across the classic dashboard point displays.
-  - Applies to the welcome card, chore point values, reward costs, and showcase totals.
-  - `fixed_0` shows a rounded whole-number display for compact layouts.
-  - `adaptive` shows whole numbers when possible, otherwise up to 2 decimals.
-  - `fixed_1` always shows 1 decimal place.
-  - `fixed_2` always shows 2 decimal places.
-  - Allowed: `fixed_0`, `adaptive`, `fixed_1`, `fixed_2`.
+- Universal points precision
+  - This template now reads the resolved precision mode from the assignee dashboard helper contract instead of a local `pref_points_precision` variable.
+  - The source of truth is the ChoreOps General Options setting surfaced as `dashboard_config.points_precision`.
+  - `fixed_0` remains the fallback when the helper value is missing during transition.
 
 ## Card: Chores
 

--- a/custom_components/choreops/dashboards/templates/admin-peruser-kidschores-classic.yaml
+++ b/custom_components/choreops/dashboards/templates/admin-peruser-kidschores-classic.yaml
@@ -246,9 +246,6 @@ views:
 
                   << template_snippets.user_override_helper >>
 
-                  {%- set pref_points_precision = 'fixed_0' -%}
-
-
                   {#-- 2. Dynamic Lookups & Validations --#}
 
                   << template_snippets.admin_setup_peruser >>
@@ -257,6 +254,7 @@ views:
 
                   << template_snippets.admin_validation_invalid_selection >>
 
+                  {%- set pref_points_precision = ((state_attr(selected_dashboard_helper, 'dashboard_config') or {}).get('points_precision', 'fixed_0')) if has_selected_dashboard_helper else 'fixed_0' -%}
                   {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
                   {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
                     {%- set pref_points_precision = 'fixed_0' -%}
@@ -320,10 +318,18 @@ views:
                       {%- set badge_display = "" -%}
                     {%- endif -%}
 
+                    {%- set points_value_numeric = points_value | float(default=0) -%}
+                    {%- set points_value_display = (
+                      (points_value_numeric | round(2) | string | regex_replace('\.?0+$', '')) if pref_points_precision == 'adaptive'
+                      else ('%.1f' | format(points_value_numeric | round(2))) if pref_points_precision == 'fixed_1'
+                      else ('%.2f' | format(points_value_numeric | round(2))) if pref_points_precision == 'fixed_2'
+                      else ('%.0f' | format(points_value_numeric | round(2)))
+                    ) -%}
+
 
                     {%- set content =
                       "## 👨‍👩‍👧 " ~ ui.get('approver_dashboard_for', 'err-approver_dashboard_for') ~ ": " ~ name ~ " \n"
-                      "#### <ha-icon icon=" ~ points_icon ~ "></ha-icon>&nbsp;&nbsp;" ~ points_label ~ ": &nbsp;&nbsp;" ~ (((points_value | round(2)) | string | regex_replace('\.?0+$', ''))) ~ "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" ~ badge_display ~ " \n\n" -%}
+                      "#### <ha-icon icon=" ~ points_icon ~ "></ha-icon>&nbsp;&nbsp;" ~ points_label ~ ": &nbsp;&nbsp;" ~ points_value_display ~ "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" ~ badge_display ~ " \n\n" -%}
 
                     {#-- STATUS TABLE: Pending Approvals and Overdue --#}
                     {%- set status_table = "<table width=100% border=0 cellspacing=0 cellpadding=0>" -%}
@@ -1005,7 +1011,7 @@ views:
                       'type': 'custom:mushroom-template-card',
                       'entity': bonus_button_eid,
                       'primary': ui.get('bonus', 'err-bonus') ~ ": " ~ bonus_name,
-                      'secondary': '⭐ ' ~ ui.get('bonus', 'err-bonus') ~ ':  ' ~ (bonus_points | string) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (bonuses_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
+                      'secondary': '⭐ ' ~ ui.get('bonus', 'err-bonus') ~ ':  ' ~ (((bonus_points | float(default=0) | round(2) | string | regex_replace('\.?0+$', '')) if pref_points_precision == 'adaptive' else ('%.1f' | format(bonus_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_1' else ('%.2f' | format(bonus_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_2' else ('%.0f' | format(bonus_points | float(default=0) | round(2))))) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (bonuses_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
                       'multiline_secondary': 'true',
                       'layout': 'vertical',
                       'icon': bonus_icon,
@@ -1165,7 +1171,7 @@ views:
                       'type': 'custom:mushroom-template-card',
                       'entity': penalty_button_eid,
                       'primary': ui.get('penalty', 'err-penalty') ~ ": " ~ penalty_name,
-                      'secondary': '💥 ' ~ ui.get('penalty', 'err-penalty') ~ ':  ' ~ (penalty_points | string) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (penalties_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
+                      'secondary': '💥 ' ~ ui.get('penalty', 'err-penalty') ~ ':  ' ~ (((penalty_points | float(default=0) | round(2) | string | regex_replace('\.?0+$', '')) if pref_points_precision == 'adaptive' else ('%.1f' | format(penalty_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_1' else ('%.2f' | format(penalty_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_2' else ('%.0f' | format(penalty_points | float(default=0) | round(2))))) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (penalties_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
                       'multiline_secondary': 'true',
                       'layout': 'vertical',
                       'icon': penalty_icon,

--- a/custom_components/choreops/dashboards/templates/admin-peruser-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/admin-peruser-v1.yaml
@@ -940,7 +940,7 @@ views:
 
               {%- set pref_claim_accent = '#a957fa' -%}
 
-              {%- set pref_points_precision = 'fixed_0' -%}
+              {#-- points precision resolves from the selected dashboard helper below --#}
 
               {%- set pref_chore_selector_column_count = 3 -%}
 
@@ -979,6 +979,7 @@ views:
               {%- set pref_chore_management_primary_tint_mix_pct = pref_chore_management_primary_tint_mix_pct | int(default=14) -%}
               {%- set pref_chore_management_show_header_background = (pref_chore_management_show_header_background | default('true') | string | lower) == 'true' -%}
               {%- set pref_chore_management_show_header_thin_border = (pref_chore_management_show_header_thin_border | default('true') | string | lower) == 'true' -%}
+              {%- set pref_points_precision = ((state_attr(selected_dashboard_helper, 'dashboard_config') or {}).get('points_precision', 'fixed_0')) if has_selected_dashboard_helper else 'fixed_0' -%}
               {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
               {%- set pref_chore_selector_column_count = pref_chore_selector_column_count | int(default=3) -%}
               {%- set pref_chore_action_column_count = pref_chore_action_column_count | int(default=4) -%}
@@ -2272,7 +2273,7 @@ views:
 
               {%- set pref_economy_management_show_header_thin_border = true -%}
 
-              {%- set pref_points_precision = 'fixed_0' -%}
+              {#-- points precision resolves from the selected dashboard helper below --#}
 
 
               {#-- 2. Dynamic Lookups & Validations --#}
@@ -2307,6 +2308,7 @@ views:
               {%- set pref_economy_management_primary_tint_mix_pct = pref_economy_management_primary_tint_mix_pct | int(default=14) -%}
               {%- set pref_economy_management_show_header_background = (pref_economy_management_show_header_background | default('true') | string | lower) == 'true' -%}
               {%- set pref_economy_management_show_header_thin_border = (pref_economy_management_show_header_thin_border | default('true') | string | lower) == 'true' -%}
+              {%- set pref_points_precision = ((state_attr(selected_dashboard_helper, 'dashboard_config') or {}).get('points_precision', 'fixed_0')) if has_selected_dashboard_helper else 'fixed_0' -%}
               {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
               {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
                 {%- set pref_points_precision = 'fixed_0' -%}

--- a/custom_components/choreops/dashboards/templates/admin-shared-kidschores-classic.yaml
+++ b/custom_components/choreops/dashboards/templates/admin-shared-kidschores-classic.yaml
@@ -248,9 +248,6 @@ views:
 
                   << template_snippets.user_override_helper >>
 
-                  {%- set pref_points_precision = 'fixed_0' -%}
-
-
                   {#-- 2. Dynamic Lookups & Validations --#}
 
                   << template_snippets.admin_setup_shared >>
@@ -259,6 +256,7 @@ views:
 
                   << template_snippets.admin_validation_invalid_selection >>
 
+                  {%- set pref_points_precision = ((state_attr(selected_dashboard_helper, 'dashboard_config') or {}).get('points_precision', 'fixed_0')) if has_selected_dashboard_helper else 'fixed_0' -%}
                   {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
                   {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
                     {%- set pref_points_precision = 'fixed_0' -%}
@@ -322,10 +320,18 @@ views:
                       {%- set badge_display = "" -%}
                     {%- endif -%}
 
+                    {%- set points_value_numeric = points_value | float(default=0) -%}
+                    {%- set points_value_display = (
+                      (points_value_numeric | round(2) | string | regex_replace('\.?0+$', '')) if pref_points_precision == 'adaptive'
+                      else ('%.1f' | format(points_value_numeric | round(2))) if pref_points_precision == 'fixed_1'
+                      else ('%.2f' | format(points_value_numeric | round(2))) if pref_points_precision == 'fixed_2'
+                      else ('%.0f' | format(points_value_numeric | round(2)))
+                    ) -%}
+
 
                     {%- set content =
                       "## 👨‍👩‍👧 " ~ ui.get('approver_dashboard_for', 'err-approver_dashboard_for') ~ ": " ~ name ~ " \n"
-                      "#### <ha-icon icon=" ~ points_icon ~ "></ha-icon>&nbsp;&nbsp;" ~ points_label ~ ": &nbsp;&nbsp;" ~ (((points_value | round(2)) | string | regex_replace('\.?0+$', ''))) ~ "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" ~ badge_display ~ " \n\n" -%}
+                      "#### <ha-icon icon=" ~ points_icon ~ "></ha-icon>&nbsp;&nbsp;" ~ points_label ~ ": &nbsp;&nbsp;" ~ points_value_display ~ "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" ~ badge_display ~ " \n\n" -%}
 
                     {#-- STATUS TABLE: Pending Approvals and Overdue --#}
                     {%- set status_table = "<table width=100% border=0 cellspacing=0 cellpadding=0>" -%}
@@ -1052,7 +1058,7 @@ views:
                       'type': 'custom:mushroom-template-card',
                       'entity': bonus_button_eid,
                       'primary': ui.get('bonus', 'err-bonus') ~ ": " ~ bonus_name,
-                      'secondary': '⭐ ' ~ ui.get('bonus', 'err-bonus') ~ ':  ' ~ (bonus_points | string) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (bonuses_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
+                      'secondary': '⭐ ' ~ ui.get('bonus', 'err-bonus') ~ ':  ' ~ (((bonus_points | float(default=0) | round(2) | string | regex_replace('\.?0+$', '')) if pref_points_precision == 'adaptive' else ('%.1f' | format(bonus_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_1' else ('%.2f' | format(bonus_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_2' else ('%.0f' | format(bonus_points | float(default=0) | round(2))))) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (bonuses_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
                       'multiline_secondary': 'true',
                       'layout': 'vertical',
                       'icon': bonus_icon,
@@ -1240,7 +1246,7 @@ views:
                       'type': 'custom:mushroom-template-card',
                       'entity': penalty_button_eid,
                       'primary': ui.get('penalty', 'err-penalty') ~ ": " ~ penalty_name,
-                      'secondary': '💥 ' ~ ui.get('penalty', 'err-penalty') ~ ':  ' ~ (penalty_points | string) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (penalties_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
+                      'secondary': '💥 ' ~ ui.get('penalty', 'err-penalty') ~ ':  ' ~ (((penalty_points | float(default=0) | round(2) | string | regex_replace('\.?0+$', '')) if pref_points_precision == 'adaptive' else ('%.1f' | format(penalty_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_1' else ('%.2f' | format(penalty_points | float(default=0) | round(2))) if pref_points_precision == 'fixed_2' else ('%.0f' | format(penalty_points | float(default=0) | round(2))))) ~ ' ' ~ ns.points_label ~ '\n' ~ '📊 ' ~ ui.get('applied', 'err-applied') ~ ':  ' ~ (penalties_applied | string) ~ ' ' ~ ui.get('times', 'err-times'),
                       'multiline_secondary': 'true',
                       'layout': 'vertical',
                       'icon': penalty_icon,

--- a/custom_components/choreops/dashboards/templates/admin-shared-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/admin-shared-v1.yaml
@@ -1024,7 +1024,7 @@ views:
 
               {%- set pref_claim_accent = '#a957fa' -%}
 
-              {%- set pref_points_precision = 'fixed_0' -%}
+              {#-- points precision resolves from the selected dashboard helper below --#}
 
               {%- set pref_chore_selector_column_count = 3 -%}
 
@@ -1047,6 +1047,7 @@ views:
               {%- set pref_chore_management_primary_tint_mix_pct = pref_chore_management_primary_tint_mix_pct | int(default=14) -%}
               {%- set pref_chore_management_show_header_background = (pref_chore_management_show_header_background | default('true') | string | lower) == 'true' -%}
               {%- set pref_chore_management_show_header_thin_border = (pref_chore_management_show_header_thin_border | default('true') | string | lower) == 'true' -%}
+              {%- set pref_points_precision = ((state_attr(selected_dashboard_helper, 'dashboard_config') or {}).get('points_precision', 'fixed_0')) if has_selected_dashboard_helper else 'fixed_0' -%}
               {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
               {%- set pref_chore_selector_column_count = pref_chore_selector_column_count | int(default=3) -%}
               {%- set pref_chore_action_column_count = pref_chore_action_column_count | int(default=4) -%}
@@ -2324,7 +2325,7 @@ views:
 
               {%- set pref_economy_management_show_header_thin_border = true -%}
 
-              {%- set pref_points_precision = 'fixed_0' -%}
+              {#-- points precision resolves from the selected dashboard helper below --#}
 
 
               {#-- 2. Dynamic Lookups & Validations --#}
@@ -2343,6 +2344,7 @@ views:
               {%- set pref_economy_management_primary_tint_mix_pct = pref_economy_management_primary_tint_mix_pct | int(default=14) -%}
               {%- set pref_economy_management_show_header_background = (pref_economy_management_show_header_background | default('true') | string | lower) == 'true' -%}
               {%- set pref_economy_management_show_header_thin_border = (pref_economy_management_show_header_thin_border | default('true') | string | lower) == 'true' -%}
+              {%- set pref_points_precision = ((state_attr(selected_dashboard_helper, 'dashboard_config') or {}).get('points_precision', 'fixed_0')) if has_selected_dashboard_helper else 'fixed_0' -%}
               {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
               {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
                 {%- set pref_points_precision = 'fixed_0' -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
@@ -126,6 +126,12 @@
   {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
   {%- set points_sensor = core_sensors.get('points_eid') -%}
   {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+  {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
+  {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+  {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+  {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+    {%- set pref_points_precision = 'fixed_0' -%}
+  {%- endif -%}
   {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
   {%- set chore_helper_eids = dashboard_helpers.get('chore_helper_eids', []) if dashboard_helpers is mapping else [] -%}
   {%- if chore_helper_eids is not iterable or chore_helper_eids is string -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/group_render_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/group_render_v1.yaml
@@ -56,6 +56,7 @@
 						'pref_due_accent': pref_due_accent,
 						'pref_overdue_accent': pref_overdue_accent,
 						'pref_steal_accent': pref_steal_accent,
+						'pref_points_precision': pref_points_precision,
 						'gamification_enabled': gamification_enabled,
 						'points_label': points_label,
 						'points_icon': points_icon

--- a/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
@@ -49,15 +49,7 @@ views:
 
                   << template_snippets.user_override_helper >>
 
-                  {%- set pref_points_precision = 'fixed_0' -%}  {#-- Controls point formatting. Allowed: fixed_0, adaptive, fixed_1, fixed_2. --#}
-
-
                   {#-- 2. Dynamic Lookups & Validations --#}
-
-                  {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
-                  {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
-                    {%- set pref_points_precision = 'fixed_0' -%}
-                  {%- endif -%}
 
                   << template_snippets.user_setup >>
 
@@ -67,11 +59,18 @@ views:
 
                     {#-- 3. Collect Data --#}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                     {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set total_sensor = core_sensors.get('chores_eid') -%}
                     {%- set highest_badge_entity = core_sensors.get('badges_eid') -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set points_value = (states(points_sensor) | float(default=0)) if points_sensor else 0 -%}
                     {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or 'Points' -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -55,15 +55,7 @@ views:
 
                     << template_snippets.user_override_helper | indent(width=20, first=true) >>
 
-                    {%- set pref_points_precision = 'fixed_0' -%}  {#-- Controls point formatting. Allowed: fixed_0, adaptive, fixed_1, fixed_2. --#}
-
-
                     {#-- 2. Dynamic Lookups & Validations --#}
-
-                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
-                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
-                      {%- set pref_points_precision = 'fixed_0' -%}
-                    {%- endif -%}
 
                     << template_snippets.user_setup | indent(width=20, first=true) >>
 
@@ -73,10 +65,17 @@ views:
 
                       {#-- 3. Collect Data --#}
                       {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                      {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                      {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                       {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
                       {%- set points_sensor = core_sensors.get('points_eid') -%}
                       {%- set total_sensor = core_sensors.get('chores_eid') -%}
-                      {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                      {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                      {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                      {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                        {%- set pref_points_precision = 'fixed_0' -%}
+                      {%- endif -%}
+                      {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                       {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                       {%- set points_value = (states(points_sensor) | float(default=0)) if points_sensor else 0 -%}
                       {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or ui.get('points_details', 'Points') -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
@@ -53,8 +53,6 @@ views:
 
                   << template_snippets.user_override_helper >>
 
-                  {%- set pref_points_precision = 'fixed_0' -%}  {#-- Controls welcome-card points formatting. Allowed: fixed_0, adaptive, fixed_1, fixed_2. --#}
-
                   {%- set pref_primary_tint_mix_pct = 14 -%}  {#-- Percent of var(--primary-color) mixed into the welcome-card background when fill is enabled. Allowed: 0-100. --#}
 
                   {%- set pref_show_header_background = false -%}  {#-- Set to false to remove the welcome-card background fill and leave it transparent. Allowed: true, false. --#}
@@ -64,13 +62,9 @@ views:
 
                   {#-- 2. Dynamic Lookups & Validations --#}
 
-                  {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
                   {%- set pref_primary_tint_mix_pct = pref_primary_tint_mix_pct | int(default=14) -%}
                   {%- set pref_show_header_background = (pref_show_header_background | default('true') | string | lower) == 'true' -%}
                   {%- set pref_show_header_thin_border = (pref_show_header_thin_border | default('true') | string | lower) == 'true' -%}
-                  {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
-                    {%- set pref_points_precision = 'fixed_0' -%}
-                  {%- endif -%}
                   {%- if pref_primary_tint_mix_pct < 0 -%}
                     {%- set pref_primary_tint_mix_pct = 0 -%}
                   {%- elif pref_primary_tint_mix_pct > 100 -%}
@@ -85,11 +79,18 @@ views:
 
                     {#-- 3. Collect Data --#}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                     {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set total_sensor = core_sensors.get('chores_eid') -%}
                     {%- set highest_badge_entity = core_sensors.get('badges_eid') -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set points_value = (states(points_sensor) | float(default=0)) if points_sensor else 0 -%}
                     {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or 'Points' -%}

--- a/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
@@ -57,8 +57,6 @@ views:
 
                   {%- set pref_primary_tint_mix_pct = 14 -%}  {#-- Percent of var(--primary-color) mixed into the welcome-card background when fill is enabled. Allowed: 0-100. --#}
 
-                  {%- set pref_points_precision = 'fixed_0' -%}  {#-- Controls point formatting. Allowed: fixed_0, adaptive, fixed_1, fixed_2. --#}
-
                   {%- set pref_show_header_background = false -%}  {#-- Set to false to remove the welcome-card background fill and leave it transparent. Allowed: true, false. --#}
 
                   {%- set pref_show_header_thin_border = true -%}  {#-- Set to false to remove the thin outer border line. Accent borders are unaffected. Allowed: true, false. --#}
@@ -67,7 +65,6 @@ views:
                   {#-- 2. Dynamic Lookups & Validations --#}
 
                   {%- set pref_primary_tint_mix_pct = pref_primary_tint_mix_pct | int(default=14) -%}
-                  {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
                   {%- set pref_show_header_background = (pref_show_header_background | default('true') | string | lower) == 'true' -%}
                   {%- set pref_show_header_thin_border = (pref_show_header_thin_border | default('true') | string | lower) == 'true' -%}
                   {%- if pref_primary_tint_mix_pct < 0 -%}
@@ -75,10 +72,6 @@ views:
                   {%- elif pref_primary_tint_mix_pct > 100 -%}
                     {%- set pref_primary_tint_mix_pct = 100 -%}
                   {%- endif -%}
-                  {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
-                    {%- set pref_points_precision = 'fixed_0' -%}
-                  {%- endif -%}
-
                   << template_snippets.user_setup >>
 
                   << template_snippets.user_validation >>
@@ -87,11 +80,18 @@ views:
 
                     {#-- 3. Collect Data --#}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                     {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set total_sensor = core_sensors.get('chores_eid') -%}
                     {%- set highest_badge_entity = core_sensors.get('badges_eid') -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set points_value = (states(points_sensor) | float(default=0)) if points_sensor else 0 -%}
                     {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or 'Points' -%}
@@ -1531,6 +1531,18 @@ views:
                   {%- if not skip_render -%}
 
                     {#-- 3. Initialize --#}
+                    {%- macro format_points(value, mode='fixed_0') -%}
+                      {%- set numeric = value | float(default=0) | round(2) -%}
+                      {%- if mode == 'adaptive' -%}
+                        {{- numeric | string | regex_replace('\.?0+$', '') -}}
+                      {%- elif mode == 'fixed_1' -%}
+                        {{- '%.1f' | format(numeric) -}}
+                      {%- elif mode == 'fixed_2' -%}
+                        {{- '%.2f' | format(numeric) -}}
+                      {%- else -%}
+                        {{- '%.0f' | format(numeric) -}}
+                      {%- endif -%}
+                    {%- endmacro -%}
                     {%- set ns = namespace(
                       badges=[],
                       points_earned_all_time=0,
@@ -1554,12 +1566,19 @@ views:
 
                     {#-- 4. Collect Data --#}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set badges_sensor = core_sensors.get('badges_eid') -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
-                    {%- set ns.points_earned_all_time = (state_attr(points_sensor, 'point_stat_points_earned_all_time') | int(default=0)) if points_sensor else 0 -%}
+                    {%- set ns.points_earned_all_time = (state_attr(points_sensor, 'point_stat_points_earned_all_time') | float(default=0)) if points_sensor else 0 -%}
                     {%- set ns.points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or 'Points' -%}
                     {%- set points_icon = (state_attr(points_sensor, 'icon') if points_sensor else None) or 'mdi:star-circle' -%}
                     {%- set ui_control = state_attr(dashboard_helper, 'ui_control') | default({}, true) -%}
@@ -2047,9 +2066,9 @@ views:
                           {%- set current_state_color = 'var(--success-color)' if ns.m_status == 'active' else ('var(--error-color)' if ns.m_status == 'demoted' else 'var(--warning-color)') -%}
                           {%- if is_current -%}
                             {%- set details_html = "<b style='color:" ~ current_state_color ~ ";'>🛡️ " ~ ui.get('current_status', 'err-current_status') ~ ": " ~ current_state_label | upper ~ "</b>" -%}
-                            {%- set details_html = details_html ~ "<br><span>🎯 " ~ ui.get('threshold', 'err-threshold') ~ ": " ~ badge.threshold|string ~ " " ~ ns.points_label ~ "</span>" -%}
+                            {%- set details_html = details_html ~ "<br><span>🎯 " ~ ui.get('threshold', 'err-threshold') ~ ": " ~ (format_points(badge.threshold, pref_points_precision) | trim) ~ " " ~ ns.points_label ~ "</span>" -%}
                           {%- else -%}
-                            {%- set details_html = "<b style='color:" ~ status_color ~ ";'>" ~ status_text | upper ~ "</b> <span style='opacity:0.7;'>•</span> <span>🎯 " ~ ui.get('threshold', 'err-threshold') ~ ": " ~ badge.threshold|string ~ " " ~ ns.points_label ~ "</span>" -%}
+                            {%- set details_html = "<b style='color:" ~ status_color ~ ";'>" ~ status_text | upper ~ "</b> <span style='opacity:0.7;'>•</span> <span>🎯 " ~ ui.get('threshold', 'err-threshold') ~ ": " ~ (format_points(badge.threshold, pref_points_precision) | trim) ~ " " ~ ns.points_label ~ "</span>" -%}
                           {%- endif -%}
                           {%- if awards_inline | length > 0 -%}
                             {%- set details_html = details_html ~ "<br><span style='display:inline-block;max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:11px;font-weight:700;color:var(--primary-text-color);'>💎 " ~ ui.get('awards', 'err-awards') ~ ": " ~ awards_inline ~ "</span>" -%}
@@ -2096,9 +2115,9 @@ views:
                               {%- set maintenance_notes = maintenance_notes + ["<span style='color:var(--error-color);font-weight:700;'>• " ~ ui.get('demoted', 'err-demoted') ~ "</span>"] -%}
                             {%- endif -%}
                             {%- set maintenance_note_html = maintenance_notes | join(' ') -%}
-                            {%- set maint_need_text = ui.get('need', 'err-need') ~ ": " ~ ns.m_remaining|string ~ " " ~ ns.points_label -%}
+                            {%- set maint_need_text = ui.get('need', 'err-need') ~ ": " ~ (format_points(ns.m_remaining, pref_points_precision) | trim) ~ " " ~ ns.points_label -%}
                             {%- set maint_need_color = 'var(--warning-color)' if ns.m_status == 'grace' else ('var(--success-color)' if ns.m_remaining <= 0 else 'var(--secondary-text-color)') -%}
-                            {%- set progress_html = "<div style='margin-top:2px;padding:8px 10px;border-radius:8px;background:var(--secondary-background-color);border:1px solid var(--divider-color);'><div style='display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:11px;'><span><ha-icon icon='mdi:shield-sync' style='width:14px;height:14px;color:" ~ bar_color ~ ";transform:translateY(-1px);'></ha-icon> " ~ ui.get('maintenance', 'err-maintenance') ~ " " ~ maintenance_note_html ~ demoted_multiplier_header_note ~ "</span><span style='font-weight:600;'>" ~ ns.m_cycle_pts|string ~ "/" ~ req_pts|string ~ "</span></div><div style='margin-top:6px;display:flex;align-items:center;gap:6px;'><div style='flex:1;height:6px;background:var(--divider-color);border-radius:999px;overflow:hidden;'><div style='width:" ~ pct|string ~ "%;height:100%;background:" ~ bar_color ~ ";border-radius:999px;'></div></div><span style='font-size:10px;color:var(--secondary-text-color);line-height:1;'>" ~ pct|string ~ "%</span></div><div style='margin-top:6px;font-size:10px;color:var(--secondary-text-color);display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;'><span>" ~ maint_recurrence ~ "</span><span style='font-weight:600;color:" ~ maint_need_color ~ ";text-align:center;white-space:nowrap;'>" ~ maint_need_text ~ "</span><span style='font-weight:600;color:" ~ ('var(--warning-color)' if ns.m_status == 'grace' else 'var(--secondary-text-color)') ~ ";text-align:right;'>" ~ maint_due_or_grace ~ "</span></div></div>" -%}
+                            {%- set progress_html = "<div style='margin-top:2px;padding:8px 10px;border-radius:8px;background:var(--secondary-background-color);border:1px solid var(--divider-color);'><div style='display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:11px;'><span><ha-icon icon='mdi:shield-sync' style='width:14px;height:14px;color:" ~ bar_color ~ ";transform:translateY(-1px);'></ha-icon> " ~ ui.get('maintenance', 'err-maintenance') ~ " " ~ maintenance_note_html ~ demoted_multiplier_header_note ~ "</span><span style='font-weight:600;'>" ~ (format_points(ns.m_cycle_pts, pref_points_precision) | trim) ~ "/" ~ (format_points(req_pts, pref_points_precision) | trim) ~ "</span></div><div style='margin-top:6px;display:flex;align-items:center;gap:6px;'><div style='flex:1;height:6px;background:var(--divider-color);border-radius:999px;overflow:hidden;'><div style='width:" ~ pct|string ~ "%;height:100%;background:" ~ bar_color ~ ";border-radius:999px;'></div></div><span style='font-size:10px;color:var(--secondary-text-color);line-height:1;'>" ~ pct|string ~ "%</span></div><div style='margin-top:6px;font-size:10px;color:var(--secondary-text-color);display:grid;grid-template-columns:1fr auto 1fr;gap:8px;align-items:center;'><span>" ~ maint_recurrence ~ "</span><span style='font-weight:600;color:" ~ maint_need_color ~ ";text-align:center;white-space:nowrap;'>" ~ maint_need_text ~ "</span><span style='font-weight:600;color:" ~ ('var(--warning-color)' if ns.m_status == 'grace' else 'var(--secondary-text-color)') ~ ";text-align:right;'>" ~ maint_due_or_grace ~ "</span></div></div>" -%}
                           {%- elif is_target and badge.threshold > 0 -%}
                             {%- set pts_to_unlock = ns.points_to_next if ns.has_earned_any else (((badge.threshold - ns.points_earned_all_time) | float(default=0) | round(0, 'ceil')) | int) -%}
                             {%- if pts_to_unlock < 0 -%}{%- set pts_to_unlock = 0 -%}{%- endif -%}
@@ -2106,7 +2125,7 @@ views:
                             {%- if current_prog < 0 -%}{%- set current_prog = 0 -%}{%- endif -%}
                             {%- set pct = (current_prog / badge.threshold * 100) | round(0) | int -%}
                             {%- if pct > 100 -%}{%- set pct = 100 -%}{%- endif -%}
-                            {%- set progress_html = "<div style='margin-top:2px;padding:8px 10px;border-radius:8px;background:var(--secondary-background-color);border:1px solid var(--divider-color);'><div style='display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:11px;'><span><ha-icon icon='mdi:rocket-launch' style='width:14px;height:14px;color:var(--primary-color);transform:translateY(-1px);'></ha-icon> " ~ ui.get('to_unlock', 'err-to_unlock') ~ "</span><span style='font-weight:600;'>" ~ current_prog|string ~ "/" ~ badge.threshold|string ~ "</span></div><div style='margin-top:6px;display:flex;align-items:center;gap:6px;'><div style='flex:1;height:6px;background:var(--divider-color);border-radius:999px;overflow:hidden;'><div style='width:" ~ pct|string ~ "%;height:100%;background:var(--primary-color);border-radius:999px;'></div></div><span style='font-size:10px;color:var(--secondary-text-color);line-height:1;'>" ~ pct|string ~ "%</span></div><div style='margin-top:6px;font-size:10px;color:var(--secondary-text-color);display:flex;justify-content:space-between;gap:8px;align-items:center;'><span><ha-icon icon='" ~ points_icon ~ "' style='width:12px;height:12px;color:var(--primary-color);transform:translateY(-1px);'></ha-icon> " ~ ui.get('total_earned', 'err-total_earned') ~ ": " ~ ns.points_earned_all_time|string ~ " " ~ ns.points_label ~ "</span><span style='font-weight:600;'>🔥 " ~ ui.get('need', 'err-need') ~ ": " ~ pts_to_unlock|string ~ " " ~ ns.points_label ~ "</span></div></div>" -%}
+                            {%- set progress_html = "<div style='margin-top:2px;padding:8px 10px;border-radius:8px;background:var(--secondary-background-color);border:1px solid var(--divider-color);'><div style='display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:11px;'><span><ha-icon icon='mdi:rocket-launch' style='width:14px;height:14px;color:var(--primary-color);transform:translateY(-1px);'></ha-icon> " ~ ui.get('to_unlock', 'err-to_unlock') ~ "</span><span style='font-weight:600;'>" ~ (format_points(current_prog, pref_points_precision) | trim) ~ "/" ~ (format_points(badge.threshold, pref_points_precision) | trim) ~ "</span></div><div style='margin-top:6px;display:flex;align-items:center;gap:6px;'><div style='flex:1;height:6px;background:var(--divider-color);border-radius:999px;overflow:hidden;'><div style='width:" ~ pct|string ~ "%;height:100%;background:var(--primary-color);border-radius:999px;'></div></div><span style='font-size:10px;color:var(--secondary-text-color);line-height:1;'>" ~ pct|string ~ "%</span></div><div style='margin-top:6px;font-size:10px;color:var(--secondary-text-color);display:flex;justify-content:space-between;gap:8px;align-items:center;'><span><ha-icon icon='" ~ points_icon ~ "' style='width:12px;height:12px;color:var(--primary-color);transform:translateY(-1px);'></ha-icon> " ~ ui.get('total_earned', 'err-total_earned') ~ ": " ~ (format_points(ns.points_earned_all_time, pref_points_precision) | trim) ~ " " ~ ns.points_label ~ "</span><span style='font-weight:600;'>🔥 " ~ ui.get('need', 'err-need') ~ ": " ~ (format_points(pts_to_unlock, pref_points_precision) | trim) ~ " " ~ ns.points_label ~ "</span></div></div>" -%}
                           {%- endif -%}
 
                           {%- set stats_parts = [] -%}
@@ -2252,15 +2271,34 @@ views:
                   {%- if not skip_render -%}
 
                     {#-- 3. Initialize --#}
+                    {%- macro format_points(value, mode='fixed_0') -%}
+                      {%- set numeric = value | float(default=0) | round(2) -%}
+                      {%- if mode == 'adaptive' -%}
+                        {{- numeric | string | regex_replace('\.?0+$', '') -}}
+                      {%- elif mode == 'fixed_1' -%}
+                        {{- '%.1f' | format(numeric) -}}
+                      {%- elif mode == 'fixed_2' -%}
+                        {{- '%.2f' | format(numeric) -}}
+                      {%- else -%}
+                        {{- '%.0f' | format(numeric) -}}
+                      {%- endif -%}
+                    {%- endmacro -%}
                     {%- set ns = namespace(
                       badges=[]
                     ) -%}
 
                     {#-- 4. Collect Data --#}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set points_icon = (state_attr(points_sensor, 'icon') if points_sensor else None) or 'mdi:star-circle' -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set gamification_enabled = state_attr(dashboard_helper, 'gamification_enabled') | default(false, true) -%}
                     {%- set ui_control = state_attr(dashboard_helper, 'ui_control') | default({}, true) -%}
@@ -2487,7 +2525,7 @@ views:
                             {%- set awards_parts = awards_parts + ['x' ~ ('%.2f' | format(badge.points_multiplier) | regex_replace('\.?0+$', ''))] -%}
                           {%- endif -%}
                           {%- if badge.award_points > 0 -%}
-                            {%- set awards_parts = awards_parts + [('%.1f' | format(badge.award_points)) ~ " <ha-icon icon='" ~ points_icon ~ "' style='width:12px;height:12px;color:var(--primary-color);transform:translateY(-2px);'></ha-icon>"] -%}
+                            {%- set awards_parts = awards_parts + [(format_points(badge.award_points, pref_points_precision) | trim) ~ " <ha-icon icon='" ~ points_icon ~ "' style='width:12px;height:12px;color:var(--primary-color);transform:translateY(-2px);'></ha-icon>"] -%}
                           {%- endif -%}
 
                           {%- set bonus_count = badge.award_bonuses | length -%}
@@ -2519,7 +2557,7 @@ views:
                           {%- if badge.description | trim | length > 0 -%}
                             {%- set details_line = badge.description | trim | replace('&', '&amp;') | replace('<', '&lt;') | replace('>', '&gt;') -%}
                           {%- elif badge.threshold > 0 -%}
-                            {%- set details_line = ui.get('threshold', 'err-threshold') ~ ': ' ~ badge.threshold|string ~ (' • ' ~ badge.target_type if badge.target_type | length > 0 else '') -%}
+                            {%- set details_line = ui.get('threshold', 'err-threshold') ~ ': ' ~ (format_points(badge.threshold, pref_points_precision) | trim) ~ (' • ' ~ badge.target_type if badge.target_type | length > 0 else '') -%}
                           {%- endif -%}
                           {%- if awards_line | length > 0 -%}
                             {%- set details_line = details_line ~ ("<br>" if details_line | length > 0 else "") ~ "<span style='display:inline-block;max-width:100%;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-size:11px;font-weight:700;color:var(--primary-text-color);'><ha-icon icon='mdi:diamond-stone' style='width:12px;height:12px;color:var(--primary-color);transform:translateY(-1px);'></ha-icon> " ~ ui.get('awards', 'err-awards') ~ ": " ~ awards_line ~ "</span>" -%}

--- a/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
@@ -45,14 +45,7 @@ views:
 
                   << template_snippets.user_override_helper >>
 
-                  {%- set pref_points_precision = 'fixed_0' -%}  {#-- Controls point formatting. Allowed: fixed_0, adaptive, fixed_1, fixed_2. --#}
-
                   {#-- 2. Dynamic Lookups & Validations --#}
-
-                  {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
-                  {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
-                    {%- set pref_points_precision = 'fixed_0' -%}
-                  {%- endif -%}
 
                   << template_snippets.user_setup >>
 
@@ -63,10 +56,17 @@ views:
 
                     {#-- 3. Collect Data --#}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set total_sensor = core_sensors.get('chores_eid') -%}
                     {%- set highest_badge_entity = core_sensors.get('badges_eid') -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set points_value = (states(points_sensor) | float(default=0)) if points_sensor else 0 -%}
                     {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor else None) or 'Points' -%}
@@ -872,16 +872,10 @@ views:
                   {%- set entry_id = '<< integration.entry_id >>' -%}
                   {%- set lookup_key = entry_id ~ ':' ~ user_id -%}
 
-                  {%- set pref_points_precision = 'fixed_0' -%}
-
                   {%- set pref_show_penalties = true -%}
 
 
                   {#-- Type coercion for preferences --#}
-                  {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
-                  {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
-                    {%- set pref_points_precision = 'fixed_0' -%}
-                  {%- endif -%}
                   {%- set pref_show_penalties = (pref_show_penalties | default('true') | string | lower) == 'true' -%}
 
                   {#-- 2. Initialize Variables --#}
@@ -934,11 +928,18 @@ views:
                   {%- if not skip_render -%}
 
                     {#-- 3. Collect Data --#}
+                    {%- set dashboard_helpers = state_attr(dashboard_helper, 'dashboard_helpers') or {} -%}
+                    {%- set dashboard_config = state_attr(dashboard_helper, 'dashboard_config') or {} -%}
+                    {%- set pref_points_precision = dashboard_config.get('points_precision', 'fixed_0') if dashboard_config is mapping else 'fixed_0' -%}
+                    {%- set pref_points_precision = pref_points_precision | default('fixed_0') | string | lower -%}
+                    {%- if pref_points_precision not in ['fixed_0', 'adaptive', 'fixed_1', 'fixed_2'] -%}
+                      {%- set pref_points_precision = 'fixed_0' -%}
+                    {%- endif -%}
                     {%- set core_sensors = state_attr(dashboard_helper, 'core_sensors') or {} -%}
                     {%- set points_sensor = core_sensors.get('points_eid') -%}
                     {%- set all_time_sensor = core_sensors.get('chores_eid') -%}
                     {%- set highest_badge_entity = core_sensors.get('badges_eid') -%}
-                    {%- set translation_sensor = (state_attr(dashboard_helper, 'dashboard_helpers') or {}).get('translation_sensor_eid') -%}
+                    {%- set translation_sensor = dashboard_helpers.get('translation_sensor_eid') -%}
                     {%- set ui = state_attr(translation_sensor, 'ui_translations') if translation_sensor else {} -%}
                     {%- set helper_attrs = states[dashboard_helper].attributes -%}
                     {%- set gamification_enabled = helper_attrs.gamification_enabled | default(false, true) -%}

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -3344,12 +3344,26 @@ def build_general_options_schema(default: dict | None = None) -> vol.Schema:
         const.CONF_ADMIN_APPROVAL_BYPASS,
         const.DEFAULT_ADMIN_APPROVAL_BYPASS,
     )
+    default_dashboard_points_precision = default.get(
+        const.CONF_DASHBOARD_POINTS_PRECISION,
+        const.DEFAULT_DASHBOARD_POINTS_PRECISION,
+    )
 
     return vol.Schema(
         {
             vol.Required(
                 const.CFOF_SYSTEM_INPUT_POINTS_ADJUST_VALUES, default=default_points_str
             ): str,
+            vol.Required(
+                const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION,
+                default=default_dashboard_points_precision,
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=const.DASHBOARD_POINTS_PRECISION_OPTIONS,
+                    translation_key=const.TRANS_KEY_CFOF_DASHBOARD_POINTS_PRECISION,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            ),
             vol.Required(
                 const.CFOF_SYSTEM_INPUT_DEFAULT_CHORE_POINTS,
                 default=default_default_chore_points,
@@ -3464,6 +3478,7 @@ def parse_retention_periods(retention_str: str) -> tuple[int, int, int, int]:
 def build_all_system_settings_schema(
     default_points_label: str | None = None,
     default_points_icon: str | None = None,
+    default_dashboard_points_precision: str | None = None,
     default_default_chore_points: float | None = None,
     default_update_interval: int | None = None,
     default_calendar_show_period: int | None = None,
@@ -3497,6 +3512,8 @@ def build_all_system_settings_schema(
     defaults = {
         "points_label": default_points_label or const.DEFAULT_POINTS_LABEL,
         "points_icon": default_points_icon or const.DEFAULT_POINTS_ICON,
+        "dashboard_points_precision": default_dashboard_points_precision
+        or const.DEFAULT_DASHBOARD_POINTS_PRECISION,
         "default_chore_points": default_default_chore_points
         or const.DEFAULT_CHORE_POINTS,
         "update_interval": default_update_interval or const.DEFAULT_UPDATE_INTERVAL,
@@ -3519,6 +3536,19 @@ def build_all_system_settings_schema(
     )
 
     # Add update interval field
+    precision_fields = {
+        vol.Required(
+            const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION,
+            default=defaults["dashboard_points_precision"],
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=const.DASHBOARD_POINTS_PRECISION_OPTIONS,
+                translation_key=const.TRANS_KEY_CFOF_DASHBOARD_POINTS_PRECISION,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        ),
+    }
+
     update_interval_fields = {
         vol.Required(
             const.CFOF_SYSTEM_INPUT_UPDATE_INTERVAL, default=defaults["update_interval"]
@@ -3570,6 +3600,7 @@ def build_all_system_settings_schema(
     # Combine all fields
     all_fields = {
         **points_fields.schema,
+        **precision_fields,
         **update_interval_fields,
         **calendar_fields,
         **retention_fields,
@@ -3632,6 +3663,14 @@ def validate_all_system_settings(user_input: dict[str, Any]) -> dict[str, str]:
             errors[const.CFOP_ERROR_DEFAULT_CHORE_POINTS] = (
                 const.TRANS_KEY_CFOF_INVALID_DEFAULT_CHORE_POINTS
             )
+
+    dashboard_points_precision = user_input.get(
+        const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION
+    )
+    if dashboard_points_precision not in const.DASHBOARD_POINTS_PRECISION_OPTIONS:
+        errors[const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION] = (
+            const.TRANS_KEY_CFOF_DASHBOARD_POINTS_PRECISION
+        )
 
     # Validate retention periods (all positive ints)
     for field, error_key in [

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -6057,6 +6057,7 @@ class ChoreManager(BaseManager):
                     )
                     continue
 
+                next_due_dt: datetime | None
                 if frequency == const.FREQUENCY_NONE:
                     if skip_non_recurring:
                         skipped.append(
@@ -6182,6 +6183,7 @@ class ChoreManager(BaseManager):
                     )
                     continue
 
+                next_assignee_due_dt: datetime | None
                 if frequency == const.FREQUENCY_NONE:
                     if skip_non_recurring:
                         skipped.append(
@@ -6194,15 +6196,18 @@ class ChoreManager(BaseManager):
                             }
                         )
                         continue
-                    next_due_dt = after_utc
+                    next_assignee_due_dt = after_utc
                 else:
-                    next_due_dt = self._calculate_next_due_date_for_assignee(
+                    next_assignee_due_dt = self._calculate_next_due_date_for_assignee(
                         chore_info,
                         chore_id,
                         assignee_id,
                         reference_time=after_utc,
                     )
-                    if next_due_dt is None or next_due_dt <= after_utc:
+                    if (
+                        next_assignee_due_dt is None
+                        or next_assignee_due_dt <= after_utc
+                    ):
                         skipped.append(
                             {
                                 "chore_id": chore_id,
@@ -6218,7 +6223,7 @@ class ChoreManager(BaseManager):
                     const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES,
                     {},
                 )
-                per_assignee_due_dates[assignee_id] = next_due_dt.isoformat()
+                per_assignee_due_dates[assignee_id] = next_assignee_due_dt.isoformat()
                 self._transition_chore_state(
                     assignee_id,
                     chore_id,
@@ -6234,7 +6239,7 @@ class ChoreManager(BaseManager):
                         "chore_name": chore_name,
                         "user_id": assignee_id,
                         "old_due_date": due_dt.isoformat(),
-                        "new_due_date": next_due_dt.isoformat(),
+                        "new_due_date": next_assignee_due_dt.isoformat(),
                         "shared": False,
                     }
                 )

--- a/custom_components/choreops/managers/gamification_manager.py
+++ b/custom_components/choreops/managers/gamification_manager.py
@@ -98,6 +98,8 @@ class GamificationManager(BaseManager):
 
         # Debounce timer handle
         self._eval_timer: asyncio.TimerHandle | None = None
+        self._schedule_eval_handle: asyncio.Handle | None = None
+        self._is_unloading = False
 
         # Debounce configuration
         self._debounce_seconds = _DEBOUNCE_SECONDS
@@ -152,10 +154,24 @@ class GamificationManager(BaseManager):
             self._pending_evaluations.update(pending)
             self._schedule_evaluation()
 
+        self.coordinator.config_entry.async_on_unload(self._cancel_eval_timer)
+
         const.LOGGER.debug(
             "GamificationManager initialized with %s second debounce",
             self._debounce_seconds,
         )
+
+    def _cancel_eval_timer(self) -> None:
+        """Cancel any pending debounce timer during config entry unload."""
+        self._is_unloading = True
+
+        if self._schedule_eval_handle is not None:
+            self._schedule_eval_handle.cancel()
+            self._schedule_eval_handle = None
+
+        if self._eval_timer is not None:
+            self._eval_timer.cancel()
+            self._eval_timer = None
 
     def _on_stats_ready(self, payload: dict[str, Any]) -> None:
         """Handle startup cascade - initialize badge references after stats ready.
@@ -729,7 +745,12 @@ class GamificationManager(BaseManager):
         Uses call_soon_threadsafe to safely interact with event loop
         since this method may be called from dispatcher (SyncWorker thread).
         """
-        self.hass.loop.call_soon_threadsafe(self._schedule_evaluation_impl)
+        if self._is_unloading:
+            return
+
+        self._schedule_eval_handle = self.hass.loop.call_soon_threadsafe(
+            self._schedule_evaluation_impl
+        )
 
     def _schedule_evaluation_impl(self) -> None:
         """Internal implementation that runs on the event loop thread.
@@ -737,6 +758,11 @@ class GamificationManager(BaseManager):
         This method must only be called from the event loop thread
         (via call_soon_threadsafe from _schedule_evaluation).
         """
+        self._schedule_eval_handle = None
+
+        if self._is_unloading:
+            return
+
         if self._eval_timer:
             self._eval_timer.cancel()
 
@@ -759,8 +785,12 @@ class GamificationManager(BaseManager):
         This is the main evaluation loop that runs after debounce timer fires.
         Clears the persistent queue after successful evaluation.
         """
-        # Clear timer reference
-        self._eval_timer = None
+        # Manual callers may force evaluation before the debounce fires.
+        # Cancel the scheduled timer so the test/runtime does not keep a stale
+        # handle alive after this batch has already been processed.
+        if self._eval_timer is not None:
+            self._eval_timer.cancel()
+            self._eval_timer = None
 
         # Capture and clear pending set atomically
         assignees_to_evaluate = self._pending_evaluations.copy()

--- a/custom_components/choreops/managers/system_manager.py
+++ b/custom_components/choreops/managers/system_manager.py
@@ -102,10 +102,12 @@ class SystemManager(BaseManager):
         # 1. Timer Owner: Register ALL System Heartbeats
         # Midnight Rollover - single timer for all nightly tasks
         # Domain managers subscribe to MIDNIGHT_ROLLOVER and perform their own tasks
-        async_track_time_change(
-            self.hass,
-            self._on_midnight_tick,
-            **const.DEFAULT_DAILY_RESET_TIME,
+        self.coordinator.config_entry.async_on_unload(
+            async_track_time_change(
+                self.hass,
+                self._on_midnight_tick,
+                **const.DEFAULT_DAILY_RESET_TIME,
+            )
         )
 
         # 2. Signal Listener: Subscribe to lifecycle DELETED signals

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -5039,6 +5039,10 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 # Remove the key if the field is left empty.
                 self._entry_options.pop(const.CONF_POINTS_ADJUST_VALUES, None)
             # Update default chore points.
+            self._entry_options[const.CONF_DASHBOARD_POINTS_PRECISION] = user_input.get(
+                const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION,
+                const.DEFAULT_DASHBOARD_POINTS_PRECISION,
+            )
             self._entry_options[const.CONF_DEFAULT_CHORE_POINTS] = user_input.get(
                 const.CFOF_SYSTEM_INPUT_DEFAULT_CHORE_POINTS,
                 const.DEFAULT_CHORE_POINTS,
@@ -5105,10 +5109,11 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             )
             const.LOGGER.debug(
                 "General Options Updated: Points Adjust Values=%s, "
-                "Default Chore Points=%s, Update Interval=%s, Calendar Period to Show=%s, "
+                "Dashboard Points Precision=%s, Default Chore Points=%s, Update Interval=%s, Calendar Period to Show=%s, "
                 "Retention Periods=%s, "
                 "Show Legacy Entities=%s, Kiosk Mode=%s, Admin Approval Bypass=%s, Backup Retention=%s",
                 self._entry_options.get(const.CONF_POINTS_ADJUST_VALUES),
+                self._entry_options.get(const.CONF_DASHBOARD_POINTS_PRECISION),
                 self._entry_options.get(const.CONF_DEFAULT_CHORE_POINTS),
                 self._entry_options.get(const.CONF_UPDATE_INTERVAL),
                 self._entry_options.get(const.CONF_CALENDAR_SHOW_PERIOD),

--- a/custom_components/choreops/sensor.py
+++ b/custom_components/choreops/sensor.py
@@ -4813,6 +4813,15 @@ class AssigneeDashboardHelperSensor(ChoreOpsCoordinatorEntity, SensorEntity):
 
         return dashboard_helpers
 
+    def _build_dashboard_config(self) -> dict[str, Any]:
+        """Build resolved dashboard configuration values for template use."""
+        return {
+            const.ATTR_POINTS_PRECISION: self._entry.options.get(
+                const.CONF_DASHBOARD_POINTS_PRECISION,
+                const.DEFAULT_DASHBOARD_POINTS_PRECISION,
+            )
+        }
+
     def _build_payload(
         self,
         entity_registry,
@@ -5151,6 +5160,7 @@ class AssigneeDashboardHelperSensor(ChoreOpsCoordinatorEntity, SensorEntity):
         self.coordinator.ui_manager.reset_pending_change_flags()
 
         core_sensors = self._build_core_sensors(entity_registry)
+        dashboard_config = self._build_dashboard_config()
         dashboard_helpers = self._build_dashboard_helpers(
             entity_registry,
             translation_sensor_eid=translation_sensor_eid,
@@ -5173,6 +5183,7 @@ class AssigneeDashboardHelperSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             "points_buttons": points_buttons_attr,
             "pending_approvals": pending_approvals,
             "core_sensors": core_sensors,
+            const.ATTR_DASHBOARD_CONFIG: dashboard_config,
             "dashboard_helpers": dashboard_helpers,
             const.ATTR_USER_NAME: self._assignee_name,
             const.ATTR_USER_ID: self._assignee_id,

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -1633,6 +1633,7 @@
         "title": "General Options",
         "description": "Manage general settings for the ChoreOps integration.\n\n ℹ️ [Learn more about General Options]({documentation_url})",
         "data": {
+          "dashboard_points_precision": "Dashboard Points Precision",
           "default_chore_points": "Default Points per Chore",
           "points_adjust_values": "Manual Points Adjustment Button Values",
           "update_interval": "Update Interval",
@@ -1649,6 +1650,7 @@
           "backup_action_selection": "Backup Actions"
         },
         "data_description": {
+          "dashboard_points_precision": "Choose how points are displayed across supported dashboards. This changes dashboard formatting only and does not change stored point values or calculations.",
           "default_chore_points": "Default points value used for new chores when custom points are not specified.",
           "points_adjust_values": "List of values for the manual points adjustment buttons. Each value separate by '|'.",
           "update_interval": "Interval in minutes for updating the internal state of ChoreOps.",
@@ -1946,6 +1948,14 @@
         "delete_backup": "🗑️  Delete a backup",
         "restore_backup": "🔄 Restore from backup",
         "return_to_menu": "↩️  Return to main menu"
+      }
+    },
+    "dashboard_points_precision": {
+      "options": {
+        "fixed_0": "Whole numbers only",
+        "adaptive": "Adaptive (show decimals only when needed)",
+        "fixed_1": "Always 1 decimal place",
+        "fixed_2": "Always 2 decimal places"
       }
     },
     "select_backup_to_delete": {
@@ -4739,6 +4749,9 @@
           },
           "core_sensors": {
             "name": "Core Sensors"
+          },
+          "dashboard_config": {
+            "name": "Dashboard Config"
           },
           "dashboard_helpers": {
             "name": "Dashboard Helpers"

--- a/docs/DASHBOARD_TEMPLATE_GUIDE.md
+++ b/docs/DASHBOARD_TEMPLATE_GUIDE.md
@@ -790,7 +790,7 @@ sharding behavior:
 | ----- | -------------- | ----- |
 | `row data` | `chores`, `rewards`, `badges`, `bonuses`, `penalties`, `achievements`, `challenges`, `points_buttons` | Lists consumed directly by dashboard cards |
 | `derived indexes` | `chores_by_label` | Transitional backend convenience index scheduled for removal from transport |
-| `auxiliary catalogs` | `pending_approvals`, `core_sensors`, `ui_control` | Supporting payloads that stay on the main helper in the first shard release |
+| `auxiliary catalogs` | `pending_approvals`, `core_sensors`, `ui_control`, `dashboard_config` | Supporting payloads that stay on the main helper in the first shard release |
 | `plumbing/meta` | `dashboard_helpers`, `user_name`, `user_id`, `integration_entry_id`, `dashboard_lookup_key`, `language`, `gamification_enabled` | Lookup, identity, and helper-pointer fields |
 
 Authoring rule:

--- a/docs/completed/UNIVERSAL_POINTS_PRECISION_DASHBOARD_SYNC_COMPLETED.md
+++ b/docs/completed/UNIVERSAL_POINTS_PRECISION_DASHBOARD_SYNC_COMPLETED.md
@@ -1,0 +1,130 @@
+# Initiative Plan: universal points precision dashboard sync
+
+## Initiative snapshot
+
+- **Name / Code**: Universal points precision dashboard sync (`UNIVERSAL_POINTS_PRECISION_DASHBOARD_SYNC`)
+- **Target release / milestone**: v0.5.x next minor/patch after backend decimal rollout
+- **Owner / driver(s)**: ChoreOps maintainers
+- **Status**: Phase 3 complete, Phase 4 targeted validation complete with follow-up coverage work pending
+
+## Summary & immediate steps
+
+| Phase / Step | Description | % complete | Quick notes |
+| --- | --- | ---: | --- |
+| Phase 1 – Backend option and helper contract | Add one general-options precision selector and surface the resolved value through a reviewed dashboard config contract | 100% | Universal precision selector added, dashboard config contract exposed, and integration-side validations passed |
+| Phase 2 – Canonical dashboard repo updates | Update canonical dashboard templates in `choreops-dashboards` to read helper-provided precision instead of per-card local prefs | 100% | Active templates now read helper-driven precision, shared chore-row context passes it through, preference docs were updated, and dashboard release sanity passed |
+| Phase 3 – Vendor sync into integration | Sync the updated dashboard assets into vendored integration copies after canonical dashboard work lands | 100% | Canonical dashboard assets were synced into the vendored integration mirror and parity check passed |
+| Phase 4 – Tests, docs, and release validation | Cover options flow, helper payload, and template rendering/parity expectations | 85% | `quick_lint`, explicit mypy, dashboard repo sanity, vendored parity, and targeted dashboard pytest passed; kiosk-mode targeted rerun also passed |
+
+1. **Key objective** – Add one universal points precision selector to General Options, expose that resolved precision through a reviewed `dashboard_config` contract, and update dashboards to consume it consistently without changing backend point storage or logic.
+2. **Summary of recent work** – Phase 2 is complete in the canonical dashboard repo: all active templates were swept, shared chore-row precision wiring now flows from `dashboard_config.points_precision`, high-visibility Gamification Premier and classic admin point renderers now honor the helper-driven precision modes, active preference docs were updated, and dashboard release sanity passed.
+3. **Next steps (short term)** – Finish the remaining focused Phase 4 follow-up by deciding whether to add any extra targeted assertions for general-options persistence or reward/chore helper payload coverage beyond the already-passing helper/render smoke tests.
+4. **Risks / blockers** – No active blocker is currently reproduced on the touched slice. The main remaining risk is under-documenting validation if additional targeted assertions are desired before close-out.
+5. **References**
+   - [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+   - [docs/DEVELOPMENT_STANDARDS.md](../DEVELOPMENT_STANDARDS.md)
+   - [docs/CODE_REVIEW_GUIDE.md](../CODE_REVIEW_GUIDE.md)
+   - [tests/AGENT_TEST_CREATION_INSTRUCTIONS.md](../../tests/AGENT_TEST_CREATION_INSTRUCTIONS.md)
+   - [docs/RELEASE_CHECKLIST.md](../RELEASE_CHECKLIST.md)
+   - [docs/completed/POINTS_DECIMAL_PRECISION_BACKEND_COMPLETE.md](../completed/POINTS_DECIMAL_PRECISION_BACKEND_COMPLETE.md)
+6. **Decisions & completion check**
+   - **Decisions captured**:
+     - The universal precision selector changes presentation only; it does not alter backend rounding, storage, statistics, affordability, or other point logic.
+     - Integer-style display remains the default via a universal precision value of `fixed_0`.
+     - Canonical dashboard work must be authored in `choreops-dashboards` first and only then vendored into `custom_components/choreops/dashboards/`.
+     - Templates should read a reviewed helper contract rather than defining `pref_points_precision` separately in each card block.
+  - The resolved universal precision value should be exposed on the assignee dashboard helper surface used by user templates, rather than requiring additional lookups to the system dashboard helper.
+     - No `.storage/choreops/choreops_data` schema bump is expected; this work should persist in config/options and helper attributes only.
+   - **Completion confirmation**: `[ ]` All follow-up items completed (backend option wiring, helper contract, canonical dashboard repo updates, vendor sync, tests, and docs) before requesting owner approval to mark initiative done.
+
+> **Important:** Keep the entire Summary section current with every meaningful update so backend/helper work, canonical dashboard changes, and vendor sync do not drift apart.
+
+## Tracking expectations
+
+- **Summary upkeep**: Refresh phase percentages, quick notes, and blockers after each meaningful implementation batch or decision.
+- **Detailed tracking**: Keep file-level implementation notes in the phase sections below; keep the summary concise.
+
+## Detailed phase tracking
+
+### Phase 1 – Backend option and helper contract
+
+- **Goal**: Add one General Options selector for universal points precision and expose the resolved value through a reviewed `dashboard_config` contract without changing point math or storage behavior.
+- **Steps / detailed work items**
+  - [x] Add a new system-setting constant set for universal dashboard precision in [custom_components/choreops/const.py](../../custom_components/choreops/const.py#L832) near the existing General Options/system-setting constants, including the config option key, form field key, default value, translation key, and any helper attribute key needed for dashboard consumption.
+  - [x] Extend the General Options schema in [custom_components/choreops/helpers/flow_helpers.py](../../custom_components/choreops/helpers/flow_helpers.py#L3293) to include a selector with the supported precision modes (`fixed_0`, `adaptive`, `fixed_1`, `fixed_2`) alongside `default_chore_points`, keeping this explicitly presentation-only.
+  - [x] Update the consolidated system-settings builders and validators in [custom_components/choreops/helpers/flow_helpers.py](../../custom_components/choreops/helpers/flow_helpers.py#L3467) and [custom_components/choreops/helpers/flow_helpers.py](../../custom_components/choreops/helpers/flow_helpers.py#L3500) so the new setting round-trips through the same options-flow path as other general settings.
+  - [x] Update General Options translations in [custom_components/choreops/translations/en.json](../../custom_components/choreops/translations/en.json#L1633) with a clear label and help text stating this affects dashboard display precision only and does not change stored values.
+  - [x] Expose the resolved precision through the reviewed dashboard config contract, using the dashboard-helper payload builder in [custom_components/choreops/sensor.py](../../custom_components/choreops/sensor.py#L4762) and the public helper payload in [custom_components/choreops/sensor.py](../../custom_components/choreops/sensor.py#L4825), so templates can read one resolved value instead of local card prefs.
+  - [x] Surface the resolved universal precision on a dedicated top-level `dashboard_config` payload for user-template access, while leaving `dashboard_helpers` focused on helper pointers such as translation and shard entity IDs.
+- **Key issues**
+  - User-facing dashboards usually start from an assignee `dashboard_helper`, so the assignee helper should be the primary source for the resolved precision value; system-helper usage should remain optional and secondary.
+  - The architecture note in [docs/ARCHITECTURE.md](../ARCHITECTURE.md#L788) requires future helper UI data to be exposed as resolved helper attributes, not raw preference dumps.
+
+### Phase 2 – Canonical dashboard repo updates
+
+- **Goal**: Update the canonical dashboard templates in `choreops-dashboards` so they consume the universal helper-provided precision and render decimal-capable values consistently.
+- **Steps / detailed work items**
+  - [x] Treat the active dashboard registry as the implementation inventory and verify all nine active templates are included in the sweep: [choreops-dashboards/templates/user-chores-standard-v1.yaml](../../../choreops-dashboards/templates/user-chores-standard-v1.yaml), [choreops-dashboards/templates/user-chores-essential-v1.yaml](../../../choreops-dashboards/templates/user-chores-essential-v1.yaml), [choreops-dashboards/templates/user-chores-lite-v1.yaml](../../../choreops-dashboards/templates/user-chores-lite-v1.yaml), [choreops-dashboards/templates/user-gamification-premier-v1.yaml](../../../choreops-dashboards/templates/user-gamification-premier-v1.yaml), [choreops-dashboards/templates/user-kidschores-classic-v1.yaml](../../../choreops-dashboards/templates/user-kidschores-classic-v1.yaml), [choreops-dashboards/templates/admin-shared-v1.yaml](../../../choreops-dashboards/templates/admin-shared-v1.yaml), [choreops-dashboards/templates/admin-peruser-v1.yaml](../../../choreops-dashboards/templates/admin-peruser-v1.yaml), [choreops-dashboards/templates/admin-shared-kidschores-classic.yaml](../../../choreops-dashboards/templates/admin-shared-kidschores-classic.yaml), and [choreops-dashboards/templates/admin-peruser-kidschores-classic.yaml](../../../choreops-dashboards/templates/admin-peruser-kidschores-classic.yaml).
+  - [x] Inventory and replace local precision defaults in canonical templates that currently define `pref_points_precision` directly, starting with [choreops-dashboards/templates/user-chores-standard-v1.yaml](../../../choreops-dashboards/templates/user-chores-standard-v1.yaml#L56), [choreops-dashboards/templates/user-chores-essential-v1.yaml](../../../choreops-dashboards/templates/user-chores-essential-v1.yaml#L52), [choreops-dashboards/templates/user-chores-lite-v1.yaml](../../../choreops-dashboards/templates/user-chores-lite-v1.yaml#L58), [choreops-dashboards/templates/user-kidschores-classic-v1.yaml](../../../choreops-dashboards/templates/user-kidschores-classic-v1.yaml#L48), and [choreops-dashboards/templates/user-gamification-premier-v1.yaml](../../../choreops-dashboards/templates/user-gamification-premier-v1.yaml#L60).
+  - [x] Update the shared chore engine contract in [choreops-dashboards/templates/shared/chore_engine/context_v1.yaml](../../../choreops-dashboards/templates/shared/chore_engine/context_v1.yaml#L128) and [choreops-dashboards/templates/shared/chore_engine/group_render_v1.yaml](../../../choreops-dashboards/templates/shared/chore_engine/group_render_v1.yaml#L52) so chore row button-card variables receive the resolved precision value used by [choreops-dashboards/templates/shared/button_card_template_chore_row_v1.yaml](../../../choreops-dashboards/templates/shared/button_card_template_chore_row_v1.yaml#L151) and [choreops-dashboards/templates/shared/button_card_template_chore_row_kids_v1.yaml](../../../choreops-dashboards/templates/shared/button_card_template_chore_row_kids_v1.yaml#L148).
+  - [x] Update Gamification Premier showcase and reward sections to use the helper-provided precision consistently, especially the showcase summary branch at [choreops-dashboards/templates/user-gamification-premier-v1.yaml](../../../choreops-dashboards/templates/user-gamification-premier-v1.yaml#L364) and the reward-cost rendering path at [choreops-dashboards/templates/user-gamification-premier-v1.yaml](../../../choreops-dashboards/templates/user-gamification-premier-v1.yaml#L1225) and [choreops-dashboards/templates/user-gamification-premier-v1.yaml](../../../choreops-dashboards/templates/user-gamification-premier-v1.yaml#L1281).
+  - [x] Sweep admin templates to remove drift between local card prefs and universal precision sources, starting with [choreops-dashboards/templates/admin-shared-v1.yaml](../../../choreops-dashboards/templates/admin-shared-v1.yaml#L1027), [choreops-dashboards/templates/admin-peruser-v1.yaml](../../../choreops-dashboards/templates/admin-peruser-v1.yaml#L943), [choreops-dashboards/templates/admin-shared-kidschores-classic.yaml](../../../choreops-dashboards/templates/admin-shared-kidschores-classic.yaml#L251), and [choreops-dashboards/templates/admin-peruser-kidschores-classic.yaml](../../../choreops-dashboards/templates/admin-peruser-kidschores-classic.yaml#L249).
+  - [x] Add one repo-wide audit pass over `choreops-dashboards/templates/**` before handoff completion to catch any remaining point-like raw string rendering outside the obvious entry points, including `reward_cost|string`, `badge.threshold|string`, `award_points`, `bonus_points | string`, `penalty_points | string`, and similar paths that should honor the universal precision unless intentionally exempted.
+  - [x] Update canonical dashboard preference docs so they describe the new universal helper-driven precision source, or explicitly note where local per-template overrides are being retired, starting with [choreops-dashboards/preferences/user-gamification-premier-v1.md](../../../choreops-dashboards/preferences/user-gamification-premier-v1.md#L22), [choreops-dashboards/preferences/user-chores-standard-v1.md](../../../choreops-dashboards/preferences/user-chores-standard-v1.md#L19), and [choreops-dashboards/preferences/admin-peruser-v1.md](../../../choreops-dashboards/preferences/admin-peruser-v1.md#L13).
+  - [x] Preserve one fallback-to-`fixed_0` behavior in templates when the helper value is absent during transition, but treat helper-provided precision as the new primary source.
+- **Key issues**
+  - Some templates currently mix three patterns: local top-of-card `pref_points_precision`, shared row variables, and raw `reward_cost|string` output. This phase must standardize all three.
+  - The canonical repo is the source of truth, so no vendored integration template should be updated first “just to unblock” render fixes.
+  - Handoff is not complete until the builder can point to a clean registry-wide audit result for all active templates, not just the initial user-facing dashboard set.
+
+### Phase 3 – Vendor sync into integration
+
+- **Goal**: Bring the integration’s vendored dashboard assets back into parity only after canonical dashboard repo changes are complete and reviewed.
+- **Steps / detailed work items**
+  - [x] Sync the updated canonical templates and preference docs from `choreops-dashboards` into vendored integration assets under [custom_components/choreops/dashboards/templates](../../custom_components/choreops/dashboards/templates) and [custom_components/choreops/dashboards/preferences](../../custom_components/choreops/dashboards/preferences), preserving canonical text and shared markers.
+  - [x] Verify shared fragment parity for the chore-engine and button-card template surfaces, especially [custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml](../../custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml), [custom_components/choreops/dashboards/templates/shared/chore_engine/group_render_v1.yaml](../../custom_components/choreops/dashboards/templates/shared/chore_engine/group_render_v1.yaml), [custom_components/choreops/dashboards/templates/shared/button_card_template_chore_row_v1.yaml](../../custom_components/choreops/dashboards/templates/shared/button_card_template_chore_row_v1.yaml), and [custom_components/choreops/dashboards/templates/shared/button_card_template_chore_row_kids_v1.yaml](../../custom_components/choreops/dashboards/templates/shared/button_card_template_chore_row_kids_v1.yaml).
+  - [x] Confirm the vendored registry and release metadata remain coherent with the synced assets in [custom_components/choreops/dashboards/dashboard_registry.json](../../custom_components/choreops/dashboards/dashboard_registry.json) if any manifest-facing dashboard preference documentation or shared-fragment requirements change.
+  - [x] Record the vendor-sync step explicitly in the initiative log so future archaeology does not mistake direct vendored edits for the primary change source.
+- **Key issues**
+  - The architecture contract in [docs/ARCHITECTURE.md](../ARCHITECTURE.md#L820) is explicit that canonical templates live in `choreops-dashboards` and vendored assets are synced artifacts.
+  - If canonical and vendored copies drift during implementation, render smoke tests in the integration repo may validate stale or partially updated templates.
+
+### Phase 4 – Tests, docs, and release validation
+
+- **Goal**: Add coverage for the universal precision option, helper payload, canonical template rendering expectations, and vendor parity.
+- **Steps / detailed work items**
+  - [x] Add General Options coverage for the new precision selector in the relevant options-flow tests, starting from the current General Options helpers and patterns referenced by [tests/AGENT_TESTING_USAGE_GUIDE.md](../../tests/AGENT_TESTING_USAGE_GUIDE.md#L28) and the helper constants in [tests/helpers/constants.py](../../tests/helpers/constants.py#L241).
+  - [x] Extend helper payload tests around resolved dashboard helper attributes in [tests/test_dashboard_helper_size_reduction.py](../../tests/test_dashboard_helper_size_reduction.py#L232) to verify the new reviewed precision value is exposed in the helper surface and defaults correctly.
+  - [ ] Add or update reward/chore dashboard helper assertions so decimal-capable reward costs and chore point values continue to round-trip through helper payloads, using existing dashboard helper verification patterns in [tests/test_reward_crud_services.py](../../tests/test_reward_crud_services.py#L431) and decimal-related checks in [tests/test_points_migration_validation.py](../../tests/test_points_migration_validation.py#L215).
+  - [x] Update render smoke coverage in [tests/test_dashboard_template_render_smoke.py](../../tests/test_dashboard_template_render_smoke.py#L1) to ensure the vendored templates still render after switching from per-card local precision prefs to helper-driven precision sourcing.
+  - [x] Record dashboard-repo-side validation expectations in the plan and release notes, including whichever parity or asset checks are used to prove canonical and vendored templates match before merge.
+  - [x] Run and record the targeted repo validations used for this change: `./utils/quick_lint.sh --fix`, `mypy custom_components/choreops/ --python-version 3.14 --explicit-package-bases`, `python utils/sync_dashboard_assets.py --check`, `python -m pytest tests/test_dashboard_helper_size_reduction.py tests/test_dashboard_template_render_smoke.py -v --tb=line`, and `python -m pytest tests/test_kiosk_mode_buttons.py -v --tb=line`, plus `python utils/release_sanity.py` in the dashboard repo.
+- **Key issues**
+  - The dashboard repo does not run through the same integration smoke tests unless the vendored sync happens, so both canonical and vendored validation steps need to be called out explicitly.
+  - Tests should prove presentation contract behavior, not alter or re-litigate backend point arithmetic that was already covered by the decimal backend initiative.
+
+## Testing & validation
+
+- Planned validation commands for the integration repo:
+  - `./utils/quick_lint.sh --fix`
+  - `mypy custom_components/choreops/`
+  - `python -m pytest tests/ -v --tb=line`
+- Planned validation focus areas:
+  - General Options persistence of the universal precision selector
+  - Dashboard helper payload exposure of the resolved precision value
+  - Reward/chore helper payload consistency for decimal-capable point values
+  - Vendored dashboard template render smoke coverage
+- Planned validation for dashboard repo:
+  - Use the dashboard repo’s parity/render workflow to confirm canonical templates compile and match the vendored sync target before final integration vendoring
+  - Phase 2 builder validation recorded: `python utils/release_sanity.py` passed in `choreops-dashboards`
+- Outstanding tests:
+  - Integration repo validation for this contract adjustment: `./utils/quick_lint.sh --fix` passed, `mypy custom_components/choreops/ --python-version 3.14 --explicit-package-bases` passed, `python utils/sync_dashboard_assets.py --check` passed, `python -m pytest tests/test_dashboard_helper_size_reduction.py tests/test_dashboard_template_render_smoke.py -v --tb=line` passed, and `python -m pytest tests/test_kiosk_mode_buttons.py -v --tb=line` passed.
+  - Optional follow-up coverage remains for extra focused reward/chore helper payload round-trip assertions if we want to raise Phase 4 from targeted validation to fuller coverage completion.
+
+## Notes & follow-up
+
+- **Schema migration note**: No `.storage/choreops/choreops_data` schema bump is expected; this is a presentation-settings and helper-contract effort.
+- **Contract note**: The existing helper pattern already provides reviewed surfaces such as `translation_sensor_eid`, `chore_helper_eids`, and `ui_control`; universal precision should follow that same model instead of introducing ad hoc template-local state.
+- **Dashboard source-of-truth note**: All authored template changes belong in `choreops-dashboards`. Vendored template edits inside the integration are a downstream sync step only.
+- **Rollout note**: During transition, templates may temporarily support both helper-driven precision and local fallback-to-`fixed_0`, but the end state should remove redundant per-card precision declarations where they no longer provide value.
+- **Release note**: Communicate that users can now set one dashboard-wide points precision from General Options, and that the setting affects dashboard display only.

--- a/tests/test_backup_utilities.py
+++ b/tests/test_backup_utilities.py
@@ -613,7 +613,7 @@ async def test_backup_includes_config_entry_settings(
     mock_hass,
     mock_storage_manager,
 ):
-    """Test backup includes config_entry_settings section with all 10 system settings."""
+    """Test backup includes config_entry_settings section with all 11 system settings."""
     from unittest.mock import MagicMock
 
     from custom_components.choreops import const
@@ -628,6 +628,7 @@ async def test_backup_includes_config_entry_settings(
     mock_config_entry.options = {
         const.CONF_POINTS_LABEL: "Stars",
         const.CONF_POINTS_ICON: "mdi:star",
+        const.CONF_DASHBOARD_POINTS_PRECISION: const.DASHBOARD_POINTS_PRECISION_FIXED_2,
         const.CONF_DEFAULT_CHORE_POINTS: 2.5,
         const.CONF_UPDATE_INTERVAL: 10,
         const.CONF_CALENDAR_SHOW_PERIOD: 60,
@@ -666,9 +667,13 @@ async def test_backup_includes_config_entry_settings(
     assert const.DATA_CONFIG_ENTRY_SETTINGS in backup_content
 
     settings = backup_content[const.DATA_CONFIG_ENTRY_SETTINGS]
-    assert len(settings) == 10
+    assert len(settings) == 11
     assert settings[const.CONF_POINTS_LABEL] == "Stars"
     assert settings[const.CONF_POINTS_ICON] == "mdi:star"
+    assert (
+        settings[const.CONF_DASHBOARD_POINTS_PRECISION]
+        == const.DASHBOARD_POINTS_PRECISION_FIXED_2
+    )
     assert settings[const.CONF_DEFAULT_CHORE_POINTS] == 2.5
     assert settings[const.CONF_UPDATE_INTERVAL] == 10
     assert settings[const.CONF_CALENDAR_SHOW_PERIOD] == 60
@@ -691,7 +696,7 @@ async def test_roundtrip_preserves_all_settings(
     mock_hass,
     mock_storage_manager,
 ):
-    """Test backup → restore roundtrip preserves all 10 system settings exactly."""
+    """Test backup → restore roundtrip preserves all 11 system settings exactly."""
     from unittest.mock import MagicMock
 
     from custom_components.choreops import const
@@ -707,6 +712,7 @@ async def test_roundtrip_preserves_all_settings(
     original_settings = {
         const.CONF_POINTS_LABEL: "Gems",
         const.CONF_POINTS_ICON: "mdi:diamond",
+        const.CONF_DASHBOARD_POINTS_PRECISION: const.DASHBOARD_POINTS_PRECISION_ADAPTIVE,
         const.CONF_DEFAULT_CHORE_POINTS: 7.25,
         const.CONF_UPDATE_INTERVAL: 15,
         const.CONF_CALENDAR_SHOW_PERIOD: 120,
@@ -748,8 +754,8 @@ async def test_roundtrip_preserves_all_settings(
     # Step 3: Simulate restore - validate and compare
     restored_settings = validate_config_entry_settings(backed_up_settings)
 
-    # Assert: All 10 settings preserved exactly
-    assert len(restored_settings) == 10
+    # Assert: All settings preserved exactly, including newly added ones.
+    assert len(restored_settings) == len(original_settings)
     for key, original_value in original_settings.items():
         assert restored_settings[key] == original_value, (
             f"Setting {key} not preserved: expected {original_value}, "

--- a/tests/test_dashboard_helper_size_reduction.py
+++ b/tests/test_dashboard_helper_size_reduction.py
@@ -25,6 +25,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 import pytest
 
+from custom_components.choreops import const
 from tests.helpers import (
     ATTR_CLAIMED_BY,
     ATTR_COMPLETED_BY,
@@ -268,6 +269,21 @@ class TestDashboardHelperUiControl:
         ui_control = helper_state.attributes.get("ui_control")
         assert isinstance(ui_control, dict)
         assert ui_control["gamification"]["rewards"]["header_collapse"] is True
+
+    async def test_dashboard_config_includes_resolved_points_precision(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+    ) -> None:
+        """Dashboard helper should expose resolved dashboard config for templates."""
+        helper_state = hass.states.get("sensor.zoe_choreops_ui_dashboard_helper")
+        assert helper_state is not None
+
+        dashboard_config = helper_state.attributes.get(const.ATTR_DASHBOARD_CONFIG)
+        assert isinstance(dashboard_config, dict)
+        assert dashboard_config.get(const.ATTR_POINTS_PRECISION) == (
+            const.DEFAULT_DASHBOARD_POINTS_PRECISION
+        )
 
 
 class TestAssigneeChoresSensorAttributes:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -252,6 +252,7 @@ async def test_diagnostics_includes_settings(hass, mock_config_entry, mock_coord
     mock_config_entry.options = {
         const.CONF_POINTS_LABEL: "Credits",
         const.CONF_POINTS_ICON: "mdi:currency-usd",
+        const.CONF_DASHBOARD_POINTS_PRECISION: const.DASHBOARD_POINTS_PRECISION_FIXED_1,
         const.CONF_DEFAULT_CHORE_POINTS: 2.5,
         const.CONF_UPDATE_INTERVAL: 25,
         const.CONF_CALENDAR_SHOW_PERIOD: 45,
@@ -270,13 +271,17 @@ async def test_diagnostics_includes_settings(hass, mock_config_entry, mock_coord
     # Get diagnostics
     result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
 
-    # Assert: config_entry_settings section exists with all 10 settings
+    # Assert: config_entry_settings section exists with all 11 settings
     assert const.DATA_CONFIG_ENTRY_SETTINGS in result
     settings = result[const.DATA_CONFIG_ENTRY_SETTINGS]
 
-    assert len(settings) == 10
+    assert len(settings) == 11
     assert settings[const.CONF_POINTS_LABEL] == "Credits"
     assert settings[const.CONF_POINTS_ICON] == "mdi:currency-usd"
+    assert (
+        settings[const.CONF_DASHBOARD_POINTS_PRECISION]
+        == const.DASHBOARD_POINTS_PRECISION_FIXED_1
+    )
     assert settings[const.CONF_UPDATE_INTERVAL] == 25
     assert settings[const.CONF_CALENDAR_SHOW_PERIOD] == 45
     assert settings[const.CONF_RETENTION_DAILY] == 8

--- a/tests/test_kiosk_mode_buttons.py
+++ b/tests/test_kiosk_mode_buttons.py
@@ -54,6 +54,21 @@ async def _press_button(
     )
 
 
+def _get_schema_default_value(data_schema: Any, field_key: str) -> Any:
+    """Return the default value for a voluptuous schema field."""
+    for schema_key in data_schema.schema:
+        normalized_key = getattr(schema_key, "schema", schema_key)
+        if normalized_key != field_key:
+            continue
+
+        default = getattr(schema_key, "default", None)
+        if callable(default):
+            return default()
+        return default
+
+    return None
+
+
 @pytest.fixture
 async def scenario_minimal(
     hass: HomeAssistant,
@@ -421,6 +436,9 @@ async def test_options_flow_saves_kiosk_mode_toggle(
         result["flow_id"],
         user_input={
             const.CFOF_SYSTEM_INPUT_POINTS_ADJUST_VALUES: "1|-1|2|-2|10|-10",
+            const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION: (
+                const.DASHBOARD_POINTS_PRECISION_FIXED_2
+            ),
             const.CFOF_SYSTEM_INPUT_UPDATE_INTERVAL: 5,
             const.CFOF_SYSTEM_INPUT_CALENDAR_SHOW_PERIOD: 90,
             const.CFOF_SYSTEM_INPUT_RETENTION_PERIODS: "14|5|3|3",
@@ -435,8 +453,32 @@ async def test_options_flow_saves_kiosk_mode_toggle(
 
     updated_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
     assert updated_entry is not None
+    assert (
+        updated_entry.options.get(const.CONF_DASHBOARD_POINTS_PRECISION)
+        == const.DASHBOARD_POINTS_PRECISION_FIXED_2
+    )
     assert updated_entry.options.get(const.CONF_KIOSK_MODE) is True
     assert updated_entry.options.get(const.CONF_ADMIN_APPROVAL_BYPASS) is False
+
+    reopened_result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+    reopened_result = await hass.config_entries.options.async_configure(
+        reopened_result["flow_id"],
+        user_input={OPTIONS_FLOW_INPUT_MENU_SELECTION: OPTIONS_FLOW_GENERAL_OPTIONS},
+    )
+
+    assert (
+        reopened_result.get("step_id") == const.OPTIONS_FLOW_STEP_MANAGE_GENERAL_OPTIONS
+    )
+    assert reopened_result.get("data_schema") is not None
+    assert (
+        _get_schema_default_value(
+            reopened_result["data_schema"],
+            const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION,
+        )
+        == const.DASHBOARD_POINTS_PRECISION_FIXED_2
+    )
 
 
 async def test_service_claim_auth_stays_strict_with_kiosk_enabled(

--- a/tests/test_points_helpers.py
+++ b/tests/test_points_helpers.py
@@ -116,6 +116,61 @@ def test_build_points_schema_rejects_zero_default_chore_points() -> None:
         )
 
 
+def test_build_general_options_schema_includes_dashboard_points_precision() -> None:
+    """Test general options schema includes dashboard points precision selector."""
+    schema = fh.build_general_options_schema()
+
+    assert const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION in schema.schema
+
+
+def test_validate_all_system_settings_accepts_dashboard_points_precision() -> None:
+    """Test system settings validation accepts a supported precision mode."""
+    user_input = {
+        const.CONF_POINTS_LABEL: "Stars",
+        const.CONF_POINTS_ICON: "mdi:star",
+        const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION: (
+            const.DASHBOARD_POINTS_PRECISION_FIXED_2
+        ),
+        const.CFOF_SYSTEM_INPUT_DEFAULT_CHORE_POINTS: 2.5,
+        const.CFOF_SYSTEM_INPUT_UPDATE_INTERVAL: 5,
+        const.CFOF_SYSTEM_INPUT_CALENDAR_SHOW_PERIOD: 90,
+        const.CFOF_SYSTEM_INPUT_RETENTION_DAILY: 14,
+        const.CFOF_SYSTEM_INPUT_RETENTION_WEEKLY: 5,
+        const.CFOF_SYSTEM_INPUT_RETENTION_MONTHLY: 3,
+        const.CFOF_SYSTEM_INPUT_RETENTION_YEARLY: 3,
+        const.CFOF_SYSTEM_INPUT_POINTS_ADJUST_VALUES: "1|-1|2|-2|10|-10",
+    }
+
+    errors = fh.validate_all_system_settings(user_input)
+
+    assert errors == {}
+
+
+def test_validate_all_system_settings_rejects_invalid_dashboard_points_precision() -> (
+    None
+):
+    """Test system settings validation rejects unsupported precision values."""
+    user_input = {
+        const.CONF_POINTS_LABEL: "Stars",
+        const.CONF_POINTS_ICON: "mdi:star",
+        const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION: "bogus",
+        const.CFOF_SYSTEM_INPUT_DEFAULT_CHORE_POINTS: 2.5,
+        const.CFOF_SYSTEM_INPUT_UPDATE_INTERVAL: 5,
+        const.CFOF_SYSTEM_INPUT_CALENDAR_SHOW_PERIOD: 90,
+        const.CFOF_SYSTEM_INPUT_RETENTION_DAILY: 14,
+        const.CFOF_SYSTEM_INPUT_RETENTION_WEEKLY: 5,
+        const.CFOF_SYSTEM_INPUT_RETENTION_MONTHLY: 3,
+        const.CFOF_SYSTEM_INPUT_RETENTION_YEARLY: 3,
+        const.CFOF_SYSTEM_INPUT_POINTS_ADJUST_VALUES: "1|-1|2|-2|10|-10",
+    }
+
+    errors = fh.validate_all_system_settings(user_input)
+
+    assert errors[const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION] == (
+        const.TRANS_KEY_CFOF_DASHBOARD_POINTS_PRECISION
+    )
+
+
 def test_validate_points_inputs_empty_label() -> None:
     """Test validate_points_inputs rejects empty label."""
     user_input = {


### PR DESCRIPTION
Add a General Options selector for dashboard-wide points precision and expose the resolved value through the dashboard helper payload.

- persist dashboard points precision in config entry options
- publish resolved precision under dashboard_config on the helper sensor
- sync the canonical dashboard asset contract into the integration mirror
- add targeted helper, render, and options-flow regression coverage

## Summary

- Describe what changed and why.

## Linked issue

- Closes #140

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [ ] Correct release-note label is applied for `.github/release.yml` categorization
- [ ] Excluded triage or status labels have been removed before merge
- [x] PR title is suitable for generated release notes

## Change type

- [ ] Bug fix
- [x] Enhancement
- [ ] Refactor
- [x] Documentation

## Scope

- [x] Integration logic/state
- [x] Dashboard/template behavior
- [ ] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [x] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/ -v --tb=line` (or targeted suite with rationale)

## Documentation impact

- [ ] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

## Release notes

- [x] No release notes needed
- [ ] Release notes needed (summarize user-visible changes below)

- Release note summary:

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)
