### PR TITLE
fix(config-flow): Default CAN_BE_ASSIGNED to True for all new users

### DIFF
--- a/custom_components/choreops/config_flow.py
+++ b/custom_components/choreops/config_flow.py
@@ -664,20 +664,9 @@ class ChoreOpsConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                 const.CFOF_USERS_INPUT_ENABLE_GAMIFICATION,
                 False,
             )
-
-            has_usage_context = any(
-                user_input.get(key)
-                for key in (
-                    const.CFOF_USERS_INPUT_ASSOCIATED_USER_IDS,
-                    const.CFOF_USERS_INPUT_CAN_APPROVE,
-                    const.CFOF_USERS_INPUT_CAN_MANAGE,
-                    const.CFOF_USERS_INPUT_ENABLE_CHORE_WORKFLOW,
-                    const.CFOF_USERS_INPUT_ENABLE_GAMIFICATION,
-                )
-            )
             user_input.setdefault(
                 const.CFOF_USERS_INPUT_CAN_BE_ASSIGNED,
-                not has_usage_context,
+                True,
             )
 
             errors = fh.validate_users_inputs(


### PR DESCRIPTION
What changed:
- Replaced has_usage_context auto-detection block with unconditional setdefault(CAN_BE_ASSIGNED, True) in async_step_users
- Users with can_approve/can_manage roles now default to assignable instead of being excluded from the assignee selection list

Why:
- The old logic assumed admin/approver roles were mutually exclusive with being an assignee, preventing approvers from being selected for chores unless they explicitly checked can_be_assigned

## Summary

- Describe what changed and why.

## Linked issue

- Closes #164 