### PR TITLE
fix(notifications): ignore foreign mobile_app_notification_action events

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -2330,6 +2330,21 @@ ACTION_DISAPPROVE_REWARD = "DISAPPROVE_REWARD"
 ACTION_REMIND_30 = "REMIND_30"
 ACTION_SKIP_CHORE = "SKIP_CHORE"
 
+# Aggregated set of all valid notification action types for early-exit gating.
+# Adding a new ACTION_* constant? Include it here so the guard covers it.
+NOTIFICATION_ACTION_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        ACTION_APPROVE_CHORE,
+        ACTION_APPROVE_REWARD,
+        ACTION_CLAIM_CHORE,
+        ACTION_COMPLETE_FOR_ASSIGNEE,
+        ACTION_DISAPPROVE_CHORE,
+        ACTION_DISAPPROVE_REWARD,
+        ACTION_REMIND_30,
+        ACTION_SKIP_CHORE,
+    }
+)
+
 
 # ------------------------------------------------------------------------------------------------
 # Translation Keys - Entity State Attributes

--- a/custom_components/choreops/notification_action_handler.py
+++ b/custom_components/choreops/notification_action_handler.py
@@ -146,17 +146,7 @@ def parse_notification_action(action_field: str) -> ParsedAction | None:
         action_type = parts[0]
 
         # Validate action_type is a known constant
-        valid_actions = {
-            const.ACTION_APPROVE_CHORE,
-            const.ACTION_DISAPPROVE_CHORE,
-            const.ACTION_CLAIM_CHORE,
-            const.ACTION_COMPLETE_FOR_ASSIGNEE,
-            const.ACTION_SKIP_CHORE,
-            const.ACTION_APPROVE_REWARD,
-            const.ACTION_DISAPPROVE_REWARD,
-            const.ACTION_REMIND_30,
-        }
-        if action_type not in valid_actions:
+        if action_type not in const.NOTIFICATION_ACTION_TYPES:
             const.LOGGER.warning("Unknown action type: %s", action_type)
             return None
 
@@ -209,7 +199,13 @@ async def async_handle_notification_action(hass: HomeAssistant, event: Event) ->
     """
     action_field = event.data.get(const.NOTIFY_ACTION)
     if not action_field:
-        const.LOGGER.error("No action found in event data: %s", event.data)
+        return
+
+    # Early-exit gate: check action type before any parsing.
+    # The mobile_app_notification_action event fires for ALL integrations,
+    # not just ChoreOps. Only process actions that use a known ChoreOps type.
+    action_type = action_field.split("|", 1)[0]
+    if action_type not in const.NOTIFICATION_ACTION_TYPES:
         return
 
     # Parse action string into typed ParsedAction object (v0.5.0+)


### PR DESCRIPTION
The mobile_app_notification_action event bus fires for all integrations, not just ChoreOps. Previously, every foreign notification action tap produced a spurious "Failed to parse notification action" ERROR in the logs.

- Add NOTIFICATION_ACTION_TYPES frozenset to const.py as the single source of truth for action type validation
- Add early-exit gate in async_handle_notification_action() that checks action type membership before any parsing, silently returning for foreign events
- Refactor parse_notification_action() to use the const set instead of a duplicated local set

Fixes #174