### PR TITLE
chore(dev): Add VS Code tasks, dev environment docs, and sync ritual

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,9 @@
   "ruff.fixAll": true,
   "ruff.lint.enable": true,
 
+  "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+  "python.terminal.activateEnvInCurrentTerminal": false,
+
   "python.linting.enabled": false,
   "python.linting.pylintEnabled": false,
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "🔗 Auto-Link ChoreOps",
+      "type": "shell",
+      "command": "mkdir -p /workspaces/core/config/custom_components && ln -snf /workspaces/choreops/custom_components/choreops /workspaces/core/config/custom_components/choreops",
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    },
+    {
+      "label": "📖 Sync ChoreOps Wiki",
+      "type": "shell",
+      "command": "if [ -d /workspaces/choreops-wiki/.git ]; then cd /workspaces/choreops-wiki && git pull --ff-only; else git clone https://github.com/ccpk1/ChoreOps.wiki.git /workspaces/choreops-wiki; fi"
+    },
+    {
+      "label": "📦 Sync Dashboard Assets",
+      "type": "shell",
+      "command": "/home/vscode/.local/ha-venv/bin/python /workspaces/choreops/utils/sync_dashboard_assets.py"
+    },
+    {
+      "label": "✅ Check Dashboard Asset Parity",
+      "type": "shell",
+      "command": "/home/vscode/.local/ha-venv/bin/python /workspaces/choreops/utils/sync_dashboard_assets.py --check"
+    },
+    {
+      "label": "🔄 Refresh HA Dev Environment",
+      "type": "shell",
+      "command": "cd /workspaces/core && git pull --ff-only && script/setup && cd /workspaces/choreops && git pull --ff-only",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": [],
+      "detail": "Pull HA core → rebuild ha-venv → pull choreops. Run after daily HA dev update."
+    },
+    {
+      "label": "🧪 Run ChoreOps Tests",
+      "type": "shell",
+      "command": "./utils/run_tests.sh tests/ -v --tb=line",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "⚡ Quick Lint",
+      "type": "shell",
+      "command": "cd /workspaces/choreops && source /home/vscode/.local/ha-venv/bin/activate && ./utils/quick_lint.sh --fix",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": [],
+      "detail": "Ruff check/format + mypy + boundary checks"
+    }
+  ]
+}

--- a/docs/DEVELOPMENT_STANDARDS.md
+++ b/docs/DEVELOPMENT_STANDARDS.md
@@ -74,9 +74,62 @@ Cross-repository coordination rule:
 - Integration and dashboard registry versions may evolve independently.
 - Compatibility must be enforced by explicit manifest compatibility fields and schema contracts, not by assuming equal version numbers across repositories.
 
-### 1.1 Development environment lock (VS Code)
+### 1.1 Development Environment
 
-To keep editor diagnostics stable across contributors, this repository uses a locked interpreter in workspace settings:
+ChoreOps is a custom component that depends on Home Assistant core at runtime and
+in tests. This creates a shared-environment dependency: tests import from both
+`custom_components.choreops` and `homeassistant.*`, so they must run under a
+Python environment that has HA installed.
+
+#### Dependency chain
+
+```
+core/.devcontainer/devcontainer.json
+  └─ postCreateCommand: script/setup
+       └─ installs HA + all deps into /home/vscode/.local/ha-venv/
+            ├─ used by: ChoreOps VS Code interpreter (locked)
+            ├─ used by: ChoreOps pytest (imports homeassistant.*)
+            └─ used by: core VS Code interpreter
+```
+
+The HA venv at `/home/vscode/.local/ha-venv/` is the **single shared Python
+environment** for both projects. It is created by HA core's `script/setup` and
+goes **stale when HA core's `dev` branch moves** — which happens daily.
+
+#### Daily sync ritual
+
+After every `git pull` on HA core (`/workspaces/core`), run:
+
+```bash
+cd /workspaces/core && script/setup
+```
+
+This rebuilds the shared HA venv with the latest dependencies, keeping ruff,
+mypy, pytest, and all HA test fixtures in sync. Without this step, tests
+silently fail against stale APIs.
+
+Complete session start:
+
+```bash
+# 1. Sync both repos
+cd /workspaces/core && git pull --ff-only && script/setup
+cd /workspaces/choreops && git pull --ff-only
+
+# 2. Verify the symlink bridge is intact
+ls -la /workspaces/core/config/custom_components/choreops  # → symlink to /workspaces/choreops/custom_components/choreops
+
+# 3. Run quality gates
+cd /workspaces/choreops && ./utils/quick_lint.sh --fix
+```
+
+**Common failure mode**: If you pull HA core and skip `script/setup`, the venv
+still has the old HA version. Tests that pass locally may fail in CI because CI
+always runs `script/setup`. Always run it after pulling core.
+
+#### VS Code interpreter lock
+
+To keep editor diagnostics stable across contributors, this repository uses a
+locked interpreter in workspace settings:
 
 - **Locked interpreter**: `/home/vscode/.local/ha-venv/bin/python`
 - **Type authority**: MyPy is authoritative; Pylance `typeCheckingMode` remains `off`

--- a/utils/run_tests.sh
+++ b/utils/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Portable test runner for ChoreOps.
+# Tries ha-venv first, falls back gracefully.
+# Usage: ./utils/run_tests.sh [pytest args...]
+
+HA_PYTHON="/home/vscode/.local/ha-venv/bin/python"
+
+if [ -x "$HA_PYTHON" ]; then
+  exec "$HA_PYTHON" -m pytest "$@"
+fi
+
+# Fallback: try any python with pytest available
+if command -v python3 &>/dev/null && python3 -c "import pytest" 2>/dev/null; then
+  exec python3 -m pytest "$@"
+fi
+
+echo "ERROR: No Python with pytest found."
+echo "Run 'script/setup' in the core workspace first, or install pytest."
+exit 1


### PR DESCRIPTION
What changed:
- Add `.vscode/tasks.json` with 7 emoji-labeled tasks covering the full dev workflow (🔗 auto-link, 📖 wiki sync, 📦 dashboard sync, ✅ parity check, 🔄 HA env refresh, 🧪 test runner, ⚡ quick lint)
- Add `python.defaultInterpreterPath` + `activateEnvInCurrentTerminal: false` to `.vscode/settings.json` to fix interpreter resolution to ha-venv
- Add `utils/run_tests.sh` — portable pytest wrapper (ha-venv first, fallback)
- Expand `docs/DEVELOPMENT_STANDARDS.md §1.1` with dependency chain diagram and daily sync ritual
- Add `🔄 Refresh HA Dev Environment` task embodying the ritual
- Remove tasks from gitignored `choreops-dev.code-workspace` so they are shared via tracked `.vscode/tasks.json`

Why:
- Tasks were invisible to anyone cloning the repo (lived in gitignored workspace file)
- Test task used `${command:python.interpreterPath}` which resolved to local `.venv/` without pytest installed
- No documented repeatable workflow for keeping the HA dev environment in sync after daily HA core updates

