### PR TITLE
fix: Preserve due time in period-end scheduling and update integration version

### DIFF
--- a/custom_components/choreops/dashboards/dashboard_registry.json
+++ b/custom_components/choreops/dashboards/dashboard_registry.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "release_version": "1.1.0-beta.1",
+  "release_version": "1.1.0",
   "repo": "ccpk1/ChoreOps-Dashboards",
   "title": "ChoreOps Dashboard Registry",
   "description": "Registry manifest for ChoreOps dashboard templates",

--- a/custom_components/choreops/engines/schedule_engine.py
+++ b/custom_components/choreops/engines/schedule_engine.py
@@ -676,6 +676,56 @@ class RecurrenceEngine:
             seconds=const.END_OF_DAY_SECOND,
         )
 
+    def advance_period_end_preserve_time(
+        self, current_due_utc: datetime, periods: int = 1
+    ) -> datetime | None:
+        """Advance by N periods and snap to period end, preserving the original time.
+
+        Unlike _calculate_period_end (which returns 23:59 local time for calendar/badges),
+        this method preserves the time component of the input datetime and only snaps
+        the DATE to the end of the next period.
+
+        Used for chore rescheduling where the due time should remain consistent
+        (e.g., June 30 5PM MONTH_END -> July 31 5PM, not July 31 23:59).
+
+        Args:
+            current_due_utc: Current due datetime in UTC (time component preserved).
+            periods: Number of periods to advance (default 1).
+
+        Returns:
+            UTC datetime with the time from current_due_utc preserved and the
+            date snapped to the end of the advanced period.
+        """
+        freq = self._frequency
+        local_dt = as_local(current_due_utc)
+
+        if freq == const.PERIOD_MONTH_END:
+            result = local_dt + relativedelta(months=periods)
+            last_day = monthrange(result.year, result.month)[1]
+            result = result.replace(day=last_day)
+        elif freq == const.PERIOD_WEEK_END:
+            result = local_dt + timedelta(weeks=periods)
+            days_until_sunday = (const.SUNDAY_WEEKDAY_INDEX - result.weekday()) % 7
+            result = result + timedelta(days=days_until_sunday)
+        elif freq == const.PERIOD_QUARTER_END:
+            result = local_dt + relativedelta(months=3 * periods)
+            last_month = (
+                (result.month - 1) // const.MONTHS_PER_QUARTER + 1
+            ) * const.MONTHS_PER_QUARTER
+            last_day = monthrange(result.year, last_month)[1]
+            result = result.replace(month=last_month, day=last_day)
+        elif freq == const.PERIOD_YEAR_END:
+            result = local_dt + relativedelta(years=periods)
+            result = result.replace(
+                month=const.LAST_MONTH_OF_YEAR, day=const.LAST_DAY_OF_DECEMBER
+            )
+        elif freq == const.PERIOD_DAY_END:
+            result = local_dt + timedelta(days=periods)
+        else:
+            return None
+
+        return as_utc(result)
+
     # =========================================================================
     # Private: applicable_days handling
     # =========================================================================
@@ -1249,6 +1299,34 @@ def calculate_next_due_date_from_chore_info(
         if result is None:
             return None
         next_due_utc = result
+    elif freq in RecurrenceEngine.PERIOD_END_FREQUENCIES:
+        # Period-end: snap DATE to period end, preserve TIME from original due
+        # e.g., June 30 5PM MONTH_END -> July 31 5PM (not July 31 23:59)
+        if not current_due_utc:
+            return None
+        pe_config: ScheduleConfig = {
+            "frequency": freq,
+            "base_date": current_due_utc.isoformat(),
+        }
+        pe_engine = RecurrenceEngine(pe_config)
+        next_due_utc = pe_engine.advance_period_end_preserve_time(current_due_utc)
+        if next_due_utc is None:
+            return None
+        # Ensure result is after reference time
+        ref_utc = reference_time or dt_now_utc()
+        pe_iteration = 0
+        while (
+            next_due_utc <= ref_utc
+            and pe_iteration < const.MAX_DATE_CALCULATION_ITERATIONS
+        ):
+            pe_iteration += 1
+            prev = next_due_utc
+            next_due_utc = pe_engine.advance_period_end_preserve_time(next_due_utc)
+            if next_due_utc is None or next_due_utc == prev:
+                next_due_utc = None
+                break
+        if next_due_utc is None:
+            return None
     else:
         next_due_utc = cast(
             "datetime",

--- a/custom_components/choreops/engines/schedule_engine.py
+++ b/custom_components/choreops/engines/schedule_engine.py
@@ -1309,24 +1309,26 @@ def calculate_next_due_date_from_chore_info(
             "base_date": current_due_utc.isoformat(),
         }
         pe_engine = RecurrenceEngine(pe_config)
-        next_due_utc = pe_engine.advance_period_end_preserve_time(current_due_utc)
-        if next_due_utc is None:
+        pe_result = pe_engine.advance_period_end_preserve_time(current_due_utc)
+        if pe_result is None:
             return None
         # Ensure result is after reference time
         ref_utc = reference_time or dt_now_utc()
         pe_iteration = 0
         while (
-            next_due_utc <= ref_utc
+            pe_result <= ref_utc
             and pe_iteration < const.MAX_DATE_CALCULATION_ITERATIONS
         ):
             pe_iteration += 1
-            prev = next_due_utc
-            next_due_utc = pe_engine.advance_period_end_preserve_time(next_due_utc)
-            if next_due_utc is None or next_due_utc == prev:
-                next_due_utc = None
+            prev = pe_result
+            next_pe = pe_engine.advance_period_end_preserve_time(pe_result)
+            if next_pe is None or next_pe == prev:
+                pe_result = None
                 break
-        if next_due_utc is None:
+            pe_result = next_pe
+        if pe_result is None:
             return None
+        next_due_utc = pe_result
     else:
         next_due_utc = cast(
             "datetime",

--- a/custom_components/choreops/managers/gamification_manager.py
+++ b/custom_components/choreops/managers/gamification_manager.py
@@ -27,10 +27,13 @@ from homeassistant.helpers.start import async_at_started
 
 from .. import const, data_builders as db
 from ..engines.gamification_engine import GamificationEngine
+from ..engines.schedule_engine import RecurrenceEngine
 from ..helpers import entity_helpers as eh
 from ..helpers.entity_helpers import get_item_id_by_name, remove_entities_by_item_id
 from ..utils.dt_utils import (
     HELPER_RETURN_DATETIME_LOCAL,
+    as_local,
+    as_utc,
     dt_add_interval,
     dt_next_schedule,
     dt_now_utc_iso,
@@ -58,6 +61,7 @@ if TYPE_CHECKING:
         ChallengeProgress,
         EvaluationContext,
         EvaluationResult,
+        ScheduleConfig,
         UserData,
     )
 
@@ -1745,6 +1749,25 @@ class GamificationManager(BaseManager):
                     return_type=const.HELPER_RETURN_ISO_DATE,
                 )
                 return str(custom_result) if custom_result else None
+            return None
+
+        if recurring_frequency in RecurrenceEngine.PERIOD_END_FREQUENCIES:
+            # Use RecurrenceEngine for period-end badge cycles.
+            # Returns 23:59 local time on the period-end date, then extracts
+            # the local date for the date-only badge cycle output.
+            pe_config: ScheduleConfig = {
+                "frequency": recurring_frequency,
+                "base_date": current_end_iso,
+            }
+            pe_engine = RecurrenceEngine(pe_config)
+            current_end_dt = dt_parse(current_end_iso)
+            if not isinstance(current_end_dt, datetime):
+                return None
+            next_dt = pe_engine.get_next_occurrence(
+                after=as_utc(current_end_dt), require_future=True
+            )
+            if next_dt:
+                return as_local(next_dt).date().isoformat()
             return None
 
         next_result = dt_next_schedule(

--- a/custom_components/choreops/manifest.json
+++ b/custom_components/choreops/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ccpk1/choreops/issues",
   "quality_scale": "platinum",
   "requirements": ["python-dateutil>=2.9.0"],
-  "version": "1.5.0-beta.5"
+  "version": "1.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,3 @@
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
-
-[project]
-name = "choreops"
-version = "1.0.8"
-description = "ChoreOps Home Assistant Integration - Gamified chore tracking for households"
-readme = "README.md"
-authors = [{ name = "ChoreOps Contributors" }]
-license = { text = "GPL-3.0-or-later" }
-requires-python = ">=3.13"
-
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
This pull request introduces improvements to period-end date calculations for chore scheduling and badge cycles, ensuring the time component is preserved when advancing due dates. It also updates version numbers for a stable release and removes the unused `pyproject.toml` file.

**Period-end scheduling improvements:**

* Added `advance_period_end_preserve_time` to `RecurrenceEngine` in `schedule_engine.py`, allowing due dates to advance by period while preserving the original time (e.g., June 30 5PM → July 31 5PM for monthly chores).
* Updated `calculate_next_due_date_from_chore_info` to use the new period-end logic, ensuring next due dates for period-end frequencies maintain the original due time and correctly advance past the reference time.
* Modified `_get_next_non_cumulative_cycle_end` in `gamification_manager.py` to use `RecurrenceEngine` for period-end badge cycles, returning the correct local date for badge cycle calculations.

**Dependency and version updates:**

* Updated `manifest.json` and `dashboard_registry.json` to move from beta to stable release (`1.5.0` and `1.1.0` respectively). [[1]](diffhunk://#diff-ece8129648dac06ffee67a9e1cce7608de04e53e990cf03bcf0c394da7da2664L13-R13) [[2]](diffhunk://#diff-96c986dbb5a3f33694f46a2d9160822d340239057b851a81f82f7d85d7cd58a8L3-R3)

**Project cleanup:**

* Removed the unused `pyproject.toml` file.