### PR TITLE
feat: track overdue duration statistics

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -246,6 +246,7 @@ SIGNAL_SUFFIX_CHORE_DISAPPROVED: Final = "chore_disapproved"
 SIGNAL_SUFFIX_CHORE_UNDONE: Final = "chore_undone"
 SIGNAL_SUFFIX_CHORE_CLAIM_UNDONE: Final = "chore_claim_undone"
 SIGNAL_SUFFIX_CHORE_OVERDUE: Final = "chore_overdue"
+SIGNAL_SUFFIX_CHORE_OVERDUE_RESOLVED: Final = "chore_overdue_resolved"
 SIGNAL_SUFFIX_CHORE_MISSED: Final = "chore_missed"
 SIGNAL_SUFFIX_CHORE_DUE_REMINDER: Final = "chore_due_reminder"
 SIGNAL_SUFFIX_CHORE_DUE_WINDOW: Final = "chore_due_window"
@@ -1075,6 +1076,7 @@ DATA_USER_CHORE_DATA_LAST_CLAIMED: Final = "last_claimed"
 DATA_USER_CHORE_DATA_LAST_COMPLETED: Final = "last_completed"
 DATA_USER_CHORE_DATA_LAST_DISAPPROVED: Final = "last_disapproved"
 DATA_USER_CHORE_DATA_LAST_OVERDUE: Final = "last_overdue"
+DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT: Final = "overdue_started_at"
 DATA_USER_CHORE_DATA_LAST_MISSED: Final = "last_missed"
 DATA_USER_CHORE_DATA_LAST_LONGEST_STREAK_ALL_TIME: Final = (
     "last_longest_streak_all_time"
@@ -1101,6 +1103,13 @@ DATA_USER_CHORE_DATA_PERIOD_LONGEST_STREAK: Final = (
     "longest_streak"  # All-time: high water mark (HWM)
 )
 DATA_USER_CHORE_DATA_PERIOD_OVERDUE: Final = "overdue"
+DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: Final = (
+    "overdue_duration_total_seconds"
+)
+DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: Final = "overdue_duration_count"
+DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: Final = (
+    "overdue_duration_max_seconds"
+)
 DATA_USER_CHORE_DATA_PERIOD_MISSED: Final = "missed"
 DATA_USER_CHORE_DATA_PERIOD_MISSED_STREAK_TALLY: Final = (
     "missed_streak_tally"  # Daily consecutive misses
@@ -1365,6 +1374,32 @@ PRES_USER_CHORES_MISSED_WEEK: Final = "pres_user_chores_missed_week"
 PRES_USER_CHORES_MISSED_MONTH: Final = "pres_user_chores_missed_month"
 PRES_USER_CHORES_MISSED_YEAR: Final = "pres_user_chores_missed_year"
 
+PRES_USER_CHORES_AVG_OVERDUE_SECONDS_TODAY: Final = (
+    "pres_user_chores_avg_overdue_seconds_today"
+)
+PRES_USER_CHORES_AVG_OVERDUE_SECONDS_WEEK: Final = (
+    "pres_user_chores_avg_overdue_seconds_week"
+)
+PRES_USER_CHORES_AVG_OVERDUE_SECONDS_MONTH: Final = (
+    "pres_user_chores_avg_overdue_seconds_month"
+)
+PRES_USER_CHORES_AVG_OVERDUE_SECONDS_YEAR: Final = (
+    "pres_user_chores_avg_overdue_seconds_year"
+)
+
+PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_TODAY: Final = (
+    "pres_user_chores_longest_overdue_seconds_today"
+)
+PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_WEEK: Final = (
+    "pres_user_chores_longest_overdue_seconds_week"
+)
+PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_MONTH: Final = (
+    "pres_user_chores_longest_overdue_seconds_month"
+)
+PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_YEAR: Final = (
+    "pres_user_chores_longest_overdue_seconds_year"
+)
+
 PRES_USER_CHORES_POINTS_TODAY: Final = "pres_user_chores_points_today"
 PRES_USER_CHORES_POINTS_WEEK: Final = "pres_user_chores_points_week"
 PRES_USER_CHORES_POINTS_MONTH: Final = "pres_user_chores_points_month"
@@ -1583,6 +1618,9 @@ CHORE_OVERDUE_EVENT_MESSAGE_TYPE: Final = "overdue_message_type"
 CHORE_OVERDUE_NOTIFICATION_TYPE_DEFAULT: Final = "default"
 CHORE_OVERDUE_NOTIFICATION_TYPE_STEAL_AVAILABLE: Final = "steal_available"
 CHORE_OVERDUE_NOTIFICATION_TYPE_STANDBY_NEEDED: Final = "standby_needed"
+CHORE_OVERDUE_RESOLVED_EVENT_DURATION_SECONDS: Final = "overdue_duration_seconds"
+CHORE_OVERDUE_RESOLVED_EVENT_STARTED_AT: Final = "overdue_started_at"
+CHORE_OVERDUE_RESOLVED_EVENT_RESOLVED_AT: Final = "overdue_resolved_at"
 
 DATA_CHORE_STATE: Final = "state"
 DATA_CHORE_TIMESTAMP: Final = "timestamp"
@@ -2478,6 +2516,8 @@ ATTR_CHORE_MISSED_COUNT: Final = "chore_missed_count"
 ATTR_CHORE_LAST_MISSED: Final = "chore_last_missed"
 ATTR_CHORE_POINTS_EARNED: Final = "chore_points_earned"
 ATTR_CHORE_OVERDUE_COUNT: Final = "chore_overdue_count"
+ATTR_CHORE_AVG_OVERDUE_SECONDS: Final = "chore_avg_overdue_seconds"
+ATTR_CHORE_LONGEST_OVERDUE_SECONDS: Final = "chore_longest_overdue_seconds"
 ATTR_CHORE_DISAPPROVED_COUNT: Final = "chore_disapproved_count"
 ATTR_CHORE_LAST_LONGEST_STREAK_DATE: Final = "chore_last_longest_streak_date"
 ATTR_CHORE_APPROVE_BUTTON_ENTITY_ID: Final = "approve_button_eid"

--- a/custom_components/choreops/engines/statistics_engine.py
+++ b/custom_components/choreops/engines/statistics_engine.py
@@ -257,6 +257,75 @@ class StatisticsEngine:
                 else:
                     all_time_bucket[metric] = current + value
 
+    def record_maximum(
+        self,
+        period_data: dict[str, Any],
+        maximums: Mapping[str, int | float],
+        period_key_mapping: Mapping[str, str] | None = None,
+        include_all_time: bool = True,
+        reference_date: date | datetime | None = None,
+    ) -> None:
+        """Record high-water marks across all period buckets.
+
+        Unlike record_transaction(), this keeps the maximum observed value for
+        each metric in the active daily/weekly/monthly/yearly buckets and the
+        optional all_time bucket.
+
+        Args:
+            period_data: Dictionary containing nested period structures.
+            maximums: Metrics to compare and their observed values.
+            period_key_mapping: Optional mapping from logical period names to
+                               data structure keys. Defaults to standard keys.
+            include_all_time: If True (default), also update all_time maximums.
+            reference_date: Date for period key generation. Defaults to today.
+        """
+        keys = self.get_period_keys(reference_date)
+
+        if period_key_mapping is None:
+            period_key_mapping = {
+                const.PERIOD_DAILY: const.PERIOD_DAILY,
+                const.PERIOD_WEEKLY: const.PERIOD_WEEKLY,
+                const.PERIOD_MONTHLY: const.PERIOD_MONTHLY,
+                const.PERIOD_YEARLY: const.PERIOD_YEARLY,
+            }
+
+        for period_type, period_key in keys.items():
+            data_key = period_key_mapping.get(period_type, period_type)
+            if data_key not in period_data:
+                period_data[data_key] = {}
+            if period_key not in period_data[data_key]:
+                period_data[data_key][period_key] = {}
+
+            bucket = period_data[data_key][period_key]
+            self._apply_maximums(bucket, maximums)
+
+        if include_all_time:
+            if const.PERIOD_ALL_TIME not in period_data:
+                period_data[const.PERIOD_ALL_TIME] = {}
+            all_time_container = period_data[const.PERIOD_ALL_TIME]
+            if const.PERIOD_ALL_TIME not in all_time_container:
+                all_time_container[const.PERIOD_ALL_TIME] = {}
+
+            self._apply_maximums(all_time_container[const.PERIOD_ALL_TIME], maximums)
+
+    @staticmethod
+    def _apply_maximums(
+        bucket: dict[str, Any],
+        maximums: Mapping[str, int | float],
+    ) -> None:
+        """Apply max updates to one period bucket."""
+        for metric, value in maximums.items():
+            current = bucket.get(metric)
+            if isinstance(current, (int, float)):
+                next_value = max(current, value)
+            else:
+                next_value = value
+
+            if isinstance(next_value, float):
+                bucket[metric] = round(next_value, const.DATA_FLOAT_PRECISION)
+            else:
+                bucket[metric] = next_value
+
     # ────────────────────────────────────────────────────────────────
     # Streak Management
     # ────────────────────────────────────────────────────────────────

--- a/custom_components/choreops/integrity/boot_repairs.py
+++ b/custom_components/choreops/integrity/boot_repairs.py
@@ -107,6 +107,10 @@ def repair_impossible_due_state_residue(data: dict[str, Any]) -> dict[str, int]:
                 assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = (
                     const.CHORE_STATE_PENDING
                 )
+                assignee_chore_data.pop(
+                    const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT,
+                    None,
+                )
                 current_state = const.CHORE_STATE_PENDING
                 summary["assignee_states_normalized"] += 1
                 chore_changed = True

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -176,6 +176,7 @@ class ChoreManager(BaseManager):
             tuple[str | None, str | None, timedelta | None, timedelta | None],
         ] = {}
         self._max_due_cache_entries = 2048
+        self._pending_overdue_resolution_signals: list[dict[str, Any]] = []
 
     async def async_setup(self) -> None:
         """Set up the ChoreManager.
@@ -847,6 +848,7 @@ class ChoreManager(BaseManager):
         else:
             # Persist → Emit (per DEVELOPMENT_STANDARDS.md § 5.3)
             self._coordinator._persist_and_update()
+            self._flush_overdue_resolution_signals()
 
         # Emit lifecycle milestone signal for claim handling.
         #
@@ -1307,6 +1309,7 @@ class ChoreManager(BaseManager):
 
         # Persist → Emit (per DEVELOPMENT_STANDARDS.md § 5.3)
         self._coordinator._persist_and_update()
+        self._flush_overdue_resolution_signals()
 
         if rotation_signal_payload:
             self.emit(
@@ -1427,6 +1430,7 @@ class ChoreManager(BaseManager):
 
         # Persist → Emit (per DEVELOPMENT_STANDARDS.md § 5.3)
         self._coordinator._persist_and_update()
+        self._flush_overdue_resolution_signals()
 
         # Emit disapproval event
         # StatisticsManager._on_chore_disapproved handles cache refresh and entity notification
@@ -1511,6 +1515,7 @@ class ChoreManager(BaseManager):
 
         # Persist → Emit (per DEVELOPMENT_STANDARDS.md § 5.3)
         self._coordinator._persist_and_update()
+        self._flush_overdue_resolution_signals()
 
         # Emit undo signal - EconomyManager listens and handles point withdrawal
         # (Platinum Architecture: signal-first, no cross-manager writes)
@@ -1632,6 +1637,7 @@ class ChoreManager(BaseManager):
         self._update_global_state(chore_id)
 
         self._coordinator._persist()
+        self._flush_overdue_resolution_signals()
         self._coordinator.async_set_updated_data(self._coordinator._data)
 
         # Emit event for NotificationManager to clear approver claim notifications
@@ -2121,8 +2127,11 @@ class ChoreManager(BaseManager):
                 == const.OVERDUE_HANDLING_AT_DUE_DATE_MARK_MISSED_AND_LOCK
             ):
                 # Lock the chore in MISSED state (not claimable)
-                assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = (
-                    const.CHORE_STATE_MISSED
+                self._set_assignee_chore_state(
+                    assignee_id,
+                    chore_id,
+                    assignee_chore_data,
+                    const.CHORE_STATE_MISSED,
                 )
                 self._update_global_state(chore_id)
 
@@ -3120,6 +3129,8 @@ class ChoreManager(BaseManager):
 
     def _emit_reset_events(self, reset_events: set[tuple[str, str, str]]) -> None:
         """Emit deferred reset events after the enclosing persist succeeds."""
+        self._flush_overdue_resolution_signals()
+
         for assignee_id, chore_id, chore_name in sorted(reset_events):
             self.emit(
                 const.SIGNAL_SUFFIX_CHORE_STATUS_RESET,
@@ -4612,6 +4623,144 @@ class ChoreManager(BaseManager):
             self._approval_locks[lock_key] = asyncio.Lock()
         return self._approval_locks[lock_key]
 
+    def _set_assignee_chore_state(
+        self,
+        assignee_id: str,
+        chore_id: str,
+        assignee_chore_data: dict[str, Any],
+        new_state: str,
+    ) -> None:
+        """Persist a per-assignee chore state and track overdue entry/exit."""
+        previous_state = cast(
+            "str",
+            assignee_chore_data.get(
+                const.DATA_USER_CHORE_DATA_STATE,
+                const.CHORE_STATE_PENDING,
+            ),
+        )
+        now_iso = dt_now_utc_iso()
+
+        if previous_state == new_state:
+            if new_state == const.CHORE_STATE_OVERDUE:
+                assignee_chore_data.setdefault(
+                    const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT,
+                    self._get_overdue_started_at(
+                        assignee_id,
+                        chore_id,
+                        now_iso,
+                    ),
+                )
+            else:
+                assignee_chore_data.pop(
+                    const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT,
+                    None,
+                )
+            assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = new_state
+            return
+
+        if new_state == const.CHORE_STATE_OVERDUE:
+            assignee_chore_data[const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT] = (
+                self._get_overdue_started_at(
+                    assignee_id,
+                    chore_id,
+                    now_iso,
+                )
+            )
+        elif previous_state == const.CHORE_STATE_OVERDUE:
+            self._queue_overdue_resolution_signal(
+                assignee_id,
+                chore_id,
+                assignee_chore_data,
+                now_iso,
+            )
+        else:
+            assignee_chore_data.pop(
+                const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT,
+                None,
+            )
+
+        assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = new_state
+
+    def _get_overdue_started_at(
+        self,
+        assignee_id: str,
+        chore_id: str,
+        fallback_iso: str,
+    ) -> str:
+        """Return the deadline timestamp that started the overdue interval."""
+        due_date = self.get_due_date(chore_id, assignee_id)
+        if due_date is None:
+            return fallback_iso
+
+        due_date_utc = dt_to_utc(due_date.isoformat())
+        fallback_utc = dt_to_utc(fallback_iso)
+        if due_date_utc is not None and fallback_utc is not None:
+            if due_date_utc <= fallback_utc:
+                return due_date_utc.isoformat()
+
+        return fallback_iso
+
+    def _queue_overdue_resolution_signal(
+        self,
+        assignee_id: str,
+        chore_id: str,
+        assignee_chore_data: dict[str, Any],
+        resolved_at_iso: str,
+    ) -> None:
+        """Queue an overdue duration signal for post-persist emission."""
+        started_at_iso = assignee_chore_data.pop(
+            const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT,
+            None,
+        )
+        if not isinstance(started_at_iso, str) or not started_at_iso:
+            const.LOGGER.debug(
+                "Skipping overdue duration signal with missing start timestamp: assignee=%s chore=%s",
+                assignee_id,
+                chore_id,
+            )
+            return
+
+        started_at = dt_to_utc(started_at_iso)
+        resolved_at = dt_to_utc(resolved_at_iso)
+        if started_at is None or resolved_at is None:
+            const.LOGGER.debug(
+                "Skipping overdue duration signal with invalid timestamps: assignee=%s chore=%s started_at=%s resolved_at=%s",
+                assignee_id,
+                chore_id,
+                started_at_iso,
+                resolved_at_iso,
+            )
+            return
+
+        duration_seconds = max(0, int((resolved_at - started_at).total_seconds()))
+        chore_info = cast(
+            "dict[str, Any]",
+            self._coordinator.chores_data.get(chore_id, {}),
+        )
+        self._pending_overdue_resolution_signals.append(
+            {
+                "user_id": assignee_id,
+                "chore_id": chore_id,
+                "chore_name": chore_info.get(const.DATA_CHORE_NAME, ""),
+                const.CHORE_OVERDUE_RESOLVED_EVENT_DURATION_SECONDS: duration_seconds,
+                const.CHORE_OVERDUE_RESOLVED_EVENT_STARTED_AT: started_at_iso,
+                const.CHORE_OVERDUE_RESOLVED_EVENT_RESOLVED_AT: resolved_at_iso,
+            }
+        )
+
+    def _flush_overdue_resolution_signals(self) -> None:
+        """Emit queued overdue duration signals after storage is persisted."""
+        signals = list(getattr(self, "_pending_overdue_resolution_signals", []))
+        if not signals:
+            return
+
+        self._pending_overdue_resolution_signals = []
+        for signal_data in signals:
+            self.emit(
+                const.SIGNAL_SUFFIX_CHORE_OVERDUE_RESOLVED,
+                **signal_data,
+            )
+
     def _transition_chore_state(
         self,
         assignee_id: str,
@@ -4656,7 +4805,12 @@ class ChoreManager(BaseManager):
         assignee_chore_data = self._get_assignee_chore_data(assignee_id, chore_id)
 
         # Update state
-        assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = new_state
+        self._set_assignee_chore_state(
+            assignee_id,
+            chore_id,
+            assignee_chore_data,
+            new_state,
+        )
 
         # Phase 2: completed_by_other_chores list management removed
         # SHARED_FIRST blocking is now computed dynamically in can_claim_chore()
@@ -4752,6 +4906,7 @@ class ChoreManager(BaseManager):
         # Persist and emit (per DEVELOPMENT_STANDARDS.md § 5.3)
         if persist:
             self._coordinator._persist()
+            self._flush_overdue_resolution_signals()
 
             # Phase 3 Step 1: Emit rotation signal after persist
             if rotation_signal_payload:
@@ -5536,7 +5691,12 @@ class ChoreManager(BaseManager):
                     state_to_persist,
                 )
                 state_to_persist = const.CHORE_STATE_PENDING
-            assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = state_to_persist
+            self._set_assignee_chore_state(
+                assignee_id,
+                chore_id,
+                assignee_chore_data,
+                state_to_persist,
+            )
 
         # Phase 2: completed_by_other_chores list management removed
         # SHARED_FIRST blocking is now computed dynamically in can_claim_chore()

--- a/custom_components/choreops/managers/statistics_manager.py
+++ b/custom_components/choreops/managers/statistics_manager.py
@@ -17,6 +17,7 @@ Event subscriptions:
 - SIGNAL_SUFFIX_CHORE_CLAIMED → _on_chore_claimed()
 - SIGNAL_SUFFIX_CHORE_DISAPPROVED → _on_chore_disapproved()
 - SIGNAL_SUFFIX_CHORE_OVERDUE → _on_chore_overdue()
+- SIGNAL_SUFFIX_CHORE_OVERDUE_RESOLVED → _on_chore_overdue_resolved()
 - SIGNAL_SUFFIX_REWARD_APPROVED → _on_reward_approved()
 
 PHASE 7.5 ARCHITECTURE (Statistics Presenter & Data Sanitization):
@@ -39,6 +40,7 @@ from homeassistant.core import callback
 
 from .. import const
 from ..utils.dt_utils import dt_add_interval, dt_now_local, dt_parse
+from ..utils.math_utils import calculate_average
 from .base_manager import BaseManager
 
 if TYPE_CHECKING:
@@ -135,6 +137,10 @@ class StatisticsManager(BaseManager):
         self.listen(const.SIGNAL_SUFFIX_CHORE_CLAIMED, self._on_chore_claimed)
         self.listen(const.SIGNAL_SUFFIX_CHORE_DISAPPROVED, self._on_chore_disapproved)
         self.listen(const.SIGNAL_SUFFIX_CHORE_OVERDUE, self._on_chore_overdue)
+        self.listen(
+            const.SIGNAL_SUFFIX_CHORE_OVERDUE_RESOLVED,
+            self._on_chore_overdue_resolved,
+        )
         self.listen(const.SIGNAL_SUFFIX_CHORE_MISSED, self._on_chore_missed)
 
         # Quiet transitions - state changes without bucket writes (snapshot only)
@@ -649,7 +655,7 @@ class StatisticsManager(BaseManager):
             )
 
     async def _on_chore_overdue(self, payload: dict[str, Any]) -> None:
-        """Handle CHORE_OVERDUE event - record overdue to period buckets.
+        """Handle CHORE_OVERDUE event - record overdue count to period buckets.
 
         Enforces max 1 overdue per day by checking today's bucket value before
         incrementing. This ensures daily buckets never exceed 1 for overdue count.
@@ -690,11 +696,15 @@ class StatisticsManager(BaseManager):
                 )
                 return
 
+        increments: dict[str, int | float] = {
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE: 1,
+        }
+
         # Proceed with increment (will create bucket if needed)
         if self._record_chore_transaction(
             assignee_id,
             chore_id,
-            {const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE: 1},
+            increments,
         ):
             # Transactional Flush: cache was refreshed inside _record_chore_transaction,
             # now notify sensors that data has changed
@@ -703,6 +713,52 @@ class StatisticsManager(BaseManager):
                 "StatisticsManager._on_chore_overdue: assignee=%s, chore=%s",
                 assignee_id,
                 chore_id,
+            )
+
+    async def _on_chore_overdue_resolved(self, payload: dict[str, Any]) -> None:
+        """Handle CHORE_OVERDUE_RESOLVED event - record time in overdue state."""
+        assignee_id = payload.get("user_id", "")
+        chore_id = payload.get("chore_id", "")
+        raw_duration = payload.get(const.CHORE_OVERDUE_RESOLVED_EVENT_DURATION_SECONDS)
+        resolved_at = payload.get(const.CHORE_OVERDUE_RESOLVED_EVENT_RESOLVED_AT)
+
+        if raw_duration is None:
+            const.LOGGER.warning(
+                "StatisticsManager._on_chore_overdue_resolved: Missing duration for assignee=%s, chore=%s",
+                assignee_id,
+                chore_id,
+            )
+            return
+
+        try:
+            overdue_duration_seconds = max(0, int(raw_duration))
+        except (TypeError, ValueError):
+            const.LOGGER.warning(
+                "StatisticsManager._on_chore_overdue_resolved: Invalid duration=%s for assignee=%s, chore=%s",
+                raw_duration,
+                assignee_id,
+                chore_id,
+            )
+            return
+
+        if self._record_chore_transaction(
+            assignee_id,
+            chore_id,
+            {
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: overdue_duration_seconds,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: 1,
+            },
+            effective_date=resolved_at,
+            maximums={
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: overdue_duration_seconds,
+            },
+        ):
+            self._coordinator.async_set_updated_data(self._coordinator._data)
+            const.LOGGER.debug(
+                "StatisticsManager._on_chore_overdue_resolved: assignee=%s, chore=%s, duration=%s",
+                assignee_id,
+                chore_id,
+                overdue_duration_seconds,
             )
 
     async def _on_chore_missed(self, payload: dict[str, Any]) -> None:
@@ -1366,6 +1422,7 @@ class StatisticsManager(BaseManager):
         chore_id: str,
         increments: dict[str, int | float],
         effective_date: str | None = None,
+        maximums: dict[str, int | float] | None = None,
         persist: bool = True,
     ) -> bool:
         """Record a chore transaction to period buckets.
@@ -1383,6 +1440,7 @@ class StatisticsManager(BaseManager):
             increments: Dict of metric keys to increment values.
             effective_date: ISO timestamp for approver-lag-proof bucketing.
                            If None, uses current time.
+            maximums: Optional metric high-water marks to write to the same buckets.
             persist: If True, calls _persist() and _refresh_chore_cache().
                     Set to False when batching multiple assignees.
 
@@ -1458,6 +1516,12 @@ class StatisticsManager(BaseManager):
             increments,
             reference_date=bucket_dt,
         )
+        if maximums:
+            self._stats_engine.record_maximum(
+                periods,
+                maximums,
+                reference_date=bucket_dt,
+            )
 
         # PHASE 2: Also record to assignee-level chore_periods bucket (v44+)
         # ChoreManager (Landlord) should have created this via _ensure_assignee_structures(assignee_id)
@@ -1469,6 +1533,12 @@ class StatisticsManager(BaseManager):
                 increments,
                 reference_date=bucket_dt,
             )
+            if maximums:
+                self._stats_engine.record_maximum(
+                    assignee_chore_periods,
+                    maximums,
+                    reference_date=bucket_dt,
+                )
         else:
             const.LOGGER.warning(
                 "StatisticsManager._record_chore_transaction: assignee-level chore_periods missing for "
@@ -1709,6 +1779,11 @@ class StatisticsManager(BaseManager):
             start_iso,
             end_iso,
         )
+        overdue_duration_rollup = self._rollup_overdue_duration(
+            chore_periods,
+            start_iso,
+            end_iso,
+        )
         rewards_rollup = self._rollup_period_metrics(
             reward_periods,
             [
@@ -1798,6 +1873,12 @@ class StatisticsManager(BaseManager):
                 "in_range_overdue": int(
                     chores_rollup["in_range"][const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE]
                 ),
+                "in_range_avg_overdue_seconds": overdue_duration_rollup[
+                    "in_range_avg_overdue_seconds"
+                ],
+                "in_range_longest_overdue_seconds": overdue_duration_rollup[
+                    "in_range_longest_overdue_seconds"
+                ],
                 "all_time_approved": int(
                     chores_rollup["all_time"][
                         const.DATA_USER_CHORE_DATA_PERIOD_APPROVED
@@ -1817,6 +1898,12 @@ class StatisticsManager(BaseManager):
                 "all_time_overdue": int(
                     chores_rollup["all_time"][const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE]
                 ),
+                "all_time_avg_overdue_seconds": overdue_duration_rollup[
+                    "all_time_avg_overdue_seconds"
+                ],
+                "all_time_longest_overdue_seconds": overdue_duration_rollup[
+                    "all_time_longest_overdue_seconds"
+                ],
             },
             "rewards": {
                 "in_range_approved": int(
@@ -1929,11 +2016,15 @@ class StatisticsManager(BaseManager):
                 "in_range_disapproved": 0,
                 "in_range_missed": 0,
                 "in_range_overdue": 0,
+                "in_range_avg_overdue_seconds": 0.0,
+                "in_range_longest_overdue_seconds": 0,
                 "all_time_approved": 0,
                 "all_time_claimed": 0,
                 "all_time_disapproved": 0,
                 "all_time_missed": 0,
                 "all_time_overdue": 0,
+                "all_time_avg_overdue_seconds": 0.0,
+                "all_time_longest_overdue_seconds": 0,
             },
             "rewards": {
                 "in_range_approved": 0,
@@ -1969,6 +2060,54 @@ class StatisticsManager(BaseManager):
                 "earned_badge_names": [],
                 "by_badge": {},
             },
+        }
+
+    def _rollup_overdue_duration(
+        self,
+        periods: dict[str, Any],
+        start_iso: str,
+        end_iso: str,
+    ) -> dict[str, int | float]:
+        """Return average and longest overdue duration rollups."""
+        total_metric = const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS
+        count_metric = const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT
+        max_metric = const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+
+        in_range = self._sum_daily_metrics(
+            periods,
+            [total_metric, count_metric],
+            start_iso,
+            end_iso,
+        )
+        in_range_max = self._max_daily_metric(periods, max_metric, start_iso, end_iso)
+
+        all_time_total = self._stats_engine.get_period_total(
+            periods,
+            const.PERIOD_ALL_TIME,
+            total_metric,
+        )
+        all_time_count = self._stats_engine.get_period_total(
+            periods,
+            const.PERIOD_ALL_TIME,
+            count_metric,
+        )
+        all_time_max = self._stats_engine.get_period_total(
+            periods,
+            const.PERIOD_ALL_TIME,
+            max_metric,
+        )
+
+        return {
+            "in_range_avg_overdue_seconds": calculate_average(
+                in_range[total_metric],
+                in_range[count_metric],
+            ),
+            "in_range_longest_overdue_seconds": in_range_max,
+            "all_time_avg_overdue_seconds": calculate_average(
+                all_time_total,
+                all_time_count,
+            ),
+            "all_time_longest_overdue_seconds": all_time_max,
         }
 
     def _rollup_period_metrics(
@@ -2166,6 +2305,41 @@ class StatisticsManager(BaseManager):
                     sums[metric] = sums[metric] + value
 
         return sums
+
+    def _max_daily_metric(
+        self,
+        periods: dict[str, Any],
+        metric: str,
+        start_iso: str,
+        end_iso: str,
+    ) -> int | float:
+        """Return the maximum daily metric value in a date range."""
+        parsed_start = dt_parse(start_iso)
+        parsed_end = dt_parse(end_iso)
+        if not isinstance(parsed_start, datetime) or not isinstance(
+            parsed_end, datetime
+        ):
+            return 0
+
+        start_key = parsed_start.date().isoformat()
+        end_key = parsed_end.date().isoformat()
+
+        daily_data = periods.get(const.PERIOD_DAILY, {})
+        if not isinstance(daily_data, dict):
+            return 0
+
+        max_value: int | float = 0
+        for day_key, bucket in daily_data.items():
+            if not isinstance(day_key, str) or not isinstance(bucket, dict):
+                continue
+            if day_key < start_key or day_key > end_key:
+                continue
+
+            value = bucket.get(metric, 0)
+            if isinstance(value, (int, float)):
+                max_value = max(max_value, value)
+
+        return max_value
 
     def _get_assignee(self, assignee_id: str) -> dict[str, Any] | None:
         """Get assignee data by ID.
@@ -2450,6 +2624,14 @@ class StatisticsManager(BaseManager):
             const.PRES_USER_CHORES_MISSED_WEEK: 0,
             const.PRES_USER_CHORES_MISSED_MONTH: 0,
             const.PRES_USER_CHORES_MISSED_YEAR: 0,
+            const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_TODAY: 0.0,
+            const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_WEEK: 0.0,
+            const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_MONTH: 0.0,
+            const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_YEAR: 0.0,
+            const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_TODAY: 0,
+            const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_WEEK: 0,
+            const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_MONTH: 0,
+            const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_YEAR: 0,
             const.PRES_USER_CHORES_POINTS_TODAY: 0.0,
             const.PRES_USER_CHORES_POINTS_WEEK: 0.0,
             const.PRES_USER_CHORES_POINTS_MONTH: 0.0,
@@ -2675,6 +2857,18 @@ class StatisticsManager(BaseManager):
         missed_week = 0
         missed_month = 0
         missed_year = 0
+        overdue_duration_total_today = 0
+        overdue_duration_total_week = 0
+        overdue_duration_total_month = 0
+        overdue_duration_total_year = 0
+        overdue_duration_count_today = 0
+        overdue_duration_count_week = 0
+        overdue_duration_count_month = 0
+        overdue_duration_count_year = 0
+        overdue_duration_max_today = 0
+        overdue_duration_max_week = 0
+        overdue_duration_max_month = 0
+        overdue_duration_max_year = 0
         points_today = 0.0
         points_week = 0.0
         points_month = 0.0
@@ -2732,6 +2926,21 @@ class StatisticsManager(BaseManager):
                 const.DATA_USER_CHORE_DATA_PERIOD_CLAIMED, 0
             )
             missed_today += today_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_MISSED, 0)
+            overdue_duration_total_today += today_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS,
+                0,
+            )
+            overdue_duration_count_today += today_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT,
+                0,
+            )
+            overdue_duration_max_today = max(
+                overdue_duration_max_today,
+                today_entry.get(
+                    const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS,
+                    0,
+                ),
+            )
             points_today += today_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_POINTS, 0)
 
             # Weekly
@@ -2746,6 +2955,21 @@ class StatisticsManager(BaseManager):
             completed_week += week_completed
             claimed_week += week_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_CLAIMED, 0)
             missed_week += week_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_MISSED, 0)
+            overdue_duration_total_week += week_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS,
+                0,
+            )
+            overdue_duration_count_week += week_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT,
+                0,
+            )
+            overdue_duration_max_week = max(
+                overdue_duration_max_week,
+                week_entry.get(
+                    const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS,
+                    0,
+                ),
+            )
             points_week += week_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_POINTS, 0)
             if week_completed > 0:
                 chore_completed_week[chore_id] = week_completed
@@ -2766,6 +2990,21 @@ class StatisticsManager(BaseManager):
                 const.DATA_USER_CHORE_DATA_PERIOD_CLAIMED, 0
             )
             missed_month += month_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_MISSED, 0)
+            overdue_duration_total_month += month_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS,
+                0,
+            )
+            overdue_duration_count_month += month_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT,
+                0,
+            )
+            overdue_duration_max_month = max(
+                overdue_duration_max_month,
+                month_entry.get(
+                    const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS,
+                    0,
+                ),
+            )
             points_month += month_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_POINTS, 0)
             if month_completed > 0:
                 chore_completed_month[chore_id] = month_completed
@@ -2782,6 +3021,21 @@ class StatisticsManager(BaseManager):
             completed_year += year_completed
             claimed_year += year_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_CLAIMED, 0)
             missed_year += year_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_MISSED, 0)
+            overdue_duration_total_year += year_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS,
+                0,
+            )
+            overdue_duration_count_year += year_entry.get(
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT,
+                0,
+            )
+            overdue_duration_max_year = max(
+                overdue_duration_max_year,
+                year_entry.get(
+                    const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS,
+                    0,
+                ),
+            )
             points_year += year_entry.get(const.DATA_USER_CHORE_DATA_PERIOD_POINTS, 0)
             if year_completed > 0:
                 chore_completed_year[chore_id] = year_completed
@@ -2818,6 +3072,36 @@ class StatisticsManager(BaseManager):
         cache[const.PRES_USER_CHORES_MISSED_MONTH] = missed_month
         cache[const.PRES_USER_CHORES_MISSED_YEAR] = missed_year
         # NOTE: all_time stats omitted from cache - must be read from storage only
+
+        cache[const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_TODAY] = calculate_average(
+            overdue_duration_total_today,
+            overdue_duration_count_today,
+        )
+        cache[const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_WEEK] = calculate_average(
+            overdue_duration_total_week,
+            overdue_duration_count_week,
+        )
+        cache[const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_MONTH] = calculate_average(
+            overdue_duration_total_month,
+            overdue_duration_count_month,
+        )
+        cache[const.PRES_USER_CHORES_AVG_OVERDUE_SECONDS_YEAR] = calculate_average(
+            overdue_duration_total_year,
+            overdue_duration_count_year,
+        )
+        cache[const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_TODAY] = (
+            overdue_duration_max_today
+        )
+        cache[const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_WEEK] = (
+            overdue_duration_max_week
+        )
+        cache[const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_MONTH] = (
+            overdue_duration_max_month
+        )
+        cache[const.PRES_USER_CHORES_LONGEST_OVERDUE_SECONDS_YEAR] = (
+            overdue_duration_max_year
+        )
+
         cache[const.PRES_USER_CHORES_POINTS_TODAY] = round(
             points_today, const.DATA_FLOAT_PRECISION
         )

--- a/custom_components/choreops/sensor.py
+++ b/custom_components/choreops/sensor.py
@@ -122,7 +122,7 @@ from .utils.dt_utils import (
     dt_to_utc,
     dt_today_local,
 )
-from .utils.math_utils import round_points
+from .utils.math_utils import calculate_average, round_points
 
 # Platinum requirement: Parallel Updates
 # Set to 0 (unlimited) for coordinator-based entities that don't poll
@@ -1104,6 +1104,28 @@ class AssigneeChoreStatusSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE,
             period_key_mapping=period_key_mapping,
         )
+        overdue_duration_total = self.coordinator.stats.get_period_total(
+            periods,
+            const.PERIOD_ALL_TIME,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS,
+            period_key_mapping=period_key_mapping,
+        )
+        overdue_duration_count = self.coordinator.stats.get_period_total(
+            periods,
+            const.PERIOD_ALL_TIME,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT,
+            period_key_mapping=period_key_mapping,
+        )
+        avg_overdue_seconds = calculate_average(
+            overdue_duration_total,
+            overdue_duration_count,
+        )
+        longest_overdue_seconds = self.coordinator.stats.get_period_total(
+            periods,
+            const.PERIOD_ALL_TIME,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS,
+            period_key_mapping=period_key_mapping,
+        )
         disapproved_count = self.coordinator.stats.get_period_total(
             periods,
             const.PERIOD_ALL_TIME,
@@ -1268,6 +1290,8 @@ class AssigneeChoreStatusSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             const.ATTR_CHORE_APPROVALS_COUNT: approvals_count,
             const.ATTR_CHORE_DISAPPROVED_COUNT: disapproved_count,
             const.ATTR_CHORE_OVERDUE_COUNT: overdue_count,
+            const.ATTR_CHORE_AVG_OVERDUE_SECONDS: avg_overdue_seconds,
+            const.ATTR_CHORE_LONGEST_OVERDUE_SECONDS: longest_overdue_seconds,
             # --- 8. Statistics (streaks) ---
             const.ATTR_CHORE_CURRENT_STREAK: current_streak,
             const.ATTR_CHORE_LONGEST_STREAK: highest_streak,
@@ -1667,6 +1691,36 @@ class AssigneeChoresSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             const.DATA_USER_CHORE_DATA_PERIOD_MISSED,
             period_key_mapping=period_key_mapping,
         )
+        all_stats["overdue_all_time"] = self.coordinator.stats.get_period_total(
+            chore_periods,
+            const.PERIOD_ALL_TIME,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE,
+            period_key_mapping=period_key_mapping,
+        )
+        overdue_duration_total_all_time = self.coordinator.stats.get_period_total(
+            chore_periods,
+            const.PERIOD_ALL_TIME,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS,
+            period_key_mapping=period_key_mapping,
+        )
+        overdue_duration_count_all_time = self.coordinator.stats.get_period_total(
+            chore_periods,
+            const.PERIOD_ALL_TIME,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT,
+            period_key_mapping=period_key_mapping,
+        )
+        all_stats["avg_overdue_seconds_all_time"] = calculate_average(
+            overdue_duration_total_all_time,
+            overdue_duration_count_all_time,
+        )
+        all_stats["longest_overdue_seconds_all_time"] = (
+            self.coordinator.stats.get_period_total(
+                chore_periods,
+                const.PERIOD_ALL_TIME,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS,
+                period_key_mapping=period_key_mapping,
+            )
+        )
         all_stats["completed_all_time"] = self.coordinator.stats.get_period_total(
             chore_periods,
             const.PERIOD_ALL_TIME,
@@ -1730,6 +1784,8 @@ class AssigneeChoresSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             "approved_today",
             "claimed_today",
             "missed_today",
+            "avg_overdue_seconds_today",
+            "longest_overdue_seconds_today",
             "completed_today",
             "points_today",
         ]:
@@ -1741,6 +1797,8 @@ class AssigneeChoresSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             "approved_week",
             "claimed_week",
             "missed_week",
+            "avg_overdue_seconds_week",
+            "longest_overdue_seconds_week",
             "completed_week",
             "points_week",
             "avg_per_day_week",
@@ -1753,6 +1811,8 @@ class AssigneeChoresSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             "approved_month",
             "claimed_month",
             "missed_month",
+            "avg_overdue_seconds_month",
+            "longest_overdue_seconds_month",
             "completed_month",
             "points_month",
             "avg_per_day_month",
@@ -1765,6 +1825,8 @@ class AssigneeChoresSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             "approved_year",
             "claimed_year",
             "missed_year",
+            "avg_overdue_seconds_year",
+            "longest_overdue_seconds_year",
             "completed_year",
             "points_year",
             "avg_per_day_year",
@@ -1780,6 +1842,8 @@ class AssigneeChoresSensor(ChoreOpsCoordinatorEntity, SensorEntity):
             "completed_all_time",
             "disapproved_all_time",
             "overdue_all_time",
+            "avg_overdue_seconds_all_time",
+            "longest_overdue_seconds_all_time",
             "points_all_time",
             "longest_streak",
             "longest_missed_streak",

--- a/custom_components/choreops/type_defs.py
+++ b/custom_components/choreops/type_defs.py
@@ -428,6 +428,9 @@ class AssigneeChoreDataPeriodEntry(TypedDict, total=False):
     claimed: int
     disapproved: int
     overdue: int
+    overdue_duration_total_seconds: int
+    overdue_duration_count: int
+    overdue_duration_max_seconds: int
     points: float
     longest_streak: int
 
@@ -578,6 +581,8 @@ Common keys (added dynamically at runtime):
 - claimed_today/week/month/year/all_time: int
 - disapproved_today/week/month/year/all_time: int
 - overdue_today/week/month/year/all_time: int
+- avg_overdue_seconds_today/week/month/year/all_time: float
+- longest_overdue_seconds_today/week/month/year/all_time: int
 - current_approved/claimed/overdue/due_today: int
 - total_points_from_chores_today/week/month/year/all_time: float
 - longest_streak_all_time/week/month/year: int
@@ -1162,7 +1167,22 @@ class ChoreOverdueEvent(TypedDict, total=False):
     days_overdue: int  # Required
     due_date: str  # Required: ISO format
     chore_labels: list[str]  # For badge criteria filtering
-    overdue_message_type: str  # Optional: default or steal_available
+    overdue_message_type: str  # Optional: default, steal_available, or standby_needed
+
+
+class ChoreOverdueResolvedEvent(TypedDict, total=False):
+    """Event payload for SIGNAL_SUFFIX_CHORE_OVERDUE_RESOLVED.
+
+    Emitted by: ChoreManager when a chore leaves the overdue state
+    Consumed by: StatisticsManager (overdue duration total/count/max)
+    """
+
+    user_id: str  # Required
+    chore_id: str  # Required
+    chore_name: str  # Required
+    overdue_duration_seconds: int  # Required
+    overdue_started_at: str  # Required: ISO format
+    overdue_resolved_at: str  # Required: ISO format
 
 
 class ChoreRescheduledEvent(TypedDict, total=False):
@@ -1404,6 +1424,7 @@ __all__ = [
     "ChoreDisapprovedEvent",
     "ChoreId",
     "ChoreOverdueEvent",
+    "ChoreOverdueResolvedEvent",
     "ChorePerAssigneeApplicableDays",
     "ChorePerAssigneeDailyMultiTimes",
     "ChorePerAssigneeDueDates",

--- a/custom_components/choreops/utils/math_utils.py
+++ b/custom_components/choreops/utils/math_utils.py
@@ -10,6 +10,7 @@ Functions:
     - round_points: Consistent rounding to configured precision
     - apply_multiplier: Multiplier arithmetic with proper rounding
     - calculate_percentage: Progress percentage calculations
+    - calculate_average: Average calculations with zero-count protection
     - parse_points_value: Parse a point-like numeric input with precision rules
     - parse_points_adjust_values: Parse pipe-separated point values (string input)
     - parse_points_adjust_values: Parse and normalize any adjustment value input
@@ -106,6 +107,17 @@ def calculate_percentage(
     if target <= 0:
         return 0.0
     return round_points((current / target) * 100, precision)
+
+
+def calculate_average(
+    total: float,
+    count: float,
+    precision: int = DATA_FLOAT_PRECISION,
+) -> float:
+    """Calculate an average with zero-count protection."""
+    if not count:
+        return 0.0
+    return round_points(float(total) / float(count), precision)
 
 
 def clamp(value: float, min_val: float, max_val: float) -> float:

--- a/tests/test_chore_manager.py
+++ b/tests/test_chore_manager.py
@@ -111,6 +111,60 @@ def chore_manager(
     return manager
 
 
+def test_overdue_resolution_signal_uses_time_in_overdue_state(
+    chore_manager: ChoreManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Leaving overdue should emit duration from overdue entry to resolution."""
+    assignee_id = "assignee-1"
+    chore_id = "chore-1"
+    assignee_chore_data = chore_manager._get_assignee_chore_data(
+        assignee_id,
+        chore_id,
+    )
+    timestamps = iter(
+        [
+            "2026-02-10T08:00:00+00:00",
+            "2026-02-10T10:30:00+00:00",
+        ]
+    )
+    monkeypatch.setattr(
+        "custom_components.choreops.managers.chore_manager.dt_now_utc_iso",
+        lambda: next(timestamps),
+    )
+
+    chore_manager._set_assignee_chore_state(
+        assignee_id,
+        chore_id,
+        assignee_chore_data,
+        const.CHORE_STATE_OVERDUE,
+    )
+    chore_manager._set_assignee_chore_state(
+        assignee_id,
+        chore_id,
+        assignee_chore_data,
+        const.CHORE_STATE_PENDING,
+    )
+    chore_manager._flush_overdue_resolution_signals()
+
+    assert const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT not in assignee_chore_data
+    chore_manager.emit.assert_called_once()
+    suffix = chore_manager.emit.call_args.args[0]
+    payload = chore_manager.emit.call_args.kwargs
+    assert suffix == const.SIGNAL_SUFFIX_CHORE_OVERDUE_RESOLVED
+    assert payload["user_id"] == assignee_id
+    assert payload["chore_id"] == chore_id
+    assert payload[const.CHORE_OVERDUE_RESOLVED_EVENT_DURATION_SECONDS] == 9000
+    assert (
+        payload[const.CHORE_OVERDUE_RESOLVED_EVENT_STARTED_AT]
+        == "2026-02-10T08:00:00+00:00"
+    )
+    assert (
+        payload[const.CHORE_OVERDUE_RESOLVED_EVENT_RESOLVED_AT]
+        == "2026-02-10T10:30:00+00:00"
+    )
+
+
 # ============================================================================
 # Test Class: Basic Validation
 # ============================================================================

--- a/tests/test_scheduler_delegation.py
+++ b/tests/test_scheduler_delegation.py
@@ -148,6 +148,10 @@ class TestOverdueEventEmission:
         assert event_payload["chore_id"] == chore_id
         assert "days_overdue" in event_payload
         assert "due_date" in event_payload
+        assignee_chore_data = coordinator.assignees_data[zoe_id][
+            const.DATA_USER_CHORE_DATA
+        ][chore_id]
+        assert const.DATA_USER_CHORE_DATA_OVERDUE_STARTED_AT in assignee_chore_data
 
     @pytest.mark.asyncio
     async def test_overdue_check_respects_never_overdue(

--- a/tests/test_statistics_engine.py
+++ b/tests/test_statistics_engine.py
@@ -324,6 +324,109 @@ class TestRecordTransaction:
         assert bucket["bonus"] == 5
 
 
+class TestRecordMaximum:
+    """Tests for record_maximum method."""
+
+    def test_records_maximum_in_all_period_buckets(
+        self, stats: StatisticsEngine, sample_period_data: dict[str, Any]
+    ) -> None:
+        """Should write high-water marks in all period buckets."""
+        stats.record_maximum(
+            sample_period_data,
+            maximums={
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 3600,
+            },
+            reference_date=date(2026, 1, 19),
+        )
+
+        assert (
+            sample_period_data["daily"]["2026-01-19"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 3600
+        )
+        assert (
+            sample_period_data["weekly"]["2026-W04"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 3600
+        )
+        assert (
+            sample_period_data["monthly"]["2026-01"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 3600
+        )
+        assert (
+            sample_period_data["yearly"]["2026"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 3600
+        )
+        assert (
+            sample_period_data["all_time"]["all_time"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 3600
+        )
+
+    def test_keeps_existing_higher_value(
+        self, stats: StatisticsEngine, sample_period_data: dict[str, Any]
+    ) -> None:
+        """Lower observations should not reduce an existing maximum."""
+        ref_date = date(2026, 1, 19)
+
+        stats.record_maximum(
+            sample_period_data,
+            maximums={
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 7200,
+            },
+            reference_date=ref_date,
+        )
+        stats.record_maximum(
+            sample_period_data,
+            maximums={
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 1800,
+            },
+            reference_date=ref_date,
+        )
+
+        assert (
+            sample_period_data["daily"]["2026-01-19"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 7200
+        )
+        assert (
+            sample_period_data["all_time"]["all_time"][
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS
+            ]
+            == 7200
+        )
+
+    def test_custom_period_key_mapping(self, stats: StatisticsEngine) -> None:
+        """Should support custom period container keys."""
+        data: dict[str, Any] = {}
+        custom_mapping = {
+            const.PERIOD_DAILY: "d",
+            const.PERIOD_WEEKLY: "w",
+            const.PERIOD_MONTHLY: "m",
+            const.PERIOD_YEARLY: "y",
+        }
+
+        stats.record_maximum(
+            data,
+            maximums={"max_value": 12},
+            period_key_mapping=custom_mapping,
+            reference_date=date(2026, 1, 19),
+        )
+
+        assert data["d"]["2026-01-19"]["max_value"] == 12
+        assert data["w"]["2026-W04"]["max_value"] == 12
+        assert data["m"]["2026-01"]["max_value"] == 12
+        assert data["y"]["2026"]["max_value"] == 12
+
+
 class TestUpdateStreak:
     """Tests for update_streak method."""
 

--- a/tests/test_statistics_manager_report_rollup.py
+++ b/tests/test_statistics_manager_report_rollup.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import MethodType, SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 from custom_components.choreops import const
+from custom_components.choreops.engines.statistics_engine import StatisticsEngine
 from custom_components.choreops.managers.statistics_manager import StatisticsManager
 
 
@@ -20,6 +23,12 @@ def test_empty_report_rollup_uses_points_spent_keys() -> None:
     assert "all_time_points_spent" in rewards
     assert "in_range_points" not in rewards
     assert "all_time_points" not in rewards
+
+    chores = rollup["chores"]
+    assert chores["in_range_avg_overdue_seconds"] == 0.0
+    assert chores["in_range_longest_overdue_seconds"] == 0
+    assert chores["all_time_avg_overdue_seconds"] == 0.0
+    assert chores["all_time_longest_overdue_seconds"] == 0
 
 
 def test_get_report_rollup_returns_normalized_reward_keys() -> None:
@@ -71,11 +80,25 @@ def test_get_report_rollup_returns_normalized_reward_keys() -> None:
             "all_time_longest_missed_streak": 0,
         }
 
+    def _rollup_overdue_duration(
+        _self: StatisticsManager,
+        _periods: dict[str, Any],
+        _start_iso: str,
+        _end_iso: str,
+    ) -> dict[str, int | float]:
+        return {
+            "in_range_avg_overdue_seconds": 0.0,
+            "in_range_longest_overdue_seconds": 0,
+            "all_time_avg_overdue_seconds": 0.0,
+            "all_time_longest_overdue_seconds": 0,
+        }
+
     manager._get_assignee = MethodType(_get_assignee, manager)
     manager._rollup_period_metrics = MethodType(_rollup_period_metrics, manager)
     manager._rollup_period_collections = MethodType(_rollup_period_collections, manager)
     manager._get_badge_rollup = MethodType(_get_badge_rollup, manager)
     manager._get_streak_rollup = MethodType(_get_streak_rollup, manager)
+    manager._rollup_overdue_duration = MethodType(_rollup_overdue_duration, manager)
 
     rollup = StatisticsManager.get_report_rollup(
         manager,
@@ -89,6 +112,183 @@ def test_get_report_rollup_returns_normalized_reward_keys() -> None:
     assert "all_time_points_spent" in rewards
     assert "in_range_points" not in rewards
     assert "all_time_points" not in rewards
+    assert rollup["chores"]["in_range_avg_overdue_seconds"] == 0.0
+
+
+def test_rollup_overdue_duration_uses_average_and_max() -> None:
+    """Overdue duration rollup should average totals and max longest values."""
+    manager = StatisticsManager.__new__(StatisticsManager)
+    manager._coordinator = SimpleNamespace(stats=StatisticsEngine())
+
+    periods = {
+        const.PERIOD_DAILY: {
+            "2026-02-10": {
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: 3600,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: 1,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 3600,
+            },
+            "2026-02-11": {
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: 10800,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: 2,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 7200,
+            },
+            "2026-02-20": {
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: 86400,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: 1,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 86400,
+            },
+        },
+        const.PERIOD_ALL_TIME: {
+            const.PERIOD_ALL_TIME: {
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: 100800,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: 4,
+                const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 86400,
+            }
+        },
+    }
+
+    rollup = StatisticsManager._rollup_overdue_duration(
+        manager,
+        periods,
+        start_iso="2026-02-10T00:00:00+00:00",
+        end_iso="2026-02-11T23:59:59+00:00",
+    )
+
+    assert rollup["in_range_avg_overdue_seconds"] == 4800.0
+    assert rollup["in_range_longest_overdue_seconds"] == 7200
+    assert rollup["all_time_avg_overdue_seconds"] == 25200.0
+    assert rollup["all_time_longest_overdue_seconds"] == 86400
+
+
+def test_record_chore_transaction_writes_overdue_duration_to_both_buckets() -> None:
+    """Overdue duration stats should write to per-chore and assignee rollups."""
+    manager = StatisticsManager.__new__(StatisticsManager)
+    assignee_id = "assignee-1"
+    chore_id = "chore-1"
+    per_chore_periods: dict[str, Any] = {}
+    assignee_chore_periods: dict[str, Any] = {}
+
+    manager._coordinator = SimpleNamespace(
+        stats=StatisticsEngine(),
+        config_entry=SimpleNamespace(options={}),
+        assignees_data={
+            assignee_id: {
+                const.DATA_USER_CHORE_DATA: {
+                    chore_id: {
+                        const.DATA_USER_CHORE_DATA_PERIODS: per_chore_periods,
+                    }
+                },
+                const.DATA_USER_CHORE_PERIODS: assignee_chore_periods,
+            }
+        },
+    )
+
+    def _get_assignee(
+        _self: StatisticsManager, current_assignee_id: str
+    ) -> dict[str, Any]:
+        return _self._coordinator.assignees_data[current_assignee_id]
+
+    manager._get_assignee = MethodType(_get_assignee, manager)
+
+    recorded = StatisticsManager._record_chore_transaction(
+        manager,
+        assignee_id,
+        chore_id,
+        increments={
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE: 1,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS: 7200,
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT: 1,
+        },
+        maximums={
+            const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS: 7200,
+        },
+        persist=False,
+    )
+
+    assert recorded is True
+    for periods in (per_chore_periods, assignee_chore_periods):
+        all_time = periods[const.PERIOD_ALL_TIME][const.PERIOD_ALL_TIME]
+        assert all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE] == 1
+        assert (
+            all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS]
+            == 7200
+        )
+        assert all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT] == 1
+        assert (
+            all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS]
+            == 7200
+        )
+
+
+def test_chore_overdue_resolved_records_duration_to_both_buckets() -> None:
+    """Resolved overdue event records duration without adding another overdue count."""
+    manager = StatisticsManager.__new__(StatisticsManager)
+    assignee_id = "assignee-1"
+    chore_id = "chore-1"
+    per_chore_periods: dict[str, Any] = {}
+    assignee_chore_periods: dict[str, Any] = {}
+
+    manager._coordinator = SimpleNamespace(
+        stats=StatisticsEngine(),
+        config_entry=SimpleNamespace(options={}),
+        assignees_data={
+            assignee_id: {
+                const.DATA_USER_CHORE_DATA: {
+                    chore_id: {
+                        const.DATA_USER_CHORE_DATA_PERIODS: per_chore_periods,
+                    }
+                },
+                const.DATA_USER_CHORE_PERIODS: assignee_chore_periods,
+            }
+        },
+        _data={},
+        _persist=MagicMock(),
+        async_set_updated_data=MagicMock(),
+    )
+
+    def _get_assignee(
+        _self: StatisticsManager, current_assignee_id: str
+    ) -> dict[str, Any]:
+        return _self._coordinator.assignees_data[current_assignee_id]
+
+    def _refresh_chore_cache(
+        _self: StatisticsManager, _current_assignee_id: str
+    ) -> None:
+        return None
+
+    def _emit_stats_updated(
+        _self: StatisticsManager, _current_assignee_id: str
+    ) -> None:
+        return None
+
+    manager._get_assignee = MethodType(_get_assignee, manager)
+    manager._refresh_chore_cache = MethodType(_refresh_chore_cache, manager)
+    manager._emit_stats_updated = MethodType(_emit_stats_updated, manager)
+
+    asyncio.run(
+        StatisticsManager._on_chore_overdue_resolved(
+            manager,
+            {
+                "user_id": assignee_id,
+                "chore_id": chore_id,
+                const.CHORE_OVERDUE_RESOLVED_EVENT_DURATION_SECONDS: 7200,
+                const.CHORE_OVERDUE_RESOLVED_EVENT_RESOLVED_AT: "2026-02-10T10:00:00+00:00",
+            },
+        )
+    )
+
+    for periods in (per_chore_periods, assignee_chore_periods):
+        all_time = periods[const.PERIOD_ALL_TIME][const.PERIOD_ALL_TIME]
+        assert const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE not in all_time
+        assert (
+            all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_TOTAL_SECONDS]
+            == 7200
+        )
+        assert all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_COUNT] == 1
+        assert (
+            all_time[const.DATA_USER_CHORE_DATA_PERIOD_OVERDUE_DURATION_MAX_SECONDS]
+            == 7200
+        )
 
 
 def test_get_stats_rehydrates_partial_cache_entry() -> None:


### PR DESCRIPTION
## Summary

- Track overdue duration when a chore overdue event is emitted.
- Store additive overdue duration totals, counts, and maximums in existing period buckets instead of adding an event timeline.
- Expose average and longest overdue duration fields through report rollups and chore stats sensors.

## Linked issue

- No linked issue.

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`) - N/A, no linked issue
- [x] Correct release-note label is applied for `.github/release.yml` categorization - `enhancement`
- [x] Excluded triage or status labels have been removed before merge
- [x] PR title is suitable for generated release notes

## Change type

- [ ] Bug fix
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Integration logic/state
- [ ] Dashboard/template behavior
- [ ] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/test_statistics_engine.py tests/test_statistics_manager_report_rollup.py` with plugin autoload disabled for pure unit coverage
- [ ] `python -m pytest tests/ -v --tb=line` - local full-suite run was attempted but stopped due local Home Assistant test harness/resource issues; CI should run the authoritative full suite

## Documentation impact

- [x] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

## Release notes

- [ ] No release notes needed
- [x] Release notes needed (summarize user-visible changes below)

- Release note summary: Adds average and longest overdue duration statistics for chore overdue events.

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)

Additive storage fields default to zero when absent, so existing installations do not require migration.
