### PR TITLE
fix(notifications): plumb notif_click_url and notif_approve_click_url

### DIFF
--- a/custom_components/choreops/config_flow.py
+++ b/custom_components/choreops/config_flow.py
@@ -712,6 +712,18 @@ class ChoreOpsConfigFlow(config_entries.ConfigFlow, domain=const.DOMAIN):
                             const.DEFAULT_DASHBOARD_LANGUAGE,
                         )
                     )
+                    assignee_projection[const.DATA_USER_NOTIF_CLICK_URL] = (
+                        user_profile_data.get(
+                            const.DATA_USER_NOTIF_CLICK_URL,
+                            "",
+                        )
+                    )
+                    assignee_projection[const.DATA_USER_NOTIF_APPROVE_CLICK_URL] = (
+                        user_profile_data.get(
+                            const.DATA_USER_NOTIF_APPROVE_CLICK_URL,
+                            "",
+                        )
+                    )
                     self._assignees_temp[internal_id] = assignee_projection
                 else:
                     self._assignees_temp.pop(internal_id, None)

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -595,6 +595,16 @@ def _validate_users_inputs_impl(
         data_dict[const.DATA_USER_CHORES_PAUSED_UNTIL] = user_input.get(
             const.CFOF_USERS_INPUT_CHORES_PAUSED_UNTIL
         )
+    if const.CFOF_USERS_INPUT_NOTIF_CLICK_URL in user_input:
+        data_dict[const.DATA_USER_NOTIF_CLICK_URL] = user_input.get(
+            const.CFOF_USERS_INPUT_NOTIF_CLICK_URL,
+            "",
+        )
+    if const.CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL in user_input:
+        data_dict[const.DATA_USER_NOTIF_APPROVE_CLICK_URL] = user_input.get(
+            const.CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL,
+            "",
+        )
 
     # Call shared validation (single source of truth)
     is_update = current_user_id is not None

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -970,6 +970,12 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             const.CFOF_USERS_INPUT_CAN_MANAGE: user_profile.get(
                 const.DATA_USER_CAN_MANAGE, False
             ),
+            const.CFOF_USERS_INPUT_NOTIF_CLICK_URL: user_profile.get(
+                const.DATA_USER_NOTIF_CLICK_URL, ""
+            ),
+            const.CFOF_USERS_INPUT_NOTIF_APPROVE_CLICK_URL: user_profile.get(
+                const.DATA_USER_NOTIF_APPROVE_CLICK_URL, ""
+            ),
         }
 
         # On validation error, merge user's attempted input with existing data


### PR DESCRIPTION
What changed:
- Added both URL fields to suggested_values in options_flow.py edit user step
- Added both URL fields to assignee_projection in config_flow.py user creation
- Added both URL fields to _validate_users_inputs_impl data_dict mapping in flow_helpers.py

Why:
The notification clickAction URL fields were defined in the schema, data builders, and type definitions (commit f46fbfc), but were never registered in the form's suggested_values or validation data mapping. This caused the edit user form to show the fields as blank on re-open, as the saved values were never loaded back into the form's suggested values dict.

