### PR TITLE
fix(notifications): skip due and reminder notifs for paused chores

### DIFF
--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -2282,6 +2282,10 @@ class ChoreManager(BaseManager):
                 if current_turn_assignee != assignee_id:
                     continue
 
+            # Pause guard: Skip paused users — no due-window notification
+            if self._is_chore_paused_for_assignee(assignee_id, entry["chore_id"]):
+                continue
+
             # Get assignee name for signal emission
             assignee_info: UserData = cast(
                 "UserData", self._coordinator.assignees_data.get(assignee_id, {})
@@ -2329,6 +2333,10 @@ class ChoreManager(BaseManager):
                 )
                 if current_turn_assignee != assignee_id:
                     continue
+
+            # Pause guard: Skip paused users — no reminder notification
+            if self._is_chore_paused_for_assignee(assignee_id, entry["chore_id"]):
+                continue
 
             # Get assignee name for signal emission
             assignee_info: UserData = cast(

--- a/custom_components/choreops/manifest.json
+++ b/custom_components/choreops/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ccpk1/choreops/issues",
   "quality_scale": "platinum",
   "requirements": ["python-dateutil>=2.9.0"],
-  "version": "1.5.0-beta.4"
+  "version": "1.5.0-beta.5"
 }


### PR DESCRIPTION
When a user's chores are paused (chores_paused = true), they still received "due soon" and "reminder" push notifications for their assigned chores. Only overdue notifications were correctly suppressed.

The `_process_due_window()` and `_process_due_reminder()` methods in the chore manager emitted notification signals without checking the user's pause state, while `_process_overdue()` already had this guard.

This aligns all three time-based notification pipelines to skip paused users, so pausing chores now silences all chore notifications instead of only overdue ones.

Closes #194 