### PR TITLE
fix(gamification): reset completion-streak achievements after a missed day

### DIFF
--- a/custom_components/choreops/engines/gamification_engine.py
+++ b/custom_components/choreops/engines/gamification_engine.py
@@ -618,13 +618,16 @@ class GamificationEngine:
             reason = f"Today: {current_value}/{threshold}"
 
         elif target_type == const.CANONICAL_TARGET_TYPE_COMPLETION_STREAK:
-            achievement_progress = context.get("current_achievement_progress") or {}
-            stored_streak = float(
-                cast("dict[str, Any]", achievement_progress).get(
-                    const.DATA_USER_CURRENT_STREAK,
-                    0,
-                )
-            )
+            # Current completion streak, derived fresh from chore data on every
+            # evaluation. _get_tracked_current_streak() zeroes a chore's streak
+            # once its last completion is older than yesterday, so this value
+            # resets after a fully missed day.
+            #
+            # This previously used max(stored_streak, tracked_streak). The stored
+            # streak (DATA_USER_CURRENT_STREAK) is only ever written from this
+            # same max(), so it behaved as a monotonic high-water-mark that could
+            # never decrease -- a streak would never reset after a missed day.
+            # Use the freshly tracked value alone.
             tracked_streak_raw: Any = cast("Any", context).get(
                 "tracked_current_streak", 0
             )
@@ -633,7 +636,7 @@ class GamificationEngine:
                 if isinstance(tracked_streak_raw, (int, float, str))
                 else 0.0
             )
-            current_value = max(stored_streak, tracked_streak)
+            current_value = tracked_streak
             reason = f"Streak: {current_value}/{threshold}"
 
         elif target_type == const.CANONICAL_TARGET_TYPE_TOTAL_WITH_BASELINE:

--- a/custom_components/choreops/managers/gamification_manager.py
+++ b/custom_components/choreops/managers/gamification_manager.py
@@ -23,12 +23,14 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.start import async_at_started
 
 from .. import const, data_builders as db
 from ..engines.gamification_engine import GamificationEngine
 from ..helpers import entity_helpers as eh
 from ..helpers.entity_helpers import get_item_id_by_name, remove_entities_by_item_id
 from ..utils.dt_utils import (
+    HELPER_RETURN_DATETIME_LOCAL,
     dt_add_interval,
     dt_next_schedule,
     dt_now_utc_iso,
@@ -155,6 +157,18 @@ class GamificationManager(BaseManager):
             self._schedule_evaluation()
 
         self.coordinator.config_entry.async_on_unload(self._cancel_eval_timer)
+
+        # Streak correctness on startup: re-derive every streak from current
+        # chore data once HA has finished starting, so a streak broken while HA
+        # was down is reset without waiting for the next completion or midnight
+        # rollover. Fires immediately if HA is already started. Preferred over a
+        # hardcoded timer, which would race against data-load timing.
+        self.coordinator.config_entry.async_on_unload(
+            async_at_started(
+                self.hass,
+                lambda _hass: self.recalculate_all_badges(),
+            )
+        )
 
         const.LOGGER.debug(
             "GamificationManager initialized with %s second debounce",
@@ -2767,12 +2781,35 @@ class GamificationManager(BaseManager):
 
         return runtime_context
 
+    def _streak_alive(self, last_value: Any) -> bool:
+        """Return True if a streak's last activity keeps it alive today.
+
+        A streak is only updated on completion; there is no midnight job that
+        decays it when a day is fully missed. So a streak whose last completion
+        is older than yesterday has actually been broken. Uses an inclusive
+        "today or yesterday" window so a streak completed yesterday is not
+        prematurely zeroed at the start of today.
+
+        Fails OPEN (returns True) on any missing value or parse failure, so a
+        valid streak is never wrongly zeroed over bad/absent data.
+        """
+        if not last_value:
+            return True
+        local_dt = dt_parse(last_value, return_type=HELPER_RETURN_DATETIME_LOCAL)
+        if not isinstance(local_dt, datetime):
+            return True
+        return local_dt.date() >= dt_today_local() - timedelta(days=1)
+
     def _get_tracked_current_streak(
         self,
         assignee_id: str,
         tracked_chores: list[str],
     ) -> int:
-        """Return current streak from assignee chore data for tracked chores."""
+        """Return current streak from assignee chore data for tracked chores.
+
+        A chore's stored streak only counts if it was last completed today or
+        yesterday; a fully missed day breaks the streak (see _streak_alive).
+        """
         assignee_data = cast(
             "dict[str, Any]",
             self.coordinator.assignees_data.get(assignee_id, {}),
@@ -2782,24 +2819,30 @@ class GamificationManager(BaseManager):
             assignee_data.get(const.DATA_USER_CHORE_DATA, {}),
         )
 
+        def _effective(chore_entry: dict[str, Any]) -> int:
+            streak = int(chore_entry.get(const.DATA_USER_CHORE_DATA_CURRENT_STREAK, 0))
+            if streak <= 0:
+                return 0
+            if not self._streak_alive(
+                chore_entry.get(const.DATA_USER_CHORE_DATA_LAST_COMPLETED)
+            ):
+                return 0
+            return streak
+
         if tracked_chores:
-            streak_values: list[int] = []
-            for chore_id in tracked_chores:
-                chore_entry = cast(
-                    "dict[str, Any]", assignee_chore_data.get(chore_id, {})
-                )
-                streak_values.append(
-                    int(chore_entry.get(const.DATA_USER_CHORE_DATA_CURRENT_STREAK, 0))
-                )
-            return max(streak_values, default=0)
+            return max(
+                (
+                    _effective(
+                        cast("dict[str, Any]", assignee_chore_data.get(chore_id, {}))
+                    )
+                    for chore_id in tracked_chores
+                ),
+                default=0,
+            )
 
         return max(
             (
-                int(
-                    cast("dict[str, Any]", chore_entry).get(
-                        const.DATA_USER_CHORE_DATA_CURRENT_STREAK, 0
-                    )
-                )
+                _effective(cast("dict[str, Any]", chore_entry))
                 for chore_entry in assignee_chore_data.values()
                 if isinstance(chore_entry, dict)
             ),

--- a/tests/test_gamification_engine.py
+++ b/tests/test_gamification_engine.py
@@ -734,16 +734,15 @@ class TestEvaluateAchievement:
         assert result["criteria_met"] is False
 
     def test_streak_achievement(self) -> None:
-        """STREAK achievement evaluation uses current_streak from tracking."""
+        """STREAK achievement uses the freshly tracked streak, not a stored peak.
+
+        The streak comes from ``tracked_current_streak`` (derived fresh from chore
+        data each evaluation). A stale persisted high-water-mark must NOT satisfy
+        the achievement on its own -- that was the monotonic-streak bug.
+        """
+        # A fresh tracked streak that meets the threshold -> achievement met.
         context = make_context()
-        # Add achievement progress with streak tracking
-        context["achievement_progress"] = {
-            "achieve-123": {
-                context["assignee_id"]: {
-                    const.DATA_USER_CURRENT_STREAK: 5,
-                }
-            }
-        }
+        context["tracked_current_streak"] = 5
         achievement = make_achievement(
             target_type=const.ACHIEVEMENT_TYPE_STREAK,
             target_value=5,
@@ -752,6 +751,23 @@ class TestEvaluateAchievement:
         result = GamificationEngine.evaluate_achievement(context, achievement)
 
         assert result["criteria_met"] is True
+
+        # A high stored peak with no live tracked streak must NOT satisfy it.
+        stale_context = make_context()
+        stale_context["tracked_current_streak"] = 0
+        stale_context["achievement_progress"] = {
+            "achieve-123": {
+                stale_context["assignee_id"]: {
+                    const.DATA_USER_CURRENT_STREAK: 5,
+                }
+            }
+        }
+
+        stale_result = GamificationEngine.evaluate_achievement(
+            stale_context, achievement
+        )
+
+        assert stale_result["criteria_met"] is False
 
     def test_total_achievement_badge_award_count_extension(self) -> None:
         """TOTAL achievement can map to badge award_count source when configured."""

--- a/tests/test_gamification_streak_reset.py
+++ b/tests/test_gamification_streak_reset.py
@@ -1,0 +1,298 @@
+"""Regression tests: completion-streak achievements must reset after a missed day.
+
+Background (bug fixed alongside these tests): the COMPLETION_STREAK achievement
+progress was computed as ``max(stored_streak, tracked_streak)``. The stored value
+was only ever written from that same ``max()``, so it behaved as a monotonic
+high-water-mark that could never decrease -- a kid's streak would stay at its peak
+forever, even after fully missing one or more days.
+
+The fix has two required parts:
+
+A. Engine (``GamificationEngine._evaluate_canonical_target_criterion``): the
+   COMPLETION_STREAK branch now uses the freshly tracked streak alone, never the
+   stored high-water-mark.
+
+B. Manager (``GamificationManager._get_tracked_current_streak`` /
+   ``_streak_alive``): a chore's stored streak only counts if it was last
+   completed today or yesterday, so a fully missed day resets it.
+
+These are pure-logic tests -- no Home Assistant runtime is started. The engine
+criterion is a staticmethod; the manager helpers only touch
+``coordinator.assignees_data``, so a MagicMock coordinator is sufficient.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, time, timedelta
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.choreops import const
+from custom_components.choreops.engines.gamification_engine import GamificationEngine
+from custom_components.choreops.managers.gamification_manager import GamificationManager
+from custom_components.choreops.utils.dt_utils import dt_today_local
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _eval_streak(
+    *,
+    tracked: float,
+    stored: float | None = None,
+    threshold: float = 14.0,
+) -> dict[str, Any]:
+    """Evaluate the COMPLETION_STREAK criterion and return the criterion result.
+
+    ``tracked`` is the freshly derived streak (``tracked_current_streak``);
+    ``stored`` is the persisted high-water-mark, supplied only when a test wants
+    to prove it is ignored.
+    """
+    context: dict[str, Any] = {"tracked_current_streak": tracked}
+    if stored is not None:
+        context["current_achievement_progress"] = {
+            const.DATA_USER_CURRENT_STREAK: stored
+        }
+    target: dict[str, Any] = {
+        "target_type": const.CANONICAL_TARGET_TYPE_COMPLETION_STREAK,
+        "threshold_value": threshold,
+    }
+    return cast(
+        "dict[str, Any]",
+        GamificationEngine._evaluate_canonical_target_criterion(
+            cast("Any", context),
+            cast("Any", target),
+        ),
+    )
+
+
+def _date_str(days_ago: int) -> str:
+    """Date-only string (``YYYY-MM-DD``) ``days_ago`` days before local today."""
+    return (dt_today_local() - timedelta(days=days_ago)).isoformat()
+
+
+def _datetime_str(days_ago: int) -> str:
+    """ISO datetime string (with ``T`` and tz) ``days_ago`` days before today."""
+    day = dt_today_local() - timedelta(days=days_ago)
+    return datetime.combine(day, time(12, 0), tzinfo=UTC).isoformat()
+
+
+@pytest.fixture
+def manager() -> GamificationManager:
+    """A GamificationManager with mock hass/coordinator and empty chore data.
+
+    Only ``coordinator.assignees_data`` is exercised by the helpers under test;
+    no async_setup is run, so no listeners or startup hooks are registered.
+    """
+    hass = MagicMock()
+    coordinator = MagicMock()
+    coordinator.assignees_data = {}
+    return GamificationManager(hass, coordinator)
+
+
+def _set_chores(
+    manager: GamificationManager,
+    assignee_id: str,
+    chores: dict[str, dict[str, Any]],
+) -> None:
+    """Install ``chores`` as the assignee's per-chore data on the mock coordinator."""
+    manager.coordinator.assignees_data[assignee_id] = {
+        const.DATA_USER_CHORE_DATA: chores
+    }
+
+
+# =============================================================================
+# A. Engine -- COMPLETION_STREAK uses tracked value, not max(stored, tracked)
+# =============================================================================
+
+
+def test_engine_streak_ignores_stale_stored_high_water_mark() -> None:
+    """Regression guard: a high stored streak must not pin the value above tracked.
+
+    This is the exact bug: stored=7 (peak), tracked=4 (current). Result must be 4.
+    """
+    result = _eval_streak(tracked=4, stored=7, threshold=14.0)
+    assert result["current_value"] == 4.0
+    assert "4.0/14.0" in result["reason"]
+
+
+def test_engine_streak_zero_when_tracked_zero_despite_high_stored() -> None:
+    """A fully reset streak (tracked=0) reports 0 even with a large stored peak."""
+    result = _eval_streak(tracked=0, stored=30, threshold=14.0)
+    assert result["current_value"] == 0.0
+    assert result["progress"] == 0.0
+    assert result["met"] is False
+
+
+def test_engine_streak_progress_and_met() -> None:
+    """Progress is tracked/threshold; met flips once the threshold is reached."""
+    partial = _eval_streak(tracked=4, threshold=14.0)
+    assert partial["current_value"] == 4.0
+    assert partial["progress"] == pytest.approx(4.0 / 14.0)
+    assert partial["met"] is False
+
+    reached = _eval_streak(tracked=14, threshold=14.0)
+    assert reached["current_value"] == 14.0
+    assert reached["progress"] == 1.0
+    assert reached["met"] is True
+
+
+# =============================================================================
+# B1. Manager -- _streak_alive staleness window
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, True),  # missing -> fail open
+        ("", True),  # empty -> fail open
+        ("not-a-date", True),  # unparseable -> fail open
+    ],
+)
+def test_streak_alive_fails_open(
+    manager: GamificationManager, value: Any, expected: bool
+) -> None:
+    """Missing or unparseable values fail open so a valid streak is never zeroed."""
+    assert manager._streak_alive(value) is expected
+
+
+def test_streak_alive_today_and_yesterday(manager: GamificationManager) -> None:
+    """Today and yesterday are both inside the inclusive window (alive)."""
+    assert manager._streak_alive(_date_str(0)) is True
+    assert manager._streak_alive(_date_str(1)) is True
+
+
+def test_streak_alive_two_days_ago_is_dead(manager: GamificationManager) -> None:
+    """A gap of a full missed day (last completion 2 days ago) breaks the streak."""
+    assert manager._streak_alive(_date_str(2)) is False
+
+
+def test_streak_alive_handles_datetime_strings(
+    manager: GamificationManager,
+) -> None:
+    """ISO datetime strings (with ``T`` and tz) are parsed and localized correctly."""
+    assert manager._streak_alive(_datetime_str(0)) is True
+    assert manager._streak_alive(_datetime_str(1)) is True
+    assert manager._streak_alive(_datetime_str(2)) is False
+
+
+# =============================================================================
+# B2. Manager -- _get_tracked_current_streak only counts alive streaks
+# =============================================================================
+
+
+def test_tracked_streak_fresh_chore_counts(manager: GamificationManager) -> None:
+    """A chore completed today contributes its full streak."""
+    _set_chores(
+        manager,
+        "kid",
+        {
+            "chore-a": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 4,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(0),
+            }
+        },
+    )
+    assert manager._get_tracked_current_streak("kid", ["chore-a"]) == 4
+
+
+def test_tracked_streak_stale_chore_resets_to_zero(
+    manager: GamificationManager,
+) -> None:
+    """A high streak with a last completion older than yesterday counts as 0."""
+    _set_chores(
+        manager,
+        "kid",
+        {
+            "chore-a": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 9,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(3),
+            }
+        },
+    )
+    assert manager._get_tracked_current_streak("kid", ["chore-a"]) == 0
+
+
+def test_tracked_streak_fresh_beats_stale_high(
+    manager: GamificationManager,
+) -> None:
+    """max() returns the best *alive* streak; a stale high streak does not win."""
+    _set_chores(
+        manager,
+        "kid",
+        {
+            "stale-high": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 9,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(3),
+            },
+            "fresh-low": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 4,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(0),
+            },
+        },
+    )
+    assert manager._get_tracked_current_streak("kid", ["stale-high", "fresh-low"]) == 4
+
+
+def test_tracked_streak_zero_streak_short_circuits(
+    manager: GamificationManager,
+) -> None:
+    """A non-positive streak contributes 0 regardless of last-completed."""
+    _set_chores(
+        manager,
+        "kid",
+        {
+            "chore-a": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 0,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(0),
+            }
+        },
+    )
+    assert manager._get_tracked_current_streak("kid", ["chore-a"]) == 0
+
+
+def test_tracked_streak_fallback_branch_scans_all_chores(
+    manager: GamificationManager,
+) -> None:
+    """With no tracked_chores list, all chores are scanned (alive ones only)."""
+    _set_chores(
+        manager,
+        "kid",
+        {
+            "stale-high": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 9,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(3),
+            },
+            "fresh-low": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 4,
+                const.DATA_USER_CHORE_DATA_LAST_COMPLETED: _date_str(0),
+            },
+        },
+    )
+    assert manager._get_tracked_current_streak("kid", []) == 4
+
+
+def test_tracked_streak_missing_timestamp_fails_open(
+    manager: GamificationManager,
+) -> None:
+    """Documents the accepted caveat: a positive streak with no last_completed.
+
+    _streak_alive fails open on missing data, so such a chore keeps its streak.
+    This should be unreachable in practice (completions always write both fields)
+    but is asserted here so the trade-off is a deliberate, visible decision.
+    """
+    _set_chores(
+        manager,
+        "kid",
+        {
+            "chore-a": {
+                const.DATA_USER_CHORE_DATA_CURRENT_STREAK: 5,
+                # no DATA_USER_CHORE_DATA_LAST_COMPLETED
+            }
+        },
+    )
+    assert manager._get_tracked_current_streak("kid", ["chore-a"]) == 5


### PR DESCRIPTION
## Summary
Completion-streak achievement progress (e.g. "On a Roll", "Unstoppable") only ever increased. Once a kid reached an N-day streak the achievement stayed at N forever, even after they skipped one or more full days.

Root cause: the COMPLETION_STREAK branch computed progress as max(stored_streak, tracked_streak). The stored value was itself only ever written from that same max(), so it acted as a monotonic high-water-mark that could never decrease. Compounding this, the tracked streak read each chore's stored current_streak without checking when it was last completed -- and a chore's streak is only updated on completion, so it stayed stale across missed days. Nothing performed any time-based decay.

Fix:
- Engine: use the freshly tracked streak alone instead of max(stored, tracked). The stored streak carried no independent information, so dropping the max() is the minimal correct change and lets a streak fall after a missed day.
- Manager: make _get_tracked_current_streak() staleness-aware via a new _streak_alive() helper. A chore's streak now only counts if it was last completed today or yesterday (inclusive window, so a streak earned yesterday is not prematurely zeroed). Fails open on missing/unparseable timestamps so a valid streak is never wrongly reset.
- Manager: re-derive every streak once HA has finished starting (via async_at_started), so a streak broken while HA was down is corrected without waiting for the next completion or midnight rollover.

Tests: add regression coverage for the engine branch, _streak_alive, and _get_tracked_current_streak; update the existing streak-achievement engine test, which had encoded the old high-water-mark behavior, to drive the streak from the freshly tracked value.

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [ ] Correct release-note label is applied for `.github/release.yml` categorization
- [ ] Excluded triage or status labels have been removed before merge
- [ ] PR title is suitable for generated release notes

## Change type

- [x] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Integration logic/state
- [ ] Dashboard/template behavior
- [ ] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/ -v --tb=line` (or targeted suite with rationale)

## Documentation impact

- [x] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

## Release notes

- [ ] No release notes needed
- [x] Release notes needed (summarize user-visible changes below)

- Release note summary:

For badges/achievements requiring streaks, a streak, by definition, is an unbroken completion of something, in this case, chores. This fix resets any streak badge/achievement on a missed day. 

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)