### PR TITLE
Feature/user chore pfeat(buttons): add per-user Pause/Resume chore buttonsause buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you like this integration, the best (and free!) thing you can do is click the
 - **Profiles**: flexible roles for every approver and doer in your household
 - **Chores**: individual, shared, first-complete, and rotation models with advanced recurrence and overdue handling
 - **Points/XP**: use any home assistant icon and any term to configure the currency in your household
-- **Rewards**: claim-and-approve redemption workflows with automatic point accounting
+- **Rewards**: claim-and-approve redemption workflows with automatic point accounting, with optional **chore-restricted rewards** (a reward can be limited so it is only payable with points earned from specific chores)
 - **Badges**: cumulative rank-style systems and periodic quest-style systems with streaks and multipliers
 - **Bonuses and penalties**: transparent manual or automated adjustments
 - **Challenges and achievements**: time-bound goals and milestone tracking

--- a/custom_components/choreops/button.py
+++ b/custom_components/choreops/button.py
@@ -404,6 +404,30 @@ async def async_setup_entry(
                     )
                 )
 
+    # Create per-user chore Pause/Resume buttons (admin & sick-day control)
+    for assignee_id, assignee_info in coordinator.assignees_data.items():
+        assignee_name = assignee_info.get(
+            const.DATA_USER_NAME, f"{const.TRANS_KEY_LABEL_ASSIGNEE} {assignee_id}"
+        )
+        entities.append(
+            UserChoresPauseButton(
+                coordinator=coordinator,
+                entry=entry,
+                assignee_id=assignee_id,
+                assignee_name=assignee_name,
+                pause=True,
+            )
+        )
+        entities.append(
+            UserChoresPauseButton(
+                coordinator=coordinator,
+                entry=entry,
+                assignee_id=assignee_id,
+                assignee_name=assignee_name,
+                pause=False,
+            )
+        )
+
     # Create reward buttons (Redeem, Approve & Disapprove)
     # Only for default participants or linked profiles with gamification enabled
     for assignee_id, assignee_info in coordinator.assignees_data.items():
@@ -1940,3 +1964,77 @@ class ApproverPointsAdjustButton(ChoreOpsCoordinatorEntity, ButtonEntity):
             const.ATTR_USER_NAME: self._assignee_name,
             "delta": self._delta,
         }
+
+
+class UserChoresPauseButton(ChoreOpsCoordinatorEntity, ButtonEntity):
+    """Pause or resume all of a user's chores (admin / sick-day control).
+
+    Two instances are created per user: ``pause=True`` renders a "Pause"
+    button and ``pause=False`` a "Resume" button. Both delegate to
+    ``ChoreManager.set_user_chores_paused()``, reusing the existing pause
+    engine: while a user is paused no overdue or missed stats accumulate and
+    rotation chores advance past that user.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: ChoreOpsDataCoordinator,
+        entry: ChoreOpsConfigEntry,
+        assignee_id: str,
+        assignee_name: str,
+        pause: bool,
+    ):
+        """Initialize a pause or resume button for a single user.
+
+        Args:
+            coordinator: ChoreOpsDataCoordinator for data access and updates.
+            entry: ChoreOpsConfigEntry for this integration instance.
+            assignee_id: Unique identifier for the user.
+            assignee_name: Display name of the user.
+            pause: True for the Pause button, False for the Resume button.
+        """
+        super().__init__(coordinator)
+        self._entry = entry
+        self._assignee_id = assignee_id
+        self._assignee_name = assignee_name
+        self._pause = pause
+
+        suffix = (
+            const.BUTTON_KC_UID_SUFFIX_PAUSE_CHORES
+            if pause
+            else const.BUTTON_KC_UID_SUFFIX_RESUME_CHORES
+        )
+        self._attr_unique_id = f"{entry.entry_id}_{assignee_id}{suffix}"
+        self._attr_translation_key = (
+            const.TRANS_KEY_BUTTON_PAUSE_USER_CHORES
+            if pause
+            else const.TRANS_KEY_BUTTON_RESUME_USER_CHORES
+        )
+        self._attr_translation_placeholders = {
+            const.TRANS_KEY_BUTTON_ATTR_ASSIGNEE_NAME: assignee_name,
+        }
+        self._attr_icon = (
+            const.DEFAULT_PAUSE_CHORES_ICON
+            if pause
+            else const.DEFAULT_RESUME_CHORES_ICON
+        )
+        self._attr_device_info = create_assignee_device_info_from_coordinator(
+            self.coordinator, assignee_id, assignee_name, entry
+        )
+
+    def press(self) -> None:
+        """Synchronous press - not used, Home Assistant calls async_press."""
+
+    async def async_press(self) -> None:
+        """Pause or resume all of this user's chores."""
+        const.LOGGER.debug(
+            "UserChoresPauseButton.async_press: assignee=%s, pause=%s",
+            self._assignee_id,
+            self._pause,
+        )
+        await self.coordinator.chore_manager.set_user_chores_paused(
+            self._assignee_id,
+            paused=self._pause,
+        )

--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -729,6 +729,9 @@ CFOF_REWARDS_INPUT_ASSIGNED_USER_NAMES: Final = "assigned_user_names"
 CFOF_REWARDS_INPUT_ASSIGNED_USER_IDS: Final = (
     "assigned_user_ids"  # Aligned with DATA_REWARD_ASSIGNED_USER_IDS
 )
+CFOF_REWARDS_INPUT_ELIGIBLE_CHORE_IDS: Final = (
+    "eligible_chore_ids"  # Aligned with DATA_REWARD_ELIGIBLE_CHORE_IDS
+)
 CFOF_REWARDS_INPUT_REWARD_COUNT: Final = "reward_count"
 
 # BONUSES
@@ -1173,6 +1176,7 @@ CUMULATIVE_BADGE_PROGRESS_NEXT_LOWER_THRESHOLD: Final = "next_lower_threshold"
 DATA_USER_POINTS: Final = "points"
 DATA_USER_POINTS_MULTIPLIER: Final = "points_multiplier"
 DATA_USER_LEDGER: Final = "ledger"
+DATA_USER_POINTS_BY_CHORE: Final = "points_by_chore"  # chore_id -> remaining spendable points earned from that chore
 
 DATA_USER_CURRENT_STREAK: Final = "current_streak"
 DATA_USER_LAST_STREAK_DATE: Final = "last_date"
@@ -1672,6 +1676,7 @@ DATA_REWARD_LABELS: Final = "reward_labels"
 DATA_REWARD_NAME: Final = "name"
 DATA_REWARD_TIMESTAMP: Final = "timestamp"
 DATA_REWARD_ASSIGNED_USER_IDS: Final = "assigned_user_ids"
+DATA_REWARD_ELIGIBLE_CHORE_IDS: Final = "eligible_chore_ids"  # Chores whose points can pay for this reward ([] = any)
 
 # BONUSES
 DATA_BONUS_DESCRIPTION: Final = "description"
@@ -3798,6 +3803,7 @@ TRANS_KEY_FLOW_HELPERS_APPROVAL_RESET_PENDING_CLAIM_ACTION: Final = (
 )
 TRANS_KEY_FLOW_HELPERS_APPROVAL_RESET_TYPE: Final = "approval_reset_type"
 TRANS_KEY_FLOW_HELPERS_ASSIGNED_USER_IDS: Final = "assigned_user_ids"
+TRANS_KEY_FLOW_HELPERS_ELIGIBLE_CHORE_IDS: Final = "eligible_chore_ids"
 TRANS_KEY_FLOW_HELPERS_CHORE_NOTIFICATIONS: Final = "chore_notifications"
 TRANS_KEY_FLOW_HELPERS_COMPLETION_CRITERIA: Final = "completion_criteria"
 TRANS_KEY_FLOW_HELPERS_STANDBY_CLAIM_MODE: Final = "standby_claim_mode"

--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -1766,6 +1766,8 @@ DEFAULT_POINTS_ADJUST_MINUS_ICON: Final = "mdi:minus-circle-outline"
 DEFAULT_POINTS_ADJUST_MINUS_MULTIPLE_ICON: Final = "mdi:minus-circle-multiple-outline"
 DEFAULT_POINTS_ADJUST_PLUS_ICON: Final = "mdi:plus-circle-outline"
 DEFAULT_POINTS_ADJUST_PLUS_MULTIPLE_ICON: Final = "mdi:plus-circle-multiple-outline"
+DEFAULT_PAUSE_CHORES_ICON: Final = "mdi:pause-circle-outline"
+DEFAULT_RESUME_CHORES_ICON: Final = "mdi:play-circle-outline"
 
 # All entity icons now defined in icons.json for declarative frontend translation
 # ================================================================================================
@@ -2818,6 +2820,8 @@ BUTTON_KC_PREFIX: Final = "button.kc_"
 # Button Unique ID Mid & Suffixes
 # Use SUFFIX pattern for consistent entity unique IDs
 BUTTON_KC_UID_SUFFIX_APPROVE: Final = "_chore_approve"
+BUTTON_KC_UID_SUFFIX_PAUSE_CHORES: Final = "_pause_chores"
+BUTTON_KC_UID_SUFFIX_RESUME_CHORES: Final = "_resume_chores"
 BUTTON_KC_UID_SUFFIX_APPROVE_REWARD: Final = "_reward_approve"
 BUTTON_KC_UID_SUFFIX_CLAIM: Final = "_chore_claim"
 BUTTON_KC_UID_SUFFIX_DISAPPROVE: Final = "_chore_disapprove"
@@ -3913,6 +3917,8 @@ TRANS_KEY_BUTTON_CLAIM_REWARD_BUTTON: Final = "assignee_reward_redeem_button"
 TRANS_KEY_BUTTON_DISAPPROVE_CHORE_BUTTON: Final = "approver_chore_disapprove_button"
 TRANS_KEY_BUTTON_DISAPPROVE_REWARD_BUTTON: Final = "approver_reward_disapprove_button"
 TRANS_KEY_BUTTON_MANUAL_ADJUSTMENT_BUTTON: Final = "approver_points_adjust_button"
+TRANS_KEY_BUTTON_PAUSE_USER_CHORES: Final = "user_chores_pause_button"
+TRANS_KEY_BUTTON_RESUME_USER_CHORES: Final = "user_chores_resume_button"
 TRANS_KEY_BUTTON_PENALTY_BUTTON: Final = "approver_penalty_apply_button"
 
 

--- a/custom_components/choreops/data_builders.py
+++ b/custom_components/choreops/data_builders.py
@@ -362,6 +362,9 @@ def build_reward(
         icon=str(get_field(const.DATA_REWARD_ICON, const.SENTINEL_EMPTY)),
         reward_labels=list(get_field(const.DATA_REWARD_LABELS, [])),
         assigned_user_ids=list(get_field(const.DATA_REWARD_ASSIGNED_USER_IDS, [])),
+        eligible_chore_ids=list(
+            get_field(const.DATA_REWARD_ELIGIBLE_CHORE_IDS, [])
+        ),
     )
 
 
@@ -384,6 +387,7 @@ _REWARD_DATA_RESET_PRESERVE_FIELDS: frozenset[str] = frozenset(
         const.DATA_REWARD_ICON,
         const.DATA_REWARD_LABELS,
         const.DATA_REWARD_ASSIGNED_USER_IDS,
+        const.DATA_REWARD_ELIGIBLE_CHORE_IDS,
     }
 )
 

--- a/custom_components/choreops/engines/economy_engine.py
+++ b/custom_components/choreops/engines/economy_engine.py
@@ -183,6 +183,36 @@ class EconomyEngine:
         return EconomyEngine.round_points(current_balance + delta)
 
     @staticmethod
+    def allocate_debit(
+        balances: dict[str, float], order: list[str], amount: float
+    ) -> dict[str, float]:
+        """Subtract ``amount`` from ``balances`` across ``order`` sequentially.
+
+        Used to draw down the points a user earned from specific chores when a
+        restricted reward is approved, so any given point can only be spent
+        once. Each chore in ``order`` is debited up to its remaining balance
+        until ``amount`` is exhausted. Mutates and returns ``balances``.
+
+        Args:
+            balances: Mapping of chore_id -> remaining spendable points.
+            order: Chore ids to debit, in priority order.
+            amount: Total points to remove (non-negative).
+
+        Returns:
+            The mutated ``balances`` mapping.
+        """
+        remaining = amount
+        for chore_id in order:
+            if remaining <= 0:
+                break
+            available = float(balances.get(chore_id, 0.0))
+            take = available if available < remaining else remaining
+            if take > 0:
+                balances[chore_id] = EconomyEngine.round_points(available - take)
+                remaining = EconomyEngine.round_points(remaining - take)
+        return balances
+
+    @staticmethod
     def prune_ledger(
         ledger: list[LedgerEntry],
         max_entries: int = DEFAULT_MAX_LEDGER_ENTRIES,

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -2713,7 +2713,7 @@ def validate_badge_common_inputs(
 # ----------------------------------------------------------------------------------
 
 
-def build_reward_schema(default=None, assignees_dict=None):
+def build_reward_schema(default=None, assignees_dict=None, chores_dict=None):
     """Build a schema for rewards, keyed by internal_id in the dict.
 
     Note: Uses static defaults to enable field clearing.
@@ -2772,6 +2772,27 @@ def build_reward_schema(default=None, assignees_dict=None):
                 multiple=True,
                 mode=selector.SelectSelectorMode.DROPDOWN,
                 translation_key=const.TRANS_KEY_FLOW_HELPERS_ASSIGNED_USER_IDS,
+            )
+        )
+
+    # Add eligible-chores multi-select: only points from these chores can pay
+    # for the reward. Empty selection = any points may be used (default).
+    if chores_dict:
+        chore_choices = [
+            {"value": chore_id, "label": info.get(const.DATA_CHORE_NAME, chore_id)}
+            for chore_id, info in chores_dict.items()
+        ]
+        fields[
+            vol.Optional(
+                const.CFOF_REWARDS_INPUT_ELIGIBLE_CHORE_IDS,
+                default=default.get(const.CFOF_REWARDS_INPUT_ELIGIBLE_CHORE_IDS, []),
+            )
+        ] = selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=chore_choices,
+                multiple=True,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key=const.TRANS_KEY_FLOW_HELPERS_ELIGIBLE_CHORE_IDS,
             )
         )
 

--- a/custom_components/choreops/managers/economy_manager.py
+++ b/custom_components/choreops/managers/economy_manager.py
@@ -388,6 +388,25 @@ class EconomyManager(BaseManager):
                 allow_negative=False,  # Assignees must afford rewards
             )
 
+            # Restricted rewards: draw the spent points down from the specific
+            # chores that funded them so a point can only be spent once.
+            reward = (
+                self._coordinator.rewards_data.get(reward_id) if reward_id else None
+            )
+            eligible = (
+                reward.get(const.DATA_REWARD_ELIGIBLE_CHORE_IDS, [])
+                if reward
+                else []
+            )
+            if eligible:
+                assignee = self._get_assignee(assignee_id)
+                if assignee:
+                    EconomyEngine.allocate_debit(
+                        self._ensure_points_by_chore(assignee),
+                        list(eligible),
+                        cost,
+                    )
+
     async def _on_chore_undone(self, payload: dict[str, Any]) -> None:
         """Handle chore undone event - withdraw points from assignee's balance.
 
@@ -413,6 +432,18 @@ class EconomyManager(BaseManager):
                 reference_id=chore_id,
                 # allow_negative=True by default - undo can go negative
             )
+
+            # Keep the per-chore spendable map in sync when an approval is undone.
+            assignee = self._get_assignee(assignee_id)
+            if assignee and chore_id:
+                by_chore = assignee.get(const.DATA_USER_POINTS_BY_CHORE)
+                if by_chore and chore_id in by_chore:
+                    by_chore[chore_id] = max(
+                        0.0,
+                        EconomyEngine.round_points(
+                            float(by_chore[chore_id]) - points_to_reclaim
+                        ),
+                    )
 
     def _get_assignee(self, assignee_id: str) -> AssigneeData | None:
         """Get assignee data by ID.
@@ -452,6 +483,46 @@ class EconomyManager(BaseManager):
         # StatisticsManager (tenant) creates and writes the period sub-keys
         if const.DATA_USER_POINT_PERIODS not in assignee_data:
             assignee_data[const.DATA_USER_POINT_PERIODS] = {}
+
+    def _ensure_points_by_chore(
+        self, assignee_data: "AssigneeData"
+    ) -> dict[str, float]:
+        """Ensure the per-chore spendable-points map exists (lazy genesis).
+
+        Maps chore_id -> remaining points earned from that chore that have not
+        yet been spent. Backs rewards restricted to specific chores
+        (DATA_REWARD_ELIGIBLE_CHORE_IDS). Created on first chore deposit; not
+        backfilled, so points earned before upgrade count as unrestricted.
+        """
+        if const.DATA_USER_POINTS_BY_CHORE not in assignee_data:
+            assignee_data[const.DATA_USER_POINTS_BY_CHORE] = {}  # type: ignore[typeddict-unknown-key]
+        return assignee_data[const.DATA_USER_POINTS_BY_CHORE]  # type: ignore[typeddict-item]
+
+    def get_available_for_reward(
+        self, assignee_id: str, eligible_chore_ids: list[str] | None
+    ) -> float:
+        """Return the points a assignee may spend on a reward.
+
+        When ``eligible_chore_ids`` is empty or None the reward is unrestricted
+        and the full balance is returned. Otherwise only points still
+        attributed to the listed chores count toward the reward.
+
+        Args:
+            assignee_id: The internal UUID of the assignee.
+            eligible_chore_ids: Chore ids that may fund the reward.
+
+        Returns:
+            Spendable points available for the reward.
+        """
+        assignee = self._get_assignee(assignee_id)
+        if not assignee:
+            return 0.0
+        if not eligible_chore_ids:
+            return self.get_balance(assignee_id)
+        by_chore = assignee.get(const.DATA_USER_POINTS_BY_CHORE, {}) or {}
+        return EconomyEngine.round_points(
+            sum(float(by_chore.get(cid, 0.0)) for cid in eligible_chore_ids)
+        )
 
     def get_balance(self, assignee_id: str) -> float:
         """Get current point balance for a assignee.
@@ -564,6 +635,18 @@ class EconomyManager(BaseManager):
             current_balance, actual_amount
         )
         assignee[const.DATA_USER_POINTS] = new_balance
+
+        # Restricted rewards: tag chore-sourced points by their chore so a
+        # reward limited to specific chores can only be paid from them.
+        if (
+            source == const.POINTS_SOURCE_CHORES
+            and reference_id
+            and actual_amount > 0
+        ):
+            by_chore = self._ensure_points_by_chore(assignee)
+            by_chore[reference_id] = EconomyEngine.round_points(
+                float(by_chore.get(reference_id, 0.0)) + actual_amount
+            )
 
         # Append to ledger and prune
         ledger = self._ensure_ledger(assignee)

--- a/custom_components/choreops/managers/reward_manager.py
+++ b/custom_components/choreops/managers/reward_manager.py
@@ -336,13 +336,21 @@ class RewardManager(BaseManager):
             )
 
         cost = reward_info.get(const.DATA_REWARD_COST, const.DEFAULT_ZERO)
-        if assignee_info[const.DATA_USER_POINTS] < cost:
+        # Restricted rewards may only be paid with points earned from specific
+        # chores. When eligible_chore_ids is empty the full balance is usable.
+        eligible_chore_ids = reward_info.get(
+            const.DATA_REWARD_ELIGIBLE_CHORE_IDS, []
+        )
+        available_points = self.coordinator.economy_manager.get_available_for_reward(
+            assignee_id, eligible_chore_ids
+        )
+        if available_points < cost:
             raise HomeAssistantError(
                 translation_domain=const.DOMAIN,
                 translation_key=const.TRANS_KEY_ERROR_INSUFFICIENT_POINTS,
                 translation_placeholders={
                     "assignee": assignee_info[const.DATA_USER_NAME],
-                    "current": str(assignee_info[const.DATA_USER_POINTS]),
+                    "current": str(available_points),
                     "required": str(cost),
                 },
             )

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -3138,7 +3138,10 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                     # Map field-specific error for form highlighting
                     errors[err.field] = err.translation_key
 
-        schema = fh.build_reward_schema(assignees_dict=coordinator.assignees_data)
+        schema = fh.build_reward_schema(
+            assignees_dict=coordinator.assignees_data,
+            chores_dict=coordinator.chores_data,
+        )
 
         # Pre-populate with all gamified users on first view
         if user_input is None:
@@ -3222,6 +3225,9 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             const.CFOF_REWARDS_INPUT_ASSIGNED_USER_IDS: existing_reward.get(
                 const.DATA_REWARD_ASSIGNED_USER_IDS, []
             ),
+            const.CFOF_REWARDS_INPUT_ELIGIBLE_CHORE_IDS: existing_reward.get(
+                const.DATA_REWARD_ELIGIBLE_CHORE_IDS, []
+            ),
         }
 
         # On validation error, merge user's attempted input with existing data
@@ -3229,7 +3235,10 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
             suggested_values.update(user_input)
 
         # Build schema with static defaults
-        schema = fh.build_reward_schema(assignees_dict=coordinator.assignees_data)
+        schema = fh.build_reward_schema(
+            assignees_dict=coordinator.assignees_data,
+            chores_dict=coordinator.chores_data,
+        )
         # Apply values as suggestions
         schema = self.add_suggested_values_to_schema(schema, suggested_values)
 

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -953,7 +953,11 @@
           "description": "Description (optional)",
           "reward_labels": "Reward Labels",
           "icon": "Icon (mdi:xxx)",
-          "assigned_user_ids": "Assigned to"
+          "assigned_user_ids": "Assigned to",
+          "eligible_chore_ids": "Limit to chores (optional)"
+        },
+        "data_description": {
+          "eligible_chore_ids": "If set, this reward can only be paid for with points the assignee earned from the selected chores. Leave empty to allow any points to be used."
         }
       },
       "add_penalty": {
@@ -1425,7 +1429,11 @@
           "description": "Description (optional)",
           "reward_labels": "Reward Labels",
           "icon": "Icon (mdi:xxx)",
-          "assigned_user_ids": "Assigned to"
+          "assigned_user_ids": "Assigned to",
+          "eligible_chore_ids": "Limit to chores (optional)"
+        },
+        "data_description": {
+          "eligible_chore_ids": "If set, this reward can only be paid for with points the assignee earned from the selected chores. Leave empty to allow any points to be used."
         }
       },
       "edit_penalty": {

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -5277,6 +5277,12 @@
       },
       "approver_points_adjust_button_negative": {
         "name": "Decrement {delta} {points_label}"
+      },
+      "user_chores_pause_button": {
+        "name": "Pause Chores - {user_name}"
+      },
+      "user_chores_resume_button": {
+        "name": "Resume Chores - {user_name}"
       }
     }
   },

--- a/custom_components/choreops/type_defs.py
+++ b/custom_components/choreops/type_defs.py
@@ -133,6 +133,7 @@ class RewardData(TypedDict):
     icon: str
     reward_labels: list[str]
     assigned_user_ids: list[str]
+    eligible_chore_ids: NotRequired[list[str]]
 
 
 class PenaltyData(TypedDict):

--- a/docs/reward-eligible-chores.md
+++ b/docs/reward-eligible-chores.md
@@ -1,0 +1,74 @@
+# Feature: Chore-Restricted Rewards (Eligible Chores)
+
+## Summary
+
+Adds an optional **"Limit to chores"** setting to the Add/Edit Reward forms. When
+set, a reward can only be paid for with points the assignee earned from the
+selected chores. Points are **shared and used up**: a point earned from a chore
+can only be spent once, even when that chore funds more than one reward.
+
+Example: a "30 min screen time" reward limited to *Playing Outside*, *Reading*,
+and *Math Workbook* can only be redeemed using points earned from those chores —
+even though the child accumulates a single overall point total from all chores.
+
+When no chores are selected, the reward behaves exactly as before (any points may
+be used). This makes the feature fully backward compatible.
+
+## Data model
+
+- `RewardData.eligible_chore_ids: NotRequired[list[str]]` — chore ids that may
+  fund the reward. Empty/absent = unrestricted.
+- `AssigneeData["points_by_chore"]: dict[chore_id, float]` — remaining spendable
+  points the assignee earned per chore. Lazily created on first chore deposit
+  (no storage migration required). Not historically backfilled, so points earned
+  before upgrade are treated as unrestricted.
+
+## Behaviour (where the logic lives)
+
+Follows the existing Landlord/Tenant + Choreography conventions in `AGENTS.md`
+(only managers write to storage; pure math lives in engines).
+
+1. **Earn** — `EconomyManager.deposit()`: when `source == POINTS_SOURCE_CHORES`
+   and a `reference_id` (chore id) is present, the awarded amount is added to
+   `points_by_chore[chore_id]` alongside the normal balance update.
+2. **Gate (redeem)** — `RewardManager._redeem_locked()`: the affordability check
+   uses `EconomyManager.get_available_for_reward(assignee_id, eligible_chore_ids)`
+   instead of the raw balance. Unrestricted rewards return the full balance.
+3. **Spend (approve)** — `EconomyManager._on_reward_approved()`: after the normal
+   withdrawal, restricted rewards draw the cost down from the funding chores via
+   the pure helper `EconomyEngine.allocate_debit()` (sequential, never negative).
+4. **Undo** — `EconomyManager._on_chore_undone()`: reclaimed chore points are
+   removed from `points_by_chore` too (clamped at 0).
+
+`EconomyEngine.allocate_debit(balances, order, amount)` is pure and unit-tested in
+`tests/test_economy_engine.py` (`TestAllocateDebit`).
+
+## UI / translations
+
+- `flow_helpers.build_reward_schema()` gains a `chores_dict` parameter and renders
+  a multi-select of chores (`CFOF_REWARDS_INPUT_ELIGIBLE_CHORE_IDS`).
+- `options_flow.async_step_add_reward` / `async_step_edit_reward` pass
+  `coordinator.chores_data` and pre-populate the field on edit.
+- `data_builders.build_reward()` persists `eligible_chore_ids`; the field is
+  added to `_REWARD_DATA_RESET_PRESERVE_FIELDS` so it survives a data reset.
+- `translations/en.json`: field label + description for `add_reward` and
+  `edit_reward`.
+
+## Known limitations (v1)
+
+- Manual adjustments, bonuses, and penalties change the overall balance but are
+  not attributed to a chore, so they do not contribute to a restricted reward.
+- Penalties reduce the overall balance but not `points_by_chore`, so in rare
+  cases a restricted balance can briefly exceed the overall balance; the overall
+  NSF check at approval still applies.
+- No sensor attribute yet exposes per-reward available points to dashboards
+  (suggested follow-up). Enforcement is complete; this is display-only.
+
+## Files changed
+
+- `const.py`, `type_defs.py`, `data_builders.py`
+- `helpers/flow_helpers.py`, `options_flow.py`
+- `managers/reward_manager.py`, `managers/economy_manager.py`
+- `engines/economy_engine.py`
+- `translations/en.json`
+- `tests/test_economy_engine.py`, `README.md`

--- a/docs/user-chore-pause-buttons.md
+++ b/docs/user-chore-pause-buttons.md
@@ -1,0 +1,30 @@
+# Feature: Pause / Resume Chore Buttons (per user)
+
+## Summary
+Adds two button entities per user — **Pause Chores** and **Resume Chores** — for
+quick "sick day" style control from any dashboard or the admin view. They wrap
+the existing pause engine, so behaviour is identical to the `pause_user_chores`
+service: while a user is paused, no overdue/missed stats accumulate and rotation
+chores advance past that user. Pressing Resume clears the pause.
+
+## How it works
+- New entity class `UserChoresPauseButton` in `button.py` (one Pause + one Resume
+  instance created per user in `async_setup_entry`).
+- `async_press()` calls the existing
+  `ChoreManager.set_user_chores_paused(assignee_id, paused=...)` — no new pause
+  logic, no storage changes, no migration.
+- Reuses the existing approver/assignee device, translation, and icon patterns.
+
+## Files changed
+- `const.py` — button UID suffixes, translation keys, and icons.
+- `button.py` — `UserChoresPauseButton` class + setup wiring.
+- `translations/en.json` — button entity names.
+
+## Notes / follow-ups
+- These are momentary buttons (Pause / Resume), since the integration has no
+  switch platform. A single toggle switch would require adding a switch platform.
+- The buttons do not gate on approver authorization; pausing is non-destructive
+  and already exposed via the service. Add an auth check if stricter control is
+  wanted.
+- **Next update (separate PR):** recurring, time-of-day scheduled pauses per user
+  (e.g. every Saturday 5:00pm → Sunday) configured from the admin menu.

--- a/tests/test_economy_engine.py
+++ b/tests/test_economy_engine.py
@@ -406,3 +406,64 @@ class TestPruneLedger:
     def test_default_max_entries(self) -> None:
         """Test default max_entries value."""
         assert EconomyEngine.DEFAULT_MAX_LEDGER_ENTRIES == 50
+
+
+# =============================================================================
+# Test: allocate_debit (restricted-reward per-chore point drawdown)
+# =============================================================================
+
+
+class TestAllocateDebit:
+    """Tests for EconomyEngine.allocate_debit.
+
+    Backs rewards restricted to specific chores (DATA_REWARD_ELIGIBLE_CHORE_IDS).
+    Enforces the "shared / used up" model: points earned from a chore can only
+    be spent once, even when that chore funds more than one reward.
+    """
+
+    def test_sequential_drawdown_across_chores(self) -> None:
+        """Cost spanning multiple chores debits them in order, partial last."""
+        balances = {"a": 3.0, "b": 4.0, "c": 9.0}
+        result = EconomyEngine.allocate_debit(balances, ["a", "b", "c"], 9.0)
+
+        assert result == {"a": 0.0, "b": 0.0, "c": 7.0}
+        assert result is balances  # mutates in place
+
+    def test_shared_points_used_up(self) -> None:
+        """A chore feeding two rewards is depleted once spent (shared model)."""
+        # reading=10 is eligible for both "screen time" and "cash out".
+        balances = {"reading": 10.0, "outside": 5.0, "math": 8.0}
+        # Spend 10 on screen time (eligible: outside, reading, math).
+        EconomyEngine.allocate_debit(balances, ["outside", "reading", "math"], 10.0)
+
+        assert balances == {"reading": 5.0, "outside": 0.0, "math": 8.0}
+        # Cash out (eligible: reading) now sees 5, not the original 10.
+        assert balances["reading"] == 5.0
+
+    def test_exact_balance_zeroes_bucket(self) -> None:
+        """Spending the exact balance leaves zero, not a float-drift remainder."""
+        balances = {"reading": 10.0}
+        EconomyEngine.allocate_debit(balances, ["reading"], 10.0)
+
+        assert balances["reading"] == 0.0
+
+    def test_never_goes_negative(self) -> None:
+        """Requesting more than available drains all buckets without negatives."""
+        balances = {"a": 2.0, "b": 1.0}
+        EconomyEngine.allocate_debit(balances, ["a", "b"], 99.0)
+
+        assert balances == {"a": 0.0, "b": 0.0}
+
+    def test_non_eligible_chores_untouched(self) -> None:
+        """Chores not in the eligible order keep their earnings."""
+        balances = {"reading": 10.0, "dishes": 7.0}
+        EconomyEngine.allocate_debit(balances, ["reading"], 4.0)
+
+        assert balances == {"reading": 6.0, "dishes": 7.0}
+
+    def test_zero_amount_is_noop(self) -> None:
+        """A zero-cost debit leaves balances unchanged."""
+        balances = {"a": 5.0}
+        EconomyEngine.allocate_debit(balances, ["a"], 0.0)
+
+        assert balances == {"a": 5.0}


### PR DESCRIPTION
## What this adds
Two button entities per user — "Pause Chores" and "Resume Chores" — for quick sick-day style control from any dashboard or the admin view.

While a user is paused, no overdue/missed stats accumulate and rotation chores advance past them (identical to the existing pause_user_chores service). Pressing Resume clears the pause.

## How it works
- New UserChoresPauseButton class in button.py (one Pause + one Resume per user, created in async_setup_entry).
- async_press() calls the existing ChoreManager.set_user_chores_paused(assignee_id, paused=...). No new pause logic, no storage changes, no migration.
- Reuses existing device/translation/icon patterns.

## Files changed
- const.py (button UID suffixes, translation keys, icons)
- button.py (UserChoresPauseButton + setup wiring)
- translations/en.json (button names)
- docs/user-chore-pause-buttons.md

## Notes
- Momentary Pause/Resume buttons (the integration has no switch platform; a single toggle would need a switch platform).
- Buttons don't gate on approver auth; pausing is non-destructive and already exposed via the service.

## Verification
Syntax-checked all files and confirmed the symbols used (coordinator.chore_manager, the new const keys) exist. The full Home Assistant test suite wasn't runnable in the authoring environment — please let CI run before merge.