### PR TITLE
fix(notifications): suppress rotation non-turn-holder signals

### DIFF
--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -2186,6 +2186,23 @@ class ChoreManager(BaseManager):
                     const.CHORE_OVERDUE_NOTIFICATION_TYPE_STEAL_AVAILABLE
                 )
 
+            elif (
+                ChoreEngine.is_rotation_mode(chore_data)
+                and chore_data.get(const.DATA_CHORE_ROTATION_CURRENT_ASSIGNEE_ID)
+                != assignee_id
+            ):
+                # Non-turn-holders in rotation modes without steal or standby
+                # capability don't get overdue notifications — only the current
+                # turn-holder receives the overdue signal.
+                const.LOGGER.debug(
+                    "Skipping overdue signal for non-turn-holder "
+                    "assignee=%s in rotation chore=%s",
+                    assignee_id,
+                    chore_id,
+                )
+                marked_count += 1
+                continue
+
             # Calculate days overdue and accumulate signal data
             days_overdue = (now_utc - due_dt).days
             signals_to_emit.append(
@@ -2248,6 +2265,14 @@ class ChoreManager(BaseManager):
             chore_name = chore_info.get(const.DATA_CHORE_NAME, "Unknown Chore")
             points = chore_info.get(const.DATA_CHORE_DEFAULT_POINTS, 0)
 
+            # Rotation guard: only notify the current turn-holder
+            if ChoreEngine.is_rotation_mode(chore_info):
+                current_turn_assignee = chore_info.get(
+                    const.DATA_CHORE_ROTATION_CURRENT_ASSIGNEE_ID
+                )
+                if current_turn_assignee != assignee_id:
+                    continue
+
             # Get assignee name for signal emission
             assignee_info: UserData = cast(
                 "UserData", self._coordinator.assignees_data.get(assignee_id, {})
@@ -2287,6 +2312,14 @@ class ChoreManager(BaseManager):
             assignee_id = entry[const.CHORE_SCAN_ENTRY_USER_ID]
             chore_name = chore_info.get(const.DATA_CHORE_NAME, "Unknown Chore")
             points = chore_info.get(const.DATA_CHORE_DEFAULT_POINTS, 0)
+
+            # Rotation guard: only notify the current turn-holder
+            if ChoreEngine.is_rotation_mode(chore_info):
+                current_turn_assignee = chore_info.get(
+                    const.DATA_CHORE_ROTATION_CURRENT_ASSIGNEE_ID
+                )
+                if current_turn_assignee != assignee_id:
+                    continue
 
             # Get assignee name for signal emission
             assignee_info: UserData = cast(

--- a/custom_components/choreops/managers/notification_manager.py
+++ b/custom_components/choreops/managers/notification_manager.py
@@ -2650,22 +2650,6 @@ class NotificationManager(BaseManager):
         if not assignee_id or not chore_id:
             return
 
-        # Phase 3 Step 9: Filter rotation chores - only notify turn-holder
-        chore_info: ChoreData | None = self.coordinator.chores_data.get(chore_id)
-        if chore_info and ChoreEngine.is_rotation_mode(chore_info):
-            current_turn_assignee = chore_info.get(
-                const.DATA_CHORE_ROTATION_CURRENT_ASSIGNEE_ID
-            )
-            if current_turn_assignee != assignee_id:
-                const.LOGGER.debug(
-                    "NotificationManager: Skipping due window notification for rotation chore=%s "
-                    "(not_my_turn: current turn is assignee=%s, not %s)",
-                    chore_name,
-                    current_turn_assignee,
-                    assignee_id,
-                )
-                return
-
         # Schedule-Lock: Check if already notified this period
         if not self._should_send_chore_notification(assignee_id, chore_id, "due_start"):
             const.LOGGER.debug(
@@ -2719,22 +2703,6 @@ class NotificationManager(BaseManager):
 
         if not assignee_id or not chore_id:
             return
-
-        # Phase 3 Step 9: Filter rotation chores - only notify turn-holder
-        chore_info: ChoreData | None = self.coordinator.chores_data.get(chore_id)
-        if chore_info and ChoreEngine.is_rotation_mode(chore_info):
-            current_turn_assignee = chore_info.get(
-                const.DATA_CHORE_ROTATION_CURRENT_ASSIGNEE_ID
-            )
-            if current_turn_assignee != assignee_id:
-                const.LOGGER.debug(
-                    "NotificationManager: Skipping due reminder notification for rotation chore=%s "
-                    "(not_my_turn: current turn is assignee=%s, not %s)",
-                    chore_name,
-                    current_turn_assignee,
-                    assignee_id,
-                )
-                return
 
         # Schedule-Lock: Check if already notified this period
         if not self._should_send_chore_notification(


### PR DESCRIPTION
Rotation-mode chores create scan entries for every assigned assignee, but only the current turn-holder should receive due/overdue notifications.

- Add rotation guard to _process_overdue: non-turn-holders without steal or standby capability are skipped before signal emission
- Add rotation guard to _process_due_window: skip non-turn-holders
- Add rotation guard to _process_due_reminder: skip non-turn-holders
- Remove now-redundant rotation guards from _handle_chore_due_window and _handle_chore_due_reminder in notification_manager.py

Single source of truth at the emission layer protects all downstream listeners (NotificationManager, StatisticsManager, GamificationManager).

Fixes #175

