### PR TITLE
feat(notifications): add per-user configurable notification clickAction URL

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -616,6 +616,8 @@ CFOF_GLOBAL_INPUT_INTERNAL_ID: Final = "internal_id"
 CFOF_USERS_INPUT_NAME: Final = "name"
 CFOF_USERS_INPUT_HA_USER_ID: Final = "ha_user_id"
 CFOF_USERS_INPUT_MOBILE_NOTIFY_SERVICE: Final = "mobile_notify_service"
+CFOF_USERS_INPUT_NOTIF_CLICK_URL: Final = "notif_click_url"
+CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL: Final = "notif_approve_click_url"
 
 # DATA RECOVERY
 CFOF_DATA_RECOVERY_INPUT_SELECTION: Final = "backup_selection"
@@ -1209,6 +1211,8 @@ DATA_USER_REWARD_STATS: Final = "reward_stats"
 
 DATA_USER_USE_PERSISTENT_NOTIFICATIONS: Final = "use_persistent_notifications"
 DATA_USER_DASHBOARD_LANGUAGE: Final = "dashboard_language"
+DATA_USER_NOTIF_CLICK_URL: Final = "notif_click_url"
+DATA_USER_NOTIF_APPROVE_CLICK_URL: Final = "notif_approve_click_url"
 
 # USERS (capability model)
 DATA_USER_ID: Final = "user_id"

--- a/custom_components/choreops/data_builders.py
+++ b/custom_components/choreops/data_builders.py
@@ -874,6 +874,15 @@ def build_user_assignment_profile(
                 const.DEFAULT_DASHBOARD_LANGUAGE,
             )
         ),
+        const.DATA_USER_NOTIF_CLICK_URL: str(
+            _resolve_user_input_field(
+                user_input,
+                existing_data,
+                const.CFOF_USERS_INPUT_NOTIF_CLICK_URL,
+                const.DATA_USER_NOTIF_CLICK_URL,
+                "",
+            )
+        ),
         const.DATA_USER_UI_PREFERENCES: _normalize_dict_field(
             _resolve_user_input_field(
                 user_input,
@@ -1185,6 +1194,24 @@ def build_user_profile(
                 const.DEFAULT_DASHBOARD_LANGUAGE,
             )
         ),
+        const.DATA_USER_NOTIF_CLICK_URL: str(
+            _resolve_user_input_field(
+                user_input,
+                existing_data,
+                const.CFOF_USERS_INPUT_NOTIF_CLICK_URL,
+                const.DATA_USER_NOTIF_CLICK_URL,
+                "",
+            )
+        ),
+        const.DATA_USER_NOTIF_APPROVE_CLICK_URL: str(
+            _resolve_user_input_field(
+                user_input,
+                existing_data,
+                const.CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL,
+                const.DATA_USER_NOTIF_APPROVE_CLICK_URL,
+                "",
+            )
+        ),
         const.DATA_USER_UI_PREFERENCES: _normalize_dict_field(
             _resolve_user_input_field(
                 user_input,
@@ -1258,6 +1285,8 @@ _USER_MANAGER_PROFILE_PRESERVE_FIELDS: frozenset[str] = frozenset(
         const.DATA_USER_MOBILE_NOTIFY_SERVICE,
         const.DATA_USER_USE_PERSISTENT_NOTIFICATIONS,
         const.DATA_USER_DASHBOARD_LANGUAGE,
+        const.DATA_USER_NOTIF_CLICK_URL,
+        const.DATA_USER_NOTIF_APPROVE_CLICK_URL,
         const.DATA_USER_UI_PREFERENCES,
     }
 )

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -296,6 +296,7 @@ USER_IDENTITY_FIELDS = (
     const.CFOF_USERS_INPUT_HA_USER_ID,
     const.CFOF_USERS_INPUT_DASHBOARD_LANGUAGE,
     const.CFOF_USERS_INPUT_MOBILE_NOTIFY_SERVICE,
+    const.CFOF_USERS_INPUT_NOTIF_CLICK_URL,
 )
 
 USER_SYSTEM_USAGE_FIELDS = (
@@ -308,6 +309,7 @@ USER_ADMIN_APPROVAL_FIELDS = (
     const.CFOF_USERS_INPUT_CAN_APPROVE,
     const.CFOF_USERS_INPUT_CAN_MANAGE,
     const.CFOF_USERS_INPUT_ASSOCIATED_USER_IDS,
+    const.CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL,
 )
 
 
@@ -411,6 +413,14 @@ async def _build_user_schema_impl(
                 multiple=False,
             )
         ),
+        vol.Optional(
+            const.CFOF_USERS_INPUT_NOTIF_CLICK_URL,
+            default="",
+        ): selector.TextSelector(
+            selector.TextSelectorConfig(
+                type=selector.TextSelectorType.URL,
+            )
+        ),
     }
 
     usage_fields: dict[Any, Any] = {
@@ -433,6 +443,14 @@ async def _build_user_schema_impl(
             const.CFOF_USERS_INPUT_CAN_APPROVE,
             default=False,
         ): selector.BooleanSelector(),
+        vol.Optional(
+            const.CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL,
+            default="",
+        ): selector.TextSelector(
+            selector.TextSelectorConfig(
+                type=selector.TextSelectorType.URL,
+            )
+        ),
         vol.Optional(
             const.CFOF_USERS_INPUT_CAN_MANAGE,
             default=False,

--- a/custom_components/choreops/managers/notification_manager.py
+++ b/custom_components/choreops/managers/notification_manager.py
@@ -1014,6 +1014,13 @@ class NotificationManager(BaseManager):
             if notification_tag:
                 final_extra_data[const.NOTIFY_TAG] = notification_tag
 
+            # Add clickAction URL if user has configured one
+            notif_click_url = str(
+                assignee_info.get(const.DATA_USER_NOTIF_CLICK_URL, const.SENTINEL_EMPTY)
+            )
+            if notif_click_url:
+                final_extra_data["clickAction"] = notif_click_url
+
             await self._send_notification(
                 mobile_notify_service,
                 title,
@@ -1162,12 +1169,22 @@ class NotificationManager(BaseManager):
 
             if mobile_notify_service:
                 approver_count += 1
+                # Build extra_data with clickAction if approver has one configured
+                final_extra_data = dict(extra_data) if extra_data else {}
+                notif_click_url = str(
+                    approver_info.get(
+                        const.DATA_USER_NOTIF_APPROVE_CLICK_URL,
+                        const.SENTINEL_EMPTY,
+                    )
+                )
+                if notif_click_url:
+                    final_extra_data["clickAction"] = notif_click_url
                 await self._send_notification(
                     mobile_notify_service,
                     title,
                     message,
                     actions=actions,
-                    extra_data=extra_data,
+                    extra_data=final_extra_data or None,
                 )
             elif persistent_enabled:
                 approver_count += 1
@@ -1312,6 +1329,15 @@ class NotificationManager(BaseManager):
             if notification_tag:
                 final_extra_data[const.NOTIFY_TAG] = notification_tag
 
+            # Add clickAction URL if approver has configured one
+            notif_click_url = str(
+                approver_info.get(
+                    const.DATA_USER_NOTIF_APPROVE_CLICK_URL, const.SENTINEL_EMPTY
+                )
+            )
+            if notif_click_url:
+                final_extra_data["clickAction"] = notif_click_url
+
             # Determine notification method and prepare coroutine
             persistent_enabled = approver_info.get(
                 const.DATA_USER_USE_PERSISTENT_NOTIFICATIONS,
@@ -1448,6 +1474,16 @@ class NotificationManager(BaseManager):
             )
 
             if mobile_notify_service:
+                # Build extra_data with clickAction if approver has configured one
+                broadcast_extra_data: dict[str, str] = {}
+                notif_click_url = str(
+                    approver_info.get(
+                        const.DATA_USER_NOTIF_APPROVE_CLICK_URL,
+                        const.SENTINEL_EMPTY,
+                    )
+                )
+                if notif_click_url:
+                    broadcast_extra_data["clickAction"] = notif_click_url
                 notification_tasks.append(
                     (
                         approver_id,
@@ -1455,6 +1491,7 @@ class NotificationManager(BaseManager):
                             mobile_notify_service,
                             title,
                             message,
+                            extra_data=broadcast_extra_data or None,
                         ),
                     )
                 )

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -81,13 +81,15 @@
               "name": "Name",
               "ha_user_id": "Home Assistant User",
               "dashboard_language": "Language",
-              "mobile_notify_service": "Notifications"
+              "mobile_notify_service": "Notifications",
+              "notif_click_url": "Notification tap URL"
             },
             "data_description": {
               "name": "Unique name for this user profile.",
               "ha_user_id": "Optional: Link this profile to a Home Assistant user. If kiosk mode is disabled, shared-device claim and redeem actions rely on this link.",
               "dashboard_language": "Language used for dashboard content and notifications.",
-              "mobile_notify_service": "Select notification service or leave empty to disable notifications."
+              "mobile_notify_service": "Select notification service or leave empty to disable notifications.",
+              "notif_click_url": "Optional URL to open when notification is tapped. Leave empty for default behavior."
             }
           },
           "section_system_usage": {
@@ -110,12 +112,14 @@
             "data": {
               "can_approve": "Can approve",
               "can_manage": "Can manage",
-              "associated_user_ids": "Associated users"
+              "associated_user_ids": "Associated users",
+              "notif_approve_click_url": "Approval notification tap URL"
             },
             "data_description": {
               "can_approve": "Allows approval and disapproval actions.",
               "can_manage": "Allows management actions that require elevated permissions.",
-              "associated_user_ids": "Users this approver/admin supervises for approval actions."
+              "associated_user_ids": "Users this approver/admin supervises for approval actions.",
+              "notif_approve_click_url": "Optional URL for approval notifications. Overrides the general notification tap URL when approving chores or rewards."
             }
           }
         }
@@ -569,13 +573,15 @@
               "name": "Name",
               "ha_user_id": "Home Assistant User",
               "dashboard_language": "Language",
-              "mobile_notify_service": "Notifications"
+              "mobile_notify_service": "Notifications",
+              "notif_click_url": "Notification tap URL"
             },
             "data_description": {
               "name": "Unique name for this user profile.",
               "ha_user_id": "Optional: Link this profile to a Home Assistant user. If kiosk mode is disabled, shared-device claim and redeem actions rely on this link.",
               "dashboard_language": "Language used for dashboard content and notifications.",
-              "mobile_notify_service": "Select notification service or leave empty to disable notifications."
+              "mobile_notify_service": "Select notification service or leave empty to disable notifications.",
+              "notif_click_url": "Optional URL to open when notification is tapped. Leave empty for default behavior."
             }
           },
           "section_system_usage": {
@@ -598,12 +604,14 @@
             "data": {
               "can_approve": "Can approve",
               "can_manage": "Can manage",
-              "associated_user_ids": "Associated users"
+              "associated_user_ids": "Associated users",
+              "notif_approve_click_url": "Approval notification tap URL"
             },
             "data_description": {
               "can_approve": "Allows approval and disapproval actions.",
               "can_manage": "Allows management actions that require elevated permissions.",
-              "associated_user_ids": "Users this approver/admin supervises for approval actions."
+              "associated_user_ids": "Users this approver/admin supervises for approval actions.",
+              "notif_approve_click_url": "Optional URL for approval notifications. Overrides the general notification tap URL when approving chores or rewards."
             }
           }
         }
@@ -1000,13 +1008,15 @@
               "name": "Name",
               "ha_user_id": "Home Assistant User",
               "dashboard_language": "Language",
-              "mobile_notify_service": "Notifications"
+              "mobile_notify_service": "Notifications",
+              "notif_click_url": "Notification tap URL"
             },
             "data_description": {
               "name": "Unique name for this user profile.",
               "ha_user_id": "Optional: Link this profile to a Home Assistant user. If kiosk mode is disabled, shared-device claim and redeem actions rely on this link.",
               "dashboard_language": "Language used for dashboard content and notifications.",
-              "mobile_notify_service": "Select notification service or leave empty to disable notifications."
+              "mobile_notify_service": "Select notification service or leave empty to disable notifications.",
+              "notif_click_url": "Optional URL to open when notification is tapped. Leave empty for default behavior."
             }
           },
           "section_system_usage": {
@@ -1029,12 +1039,14 @@
             "data": {
               "can_approve": "Can approve",
               "can_manage": "Can manage",
-              "associated_user_ids": "Associated users"
+              "associated_user_ids": "Associated users",
+              "notif_approve_click_url": "Approval notification tap URL"
             },
             "data_description": {
               "can_approve": "Allows approval and disapproval actions.",
               "can_manage": "Allows management actions that require elevated permissions.",
-              "associated_user_ids": "Users this approver/admin supervises for approval actions."
+              "associated_user_ids": "Users this approver/admin supervises for approval actions.",
+              "notif_approve_click_url": "Optional URL for approval notifications. Overrides the general notification tap URL when approving chores or rewards."
             }
           }
         }

--- a/custom_components/choreops/type_defs.py
+++ b/custom_components/choreops/type_defs.py
@@ -621,6 +621,8 @@ class AssigneeData(TypedDict):
     mobile_notify_service: str
     use_persistent_notifications: bool
     dashboard_language: NotRequired[str]
+    notif_click_url: NotRequired[str]
+    notif_approve_click_url: NotRequired[str]
     ui_preferences: NotRequired[dict[str, Any]]
 
     # Badge tracking


### PR DESCRIPTION
Add two optional per-user fields that inject a `clickAction` value into mobile notification payloads, allowing users to land on a specific dashboard when tapping a notification instead of the last-open screen.

- `notif_click_url`: Used for assignee-directed notifications (chore approved, badge earned, points awarded). Configurable in the Identity and profile section of the user form.
- `notif_approve_click_url`: Used for approver-directed notifications (chore/reward claimed, needs review). Configurable in the Admin and approval options section, positioned below the Can approve toggle.

Both fields are optional URL-type text inputs with empty-string defaults, fully backward compatible with no migration needed. Each recipient's own URL is used based on notification role (assignee vs approver), supporting users who serve in both capacities with different landing pages.

Completes Configurable notification clickAction URL per user

Fixes #111
