### PR TITLE
fix: Reset multiplier on assignees when a cumulative badge is deleted

### DIFF
--- a/custom_components/choreops/managers/gamification_manager.py
+++ b/custom_components/choreops/managers/gamification_manager.py
@@ -4946,12 +4946,22 @@ class GamificationManager(BaseManager):
             )
 
         badge_name = badges_data[badge_id].get(const.DATA_BADGE_NAME, badge_id)
+        badge_type = badges_data[badge_id].get(const.DATA_BADGE_TYPE)
+        earned_by = list(badges_data[badge_id].get(const.DATA_BADGE_EARNED_BY, []))
 
         # Delete from storage
         del self.coordinator._data[const.DATA_BADGES][badge_id]
 
         # Remove awarded badges from assignees (this manager has the method)
         self.remove_awarded_badges_by_id(badge_id=badge_id)
+
+        # Recalculate multiplier for assignees that had this badge earned,
+        # since remove_awarded_badges_by_id can no longer find the badge data.
+        # Must happen after deletion from badges_data so get_cumulative_badge_levels
+        # does not match the deleted badge via threshold check.
+        if badge_type == const.BADGE_TYPE_CUMULATIVE:
+            for assignee_id in earned_by:
+                self.update_point_multiplier_for_assignee(assignee_id)
 
         # Sync badge progress for all assignees after badge deletion
         # Phase 3A: cumulative progress computed on-read (no storage write needed)

--- a/tests/test_badge_cumulative.py
+++ b/tests/test_badge_cumulative.py
@@ -1267,3 +1267,55 @@ class TestCumulativeBadgeMultiplierTransitions:
             assignee_progress.get(const.DATA_USER_CUMULATIVE_BADGE_PROGRESS_STATUS)
             == const.CUMULATIVE_BADGE_STATE_GRACE
         )
+
+    async def test_deleting_cumulative_badge_resets_multiplier(
+        self,
+        hass: HomeAssistant,
+        setup_badges,  # noqa: F811
+    ) -> None:
+        """Deleting a cumulative badge must reset the multiplier for assignees.
+
+        Issue #198: Deleting a badge with a multiplier left the stale value
+        in the assignee's DATA_USER_POINTS_MULTIPLIER because delete_badge()
+        removed the badge from badges_data before remove_awarded_badges_by_id
+        could detect its type and trigger update_point_multiplier_for_assignee.
+        """
+        coordinator = setup_badges.coordinator
+        gamification_manager = coordinator.gamification_manager
+        max_id = get_assignee_by_name(coordinator, "Max!")
+        badge_id = get_badge_by_name(coordinator, "Team Player Badge")
+
+        # Set a 2.0x multiplier on the badge
+        badge_awards = coordinator.badges_data[badge_id].setdefault(
+            const.DATA_BADGE_AWARDS, {}
+        )
+        badge_awards[const.DATA_BADGE_AWARDS_POINT_MULTIPLIER] = 2.0
+
+        # Put the badge in Max!'s badges_earned and badge's earned_by list
+        assignee_data = coordinator.assignees_data[max_id]
+        assignee_data.setdefault(const.DATA_USER_BADGES_EARNED, {})[badge_id] = {
+            const.DATA_USER_BADGES_EARNED_NAME: coordinator.badges_data[badge_id][
+                const.DATA_BADGE_NAME
+            ],
+        }
+        coordinator.badges_data[badge_id].setdefault(
+            const.DATA_BADGE_EARNED_BY, []
+        ).append(max_id)
+
+        # Apply the multiplier
+        gamification_manager.update_point_multiplier_for_assignee(max_id)
+        await hass.async_block_till_done()
+
+        assert assignee_data[const.DATA_USER_POINTS_MULTIPLIER] == 2.0, (
+            "Multiplier should be 2.0 before badge deletion"
+        )
+
+        # Delete the badge
+        gamification_manager.delete_badge(badge_id)
+        await hass.async_block_till_done()
+
+        # Verify multiplier reset to default
+        assert (
+            assignee_data[const.DATA_USER_POINTS_MULTIPLIER]
+            == const.DEFAULT_ASSIGNEE_POINTS_MULTIPLIER
+        ), "Multiplier should reset to default after badge deletion"


### PR DESCRIPTION
What changed:
- Capture badge type and earned_by list before deletion in delete_badge()
- Recalculate multiplier for affected assignees after badge removal
- Add test confirming multiplier resets to default after badge deletion

Why:
- Deleting a cumulative badge with a multiplier left the stale value in assignee data because the badge was removed from badges_data before remove_awarded_badges_by_id could detect its type and trigger update_point_multiplier_for_assignee
- Fixes #198

