### PR TITLE
fix(notifications): strip points from messages to non-gamified users

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -2165,6 +2165,36 @@ TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_WINDOW_ASSIGNEE: Final = (
     "notification_message_chore_due_window_assignee"
 )
 
+# Non-gamified variants (no {points} or {points_label} references)
+TRANS_KEY_NOTIF_MESSAGE_CHORE_APPROVED_ASSIGNEE_NO_POINTS: Final = (
+    "notification_message_chore_approved_assignee_no_points"
+)
+TRANS_KEY_NOTIF_MESSAGE_CHORE_OVERDUE_ASSIGNEE_NO_POINTS: Final = (
+    "notification_message_chore_overdue_assignee_no_points"
+)
+TRANS_KEY_NOTIF_MESSAGE_CHORE_OVERDUE_STEAL_AVAILABLE_NO_POINTS: Final = (
+    "notification_message_chore_overdue_steal_available_no_points"
+)
+TRANS_KEY_NOTIF_MESSAGE_CHORE_STANDBY_NEEDED_NO_POINTS: Final = (
+    "notification_message_chore_standby_needed_no_points"
+)
+TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_REMINDER_ASSIGNEE_NO_POINTS: Final = (
+    "notification_message_chore_due_reminder_assignee_no_points"
+)
+TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_WINDOW_ASSIGNEE_NO_POINTS: Final = (
+    "notification_message_chore_due_window_assignee_no_points"
+)
+
+# Mapping from gamified message keys to their non-gamified alternatives
+NOTIF_NON_GAMIFIED_MESSAGE_KEYS: Final[dict[str, str]] = {
+    TRANS_KEY_NOTIF_MESSAGE_CHORE_APPROVED_ASSIGNEE: TRANS_KEY_NOTIF_MESSAGE_CHORE_APPROVED_ASSIGNEE_NO_POINTS,
+    TRANS_KEY_NOTIF_MESSAGE_CHORE_OVERDUE_ASSIGNEE: TRANS_KEY_NOTIF_MESSAGE_CHORE_OVERDUE_ASSIGNEE_NO_POINTS,
+    TRANS_KEY_NOTIF_MESSAGE_CHORE_OVERDUE_STEAL_AVAILABLE: TRANS_KEY_NOTIF_MESSAGE_CHORE_OVERDUE_STEAL_AVAILABLE_NO_POINTS,
+    TRANS_KEY_NOTIF_MESSAGE_CHORE_STANDBY_NEEDED: TRANS_KEY_NOTIF_MESSAGE_CHORE_STANDBY_NEEDED_NO_POINTS,
+    TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_REMINDER_ASSIGNEE: TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_REMINDER_ASSIGNEE_NO_POINTS,
+    TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_WINDOW_ASSIGNEE: TRANS_KEY_NOTIF_MESSAGE_CHORE_DUE_WINDOW_ASSIGNEE_NO_POINTS,
+}
+
 # Assignee: Reward Notifications
 TRANS_KEY_NOTIF_TITLE_REWARD_APPROVED_ASSIGNEE: Final = (
     "notification_title_reward_approved_assignee"

--- a/custom_components/choreops/managers/economy_manager.py
+++ b/custom_components/choreops/managers/economy_manager.py
@@ -310,35 +310,55 @@ class EconomyManager(BaseManager):
         notify_assignee = bool(payload.get("notify_assignee", True))
 
         if base_points > 0 and assignee_id:
-            apply_multiplier = True
-            multiplier_applied = 1.0
-            if apply_multiplier and (assignee := self._get_assignee(assignee_id)):
-                multiplier_applied = float(
-                    assignee.get(const.DATA_USER_POINTS_MULTIPLIER, 1.0)
+            assignee = self._get_assignee(assignee_id)
+            gamification_enabled = (
+                bool(assignee.get(const.DATA_USER_ENABLE_GAMIFICATION, True))
+                if assignee
+                else True
+            )
+
+            if gamification_enabled:
+                apply_multiplier = True
+                multiplier_applied = 1.0
+                if apply_multiplier and assignee:
+                    multiplier_applied = float(
+                        assignee.get(const.DATA_USER_POINTS_MULTIPLIER, 1.0)
+                    )
+                points_awarded = EconomyEngine.calculate_with_multiplier(
+                    base_points,
+                    multiplier_applied,
                 )
-            points_awarded = EconomyEngine.calculate_with_multiplier(
-                base_points,
-                multiplier_applied,
-            )
 
-            await self.deposit(
-                assignee_id=assignee_id,
-                amount=base_points,
-                source=const.POINTS_SOURCE_CHORES,
-                reference_id=chore_id,
-                item_name=chore_name,
-                apply_multiplier=apply_multiplier,
-            )
+                await self.deposit(
+                    assignee_id=assignee_id,
+                    amount=base_points,
+                    source=const.POINTS_SOURCE_CHORES,
+                    reference_id=chore_id,
+                    item_name=chore_name,
+                    apply_multiplier=apply_multiplier,
+                )
 
-            self.emit(
-                const.SIGNAL_SUFFIX_CHORE_POINTS_AWARDED,
-                user_id=assignee_id,
-                chore_id=chore_id,
-                points_awarded=points_awarded,
-                chore_name=chore_name,
-                effective_date=effective_date,
-                notify_assignee=notify_assignee,
-            )
+                self.emit(
+                    const.SIGNAL_SUFFIX_CHORE_POINTS_AWARDED,
+                    user_id=assignee_id,
+                    chore_id=chore_id,
+                    points_awarded=points_awarded,
+                    chore_name=chore_name,
+                    effective_date=effective_date,
+                    notify_assignee=notify_assignee,
+                )
+            else:
+                # Gamification disabled: emit notification signal with zero points
+                # so the assignee still receives a non-gamified approval message.
+                self.emit(
+                    const.SIGNAL_SUFFIX_CHORE_POINTS_AWARDED,
+                    user_id=assignee_id,
+                    chore_id=chore_id,
+                    points_awarded=0,
+                    chore_name=chore_name,
+                    effective_date=effective_date,
+                    notify_assignee=notify_assignee,
+                )
 
     async def _on_reward_approved(self, payload: dict[str, Any]) -> None:
         """Handle reward approved event - withdraw points from assignee's balance.

--- a/custom_components/choreops/managers/notification_manager.py
+++ b/custom_components/choreops/managers/notification_manager.py
@@ -808,6 +808,25 @@ class NotificationManager(BaseManager):
             )
         )
 
+    def _get_assignee_gamification_enabled(self, assignee_id: str) -> bool:
+        """Check if gamification is enabled for the target assignee.
+
+        Args:
+            assignee_id: The internal UUID of the assignee
+
+        Returns:
+            True if gamification is enabled, False otherwise
+        """
+        assignee_info: AssigneeData = cast(
+            "AssigneeData", self.coordinator.assignees_data.get(assignee_id, {})
+        )
+        return bool(
+            assignee_info.get(
+                const.DATA_USER_ENABLE_GAMIFICATION,
+                const.DEFAULT_USER_ENABLE_GAMIFICATION,
+            )
+        )
+
     def _build_notification_placeholders(
         self, message_data: dict[str, Any] | None
     ) -> dict[str, Any]:
@@ -1083,6 +1102,18 @@ class NotificationManager(BaseManager):
             title_key,
         )
 
+        # Check gamification status and resolve non-gamified key if needed
+        if not self._get_assignee_gamification_enabled(assignee_id):
+            message_key = const.NOTIF_NON_GAMIFIED_MESSAGE_KEYS.get(
+                message_key, message_key
+            )
+            if message_data:
+                message_data = {
+                    k: v
+                    for k, v in message_data.items()
+                    if k not in ("points", "points_label")
+                }
+
         # Load notification translations from custom translations directory
         translations = await th.load_notification_translation(self.hass, language)
         const.LOGGER.debug(
@@ -1291,12 +1322,30 @@ class NotificationManager(BaseManager):
                 self.hass, approver_language
             )
 
+            # Resolve non-gamified key based on approver's gamification flag
+            resolved_message_key = message_key
+            if not self._get_assignee_gamification_enabled(approver_id):
+                resolved_message_key = const.NOTIF_NON_GAMIFIED_MESSAGE_KEYS.get(
+                    message_key, message_key
+                )
+                approver_message_data = (
+                    {
+                        k: v
+                        for k, v in message_data.items()
+                        if k not in ("points", "points_label")
+                    }
+                    if message_data
+                    else None
+                )
+            else:
+                approver_message_data = message_data
+
             # Convert const keys to JSON keys and look up translations
             title_json_key = self._convert_notification_key(title_key)
-            message_json_key = self._convert_notification_key(message_key)
+            message_json_key = self._convert_notification_key(resolved_message_key)
             title_notification = translations.get(title_json_key, {})
             message_notification = translations.get(message_json_key, {})
-            placeholders = self._build_notification_placeholders(message_data)
+            placeholders = self._build_notification_placeholders(approver_message_data)
 
             # Format both title and message with placeholders
             title = self._format_notification_text(

--- a/custom_components/choreops/translations_custom/en_notifications.json
+++ b/custom_components/choreops/translations_custom/en_notifications.json
@@ -30,6 +30,24 @@
     "title": "🎯 Chore Now Due",
     "message": "{chore_name} is now due! Complete within {hours} hour(s) to earn {points} {points_label}"
   },
+  "chore_approved_assignee_no_points": {
+    "message": "{chore_name} approved!"
+  },
+  "chore_overdue_assignee_no_points": {
+    "message": "{chore_name} is overdue! Complete it now"
+  },
+  "chore_overdue_steal_available_no_points": {
+    "message": "{chore_name} is overdue and available to steal! Complete it first"
+  },
+  "chore_standby_needed_no_points": {
+    "message": "{primary_name}'s chore {chore_name} is overdue! Claim it now"
+  },
+  "chore_due_reminder_assignee_no_points": {
+    "message": "{chore_name} is due in {minutes} minutes!"
+  },
+  "chore_due_window_assignee_no_points": {
+    "message": "{chore_name} is now due! Complete within {hours} hour(s)"
+  },
   "reward_approved_assignee": {
     "title": "🎉 Reward Approved!",
     "message": "{reward_name} approved!"


### PR DESCRIPTION
When a user has enable_gamification=False, notifications still included points references like "You earned 50 Points". Two code paths were affected:

1. EconomyManager._on_chore_approved() processed and deposited points unconditionally — now gates on user's gamification flag
2. NotificationManager always used gamified message keys — now resolves to non-gamified _NO_POINTS variants based on recipient's gamification flag, and strips points/points_label from message_data

- Add 6 TRANS_KEY_NOTIF_*_NO_POINTS constants + NOTIF_NON_GAMIFIED_MESSAGE_KEYS mapping to const.py
- Add 6 non-gamified English notification templates to en_notifications.json
- Add _get_assignee_gamification_enabled() to notification_manager.py
- Apply key resolution and points stripping in notify_assignee_translated() and notify_approvers_translated()
- Add gamification guard in EconomyManager._on_chore_approved()

Fixes #177