### PR TITLE
chore: bump version to 1.5.1-beta.4

### DIFF
--- a/custom_components/choreops/manifest.json
+++ b/custom_components/choreops/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/ccpk1/choreops/issues",
   "quality_scale": "platinum",
   "requirements": ["python-dateutil>=2.9.0"],
-  "version": "1.5.1-beta.3"
+  "version": "1.5.1-beta.4"
 }


### PR DESCRIPTION
## Summary

Version bump for 1.5.1-beta.4 release.

### Changes
- Bump manifest.json version from 1.5.1-beta.3 to 1.5.1-beta.4

### Release notes
- Fixed: non-actionable chores (not_my_turn, blocked standby, paused) no longer inflate dashboard group headers
- Fixed: overdue notification storm for primary-standby chores (from 1.5.1-beta.1)
- Fixed: stale assignment data counting toward 'Due Today' summary (from 1.5.1-beta.1)
- l10n: sync translations from Crowdin

### Quality gates
- quick_lint.sh: ✅
- Boundary checks: ✅
- Tests: passed (resource-limited at 80%, no failures)