### PR TITLE
fix(choreops): missed notification loop

### DIFF
--- a/custom_components/choreops/engines/schedule_engine.py
+++ b/custom_components/choreops/engines/schedule_engine.py
@@ -1186,6 +1186,7 @@ def calculate_next_due_date_from_chore_info(
                 interval_unit=custom_unit,
                 delta=custom_interval,
                 require_future=True,
+                reference_datetime=reference_time,
                 return_type=const.HELPER_RETURN_DATETIME,
             ),
         )

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -5679,8 +5679,14 @@ class ChoreManager(BaseManager):
         # Emit signal for StatisticsManager to handle period buckets
         # Pass missed_streak_tally for daily bucket snapshot (display purposes)
         # Phase 3 Step 2: Include optional due_date and reason fields (D-07)
+        chore_info = self.coordinator.chores_data.get(chore_id)
         signal_payload: dict[str, Any] = {
             "chore_id": chore_id,
+            "chore_name": str(
+                chore_info.get(const.DATA_CHORE_NAME, "Unknown Chore")
+                if chore_info
+                else "Unknown Chore"
+            ),
             "user_id": assignee_id,
             "user_name": assignee_name,
             "missed_streak_tally": new_missed_streak,


### PR DESCRIPTION
What changed:
- Found that custom_from_complete could reschedule a chore back into the past after a missed-and-locked reset.
- Included chore_name in the CHORE_MISSED payload so missed notifications no longer fall back to Unknown Chore.

Why:
- Prevent repeated expired/missed notifications

Fixes #132
Fixes #133 
