### PR TITLE
fix(services): map due-date validation errors to a single exception key

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -3314,6 +3314,9 @@ TRANS_KEY_ERROR_INVALID_DATE_FORMAT: Final = (
     "invalid_date_format"  # Invalid date format
 )
 TRANS_KEY_ERROR_DATE_IN_PAST: Final = "date_in_past"  # Due date cannot be in the past
+TRANS_KEY_ERROR_FUTURE_DUE_DATE_REQUIRED: Final = (
+    "future_due_date_required"  # The requested changes require a future due date
+)
 TRANS_KEY_ERROR_MISSING_CHORE: Final = "missing_chore"  # Must provide chore ID or name
 TRANS_KEY_ERROR_MISSING_REWARD_IDENTIFIER: Final = (
     "missing_reward_identifier"  # Must provide reward_id or reward_name

--- a/custom_components/choreops/services.py
+++ b/custom_components/choreops/services.py
@@ -1655,6 +1655,22 @@ def async_setup_services(hass: HomeAssistant):
         if validation_errors:
             # Get first error and raise
             error_field, error_key = next(iter(validation_errors.items()))
+
+            # Map due-date-related config-flow keys to a single general
+            # exception key so service callers see one clear message
+            # regardless of which specific date validation failed.
+            _DUE_DATE_ERROR_KEYS = frozenset(
+                {
+                    const.TRANS_KEY_CFOF_DUE_DATE_IN_PAST,
+                    const.TRANS_KEY_CFOF_DATE_REQUIRED_FOR_FREQUENCY,
+                    const.TRANS_KEY_CFOF_ERROR_DAILY_MULTI_DUE_DATE_REQUIRED,
+                    const.TRANS_KEY_CFOF_ERROR_AT_DUE_DATE_RESET_REQUIRES_DUE_DATE,
+                    const.TRANS_KEY_CFOF_INVALID_DUE_DATE,
+                }
+            )
+            if error_key in _DUE_DATE_ERROR_KEYS:
+                error_key = const.TRANS_KEY_ERROR_FUTURE_DUE_DATE_REQUIRED
+
             raise HomeAssistantError(
                 translation_domain=const.DOMAIN,
                 translation_key=error_key,

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -5465,6 +5465,9 @@
     "date_in_past": {
       "message": "Due date cannot be in the past. Please provide a future date."
     },
+    "future_due_date_required": {
+      "message": "The requested changes require a future due date"
+    },
     "missing_chore": {
       "message": "Must provide either chore ID or chore name."
     },


### PR DESCRIPTION
What changed:
- Added TRANS_KEY_ERROR_FUTURE_DUE_DATE_REQUIRED constant
- Added "future_due_date_required" translation under exceptions
- Mapped five config-flow due-date error keys to the general key before raising HomeAssistantError in handle_update_chore

Related to #218

Why:
Instead of a 500 crash or a config-flow-specific error message, service callers now see a single clear, translatable message: "The requested changes require a future due date"

