### PR TITLE
feat: expose custom interval attrs on chore status sensors for all custom frequencies

### DIFF
--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -4000,6 +4000,16 @@ CHORE_FREQUENCY_OPTIONS_CONFIG_FLOW = [
     FREQUENCY_CUSTOM_FROM_COMPLETE_DATE_ONLY,
 ]
 
+# Frequencies that carry a user-defined custom interval value + unit.
+# FREQUENCY_CUSTOM_1_* shortcuts are NOT included (fixed-length, no stored value).
+CUSTOM_INTERVAL_FREQUENCIES = frozenset(
+    {
+        FREQUENCY_CUSTOM,
+        FREQUENCY_CUSTOM_FROM_COMPLETE,
+        FREQUENCY_CUSTOM_FROM_COMPLETE_DATE_ONLY,
+    }
+)
+
 # Weekday Options
 WEEKDAY_OPTIONS = {
     "mon": "Monday",

--- a/custom_components/choreops/dashboards/templates/admin-peruser-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/admin-peruser-v1.yaml
@@ -1510,6 +1510,9 @@ views:
                   {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor not in ['', None, 'None'] else None) or 'Points' -%}
                   {%- set recurrence_key = chore_attrs.get('recurring_frequency', 'none') -%}
                   {%- set recurrence_display = recurrence_map.get(recurrence_key, recurrence_key | title) -%}
+                  {%- set custom_interval_value = chore_attrs.get('custom_frequency_interval') -%}
+                  {%- set custom_interval_unit = chore_attrs.get('custom_frequency_unit') -%}
+                  {%- set recurrence_interval_display = (ui.get('every', 'err-every') ~ ' ' ~ custom_interval_value ~ ' ' ~ custom_interval_unit) if custom_interval_value not in [None, 'None', ''] and custom_interval_unit not in [None, 'None', ''] else '' -%}
                   {%- set approval_reset_display = approval_reset_map.get(chore_attrs.get('approval_reset_type', 'at_midnight_once'), chore_attrs.get('approval_reset_type', ui.get('unknown', 'err-unknown'))) -%}
                   {%- set pending_claim_action_map = {
                     'hold_pending': ui.get('hold_pending', 'Hold pending'),
@@ -1640,7 +1643,7 @@ views:
                   {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('completion_criteria', 'err-completion_criteria') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ completion_type_display ~ "</div></div>" -%}
                   {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('value', 'err-value') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ chore_value ~ " " ~ points_label ~ "</div></div>" -%}
                   {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('approval_reset_type', 'err-approval_reset_type') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ approval_reset_display ~ "</div></div>" -%}
-                  {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('recurrence', 'err-recurrence') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ recurrence_display ~ "</div></div>" -%}
+                  {%- set detail_grid = detail_grid ~ ("<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('recurrence', 'err-recurrence') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ recurrence_display ~ "</div>" ~ ("<div style='margin-top:2px;font-size:11px;font-weight:500;line-height:1.3;color:var(--secondary-text-color);'>" ~ recurrence_interval_display ~ "</div>" if recurrence_interval_display != '' else '') ~ "</div>") -%}
                   {%- if is_rotation_type and assigned_users | count > 0 -%}
                     {%- set assignee_order_ns = namespace(items=[]) -%}
                     {%- if completion_type_key == 'rotation_primary_standby' -%}

--- a/custom_components/choreops/dashboards/templates/admin-shared-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/admin-shared-v1.yaml
@@ -1578,6 +1578,9 @@ views:
                   {%- set points_label = (state_attr(points_sensor, 'unit_of_measurement') if points_sensor not in ['', None, 'None'] else None) or 'Points' -%}
                   {%- set recurrence_key = chore_attrs.get('recurring_frequency', 'none') -%}
                   {%- set recurrence_display = recurrence_map.get(recurrence_key, recurrence_key | title) -%}
+                  {%- set custom_interval_value = chore_attrs.get('custom_frequency_interval') -%}
+                  {%- set custom_interval_unit = chore_attrs.get('custom_frequency_unit') -%}
+                  {%- set recurrence_interval_display = (ui.get('every', 'err-every') ~ ' ' ~ custom_interval_value ~ ' ' ~ custom_interval_unit) if custom_interval_value not in [None, 'None', ''] and custom_interval_unit not in [None, 'None', ''] else '' -%}
                   {%- set approval_reset_display = approval_reset_map.get(chore_attrs.get('approval_reset_type', 'at_midnight_once'), chore_attrs.get('approval_reset_type', ui.get('unknown', 'err-unknown'))) -%}
                   {%- set pending_claim_action_map = {
                     'hold_pending': ui.get('hold_pending', 'Hold pending'),
@@ -1708,7 +1711,7 @@ views:
                   {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('completion_criteria', 'err-completion_criteria') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ completion_type_display ~ "</div></div>" -%}
                   {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('value', 'err-value') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ chore_value ~ " " ~ points_label ~ "</div></div>" -%}
                   {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('approval_reset_type', 'err-approval_reset_type') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ approval_reset_display ~ "</div></div>" -%}
-                  {%- set detail_grid = detail_grid ~ "<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('recurrence', 'err-recurrence') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ recurrence_display ~ "</div></div>" -%}
+                  {%- set detail_grid = detail_grid ~ ("<div><div style='font-size:10px;text-transform:uppercase;letter-spacing:0.06em;color:var(--secondary-text-color);'>" ~ ui.get('recurrence', 'err-recurrence') ~ "</div><div style='margin-top:2px;font-size:13px;font-weight:600;line-height:1.3;'>" ~ recurrence_display ~ "</div>" ~ ("<div style='margin-top:2px;font-size:11px;font-weight:500;line-height:1.3;color:var(--secondary-text-color);'>" ~ recurrence_interval_display ~ "</div>" if recurrence_interval_display != '' else '') ~ "</div>") -%}
                   {%- if is_rotation_type and assigned_users | count > 0 -%}
                     {%- set assignee_order_ns = namespace(items=[]) -%}
                     {%- if completion_type_key == 'rotation_primary_standby' -%}

--- a/custom_components/choreops/sensor.py
+++ b/custom_components/choreops/sensor.py
@@ -1316,7 +1316,7 @@ class AssigneeChoreStatusSensor(ChoreOpsCoordinatorEntity, SensorEntity):
 
         if (
             chore_info.get(const.DATA_CHORE_RECURRING_FREQUENCY)
-            == const.FREQUENCY_CUSTOM
+            in const.CUSTOM_INTERVAL_FREQUENCIES
         ):
             attributes[const.ATTR_CUSTOM_FREQUENCY_INTERVAL] = chore_info.get(
                 const.DATA_CHORE_CUSTOM_INTERVAL
@@ -2794,7 +2794,7 @@ class SystemChoreSharedStateSensor(ChoreOpsCoordinatorEntity, SensorEntity):
 
         if (
             chore_info.get(const.DATA_CHORE_RECURRING_FREQUENCY)
-            == const.FREQUENCY_CUSTOM
+            in const.CUSTOM_INTERVAL_FREQUENCIES
         ):
             attributes[const.ATTR_CUSTOM_FREQUENCY_INTERVAL] = chore_info.get(
                 const.DATA_CHORE_CUSTOM_INTERVAL

--- a/tests/test_frequency_enhanced.py
+++ b/tests/test_frequency_enhanced.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, patch
 from zoneinfo import ZoneInfo
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 import pytest
 
@@ -1312,3 +1313,151 @@ class TestCustomHours:
         # Jan 14 + 1 month = Feb 14
         assert result_dt.month == 2
         assert result_dt.day == 14
+
+
+# =============================================================================
+# CUSTOM INTERVAL ATTRIBUTES (GH-238)
+# =============================================================================
+
+
+class TestCustomIntervalSensorAttributes:
+    """Verify custom interval/unit attributes on chore status sensors.
+
+    The global (shared) and per-user chore status sensors must expose the
+    configured custom interval value and unit when the chore uses one of the
+    custom frequencies (FREQUENCY_CUSTOM, FREQUENCY_CUSTOM_FROM_COMPLETE,
+    FREQUENCY_CUSTOM_FROM_COMPLETE_DATE_ONLY).
+    """
+
+    def _per_user_sensor_unique_id(
+        self,
+        entry_id: str,
+        assignee_id: str,
+        chore_id: str,
+    ) -> str:
+        """Return the unique ID for a per-user chore status sensor."""
+        return (
+            f"{entry_id}_{assignee_id}_{chore_id}"
+            f"{const.SENSOR_KC_UID_SUFFIX_CHORE_STATUS_SENSOR}"
+        )
+
+    def _shared_sensor_unique_id(self, entry_id: str, chore_id: str) -> str:
+        """Return the unique ID for a shared chore global status sensor."""
+        return (
+            f"{entry_id}_{chore_id}"
+            f"{const.SENSOR_KC_UID_SUFFIX_SHARED_CHORE_GLOBAL_STATE_SENSOR}"
+        )
+
+    def _entity_id_from_unique_id(
+        self,
+        entity_registry: er.EntityRegistry,
+        unique_id: str,
+    ) -> str | None:
+        """Resolve an entity id from its registry unique id."""
+        return entity_registry.async_get_entity_id("sensor", const.DOMAIN, unique_id)
+
+    async def test_custom_from_complete_per_user_and_shared_attributes(
+        self,
+        hass: HomeAssistant,
+        entity_registry: er.EntityRegistry,
+        scenario_enhanced_frequencies: SetupResult,
+    ) -> None:
+        """Custom-from-complete chore exposes interval attrs on both sensors."""
+        coordinator = scenario_enhanced_frequencies.coordinator
+        config_entry = scenario_enhanced_frequencies.config_entry
+        chore_id = scenario_enhanced_frequencies.chore_ids[
+            "Custom From Complete SHARED"
+        ]
+        assignee_id = scenario_enhanced_frequencies.assignee_ids["Zoë"]
+
+        chore_info = coordinator.chores_data.get(chore_id, {})
+        assert (
+            chore_info.get(DATA_CHORE_RECURRING_FREQUENCY)
+            == FREQUENCY_CUSTOM_FROM_COMPLETE
+        )
+        assert chore_info.get(DATA_CHORE_CUSTOM_INTERVAL) == 10
+        assert chore_info.get(DATA_CHORE_CUSTOM_INTERVAL_UNIT) == TIME_UNIT_DAYS
+
+        # Per-user sensor exposure
+        per_user_eid = self._per_user_sensor_unique_id(
+            config_entry.entry_id, assignee_id, chore_id
+        )
+        per_user_entity_id = self._entity_id_from_unique_id(
+            entity_registry, per_user_eid
+        )
+        assert per_user_entity_id is not None
+        per_user_state = hass.states.get(per_user_entity_id)
+        assert per_user_state is not None
+        assert per_user_state.attributes[const.ATTR_CUSTOM_FREQUENCY_INTERVAL] == 10
+        assert per_user_state.attributes[const.ATTR_CUSTOM_FREQUENCY_UNIT] == (
+            TIME_UNIT_DAYS
+        )
+
+        # Shared global sensor (chore is shared_all) exposure
+        shared_sensor_unique_id = self._shared_sensor_unique_id(
+            config_entry.entry_id, chore_id
+        )
+        shared_entity_id = self._entity_id_from_unique_id(
+            entity_registry, shared_sensor_unique_id
+        )
+        assert shared_entity_id is not None
+        shared_state = hass.states.get(shared_entity_id)
+        assert shared_state is not None
+        assert shared_state.attributes[const.ATTR_CUSTOM_FREQUENCY_INTERVAL] == 10
+        assert shared_state.attributes[const.ATTR_CUSTOM_FREQUENCY_UNIT] == (
+            TIME_UNIT_DAYS
+        )
+
+    @pytest.mark.parametrize(
+        ("chore_name", "assignee_name", "frequency", "interval", "unit"),
+        [
+            pytest.param(
+                "Custom From Complete SHARED",
+                "Zoë",
+                FREQUENCY_CUSTOM_FROM_COMPLETE,
+                10,
+                TIME_UNIT_DAYS,
+                id="custom_from_complete",
+            ),
+            pytest.param(
+                "Custom Hours 4h",
+                "Zoë",
+                FREQUENCY_CUSTOM,
+                4,
+                TIME_UNIT_HOURS,
+                id="custom",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_per_user_sensor_attributes_parametrized(
+        self,
+        hass: HomeAssistant,
+        entity_registry: er.EntityRegistry,
+        scenario_enhanced_frequencies: SetupResult,
+        chore_name: str,
+        assignee_name: str,
+        frequency: str,
+        interval: int,
+        unit: str,
+    ) -> None:
+        """Per-user chore sensor exposes interval attrs across custom freqs."""
+        coordinator = scenario_enhanced_frequencies.coordinator
+        config_entry = scenario_enhanced_frequencies.config_entry
+        chore_id = scenario_enhanced_frequencies.chore_ids[chore_name]
+        assignee_id = scenario_enhanced_frequencies.assignee_ids[assignee_name]
+
+        chore_info = coordinator.chores_data.get(chore_id, {})
+        assert chore_info.get(DATA_CHORE_RECURRING_FREQUENCY) == frequency
+        assert chore_info.get(DATA_CHORE_CUSTOM_INTERVAL) == interval
+        assert chore_info.get(DATA_CHORE_CUSTOM_INTERVAL_UNIT) == unit
+
+        unique_id = self._per_user_sensor_unique_id(
+            config_entry.entry_id, assignee_id, chore_id
+        )
+        entity_id = self._entity_id_from_unique_id(entity_registry, unique_id)
+        assert entity_id is not None
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.attributes[const.ATTR_CUSTOM_FREQUENCY_INTERVAL] == interval
+        assert state.attributes[const.ATTR_CUSTOM_FREQUENCY_UNIT] == unit


### PR DESCRIPTION
## Summary

Expose the configured custom recurrence interval and its unit as attributes on chore status sensors for **all** interval-based custom frequencies, and surface them in the admin v1 dashboards.

Previously the `custom_frequency_interval` and `custom_frequency_unit` attributes were only emitted when `recurring_frequency == FREQUENCY_CUSTOM`. Chores using `custom_from_complete` or `custom_from_complete_date_only` did not expose their configured interval, forcing dashboards and consumers to hardcode a separate lookup table.

This change:

- Adds a shared `CUSTOM_INTERVAL_FREQUENCIES` frozenset (`custom`, `custom_from_complete`, `custom_from_complete_date_only`) in `const.py`.
- Updates both chore status sensors — the per-user `AssigneeChoreStatusSensor` and the global `SystemChoreSharedStateSensor` — to expose `custom_frequency_interval` / `custom_frequency_unit` for all frequencies in that set.
- Updates the mirrored admin v1 dashboard templates to stack the interval ("Every X unit") as a second line inside the recurrence cell, preserving the `custom` vs `custom_from_complete` mode label.
- Adds targeted tests verifying attribute exposure on both sensor classes across the custom frequencies.

## Linked issue

- Closes #238

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [x] Correct release-note label is applied for `.github/release.yml` categorization
- [x] Excluded triage or status labels have been removed before merge
- [x] PR title is suitable for generated release notes

## Change type

- [ ] Bug fix
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Integration logic/state
- [ ] Dashboard/template behavior
- [ ] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [x] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/ -v --tb=line` (or targeted suite with rationale)

Targeted suites run in this PR's development cycle:
- `tests/test_frequency_enhanced.py` (new + existing custom-frequency tests)
- `tests/test_workflow_chores.py`
- `tests/test_chore_runtime_entity_sync.py`
- `tests/test_dashboard_template_render_smoke.py` + `tests/test_dashboard_template_contract.py`
- `tests/test_dashboard_*.py` + `tests/test_sync_dashboard_assets.py`

## Documentation impact

- [x] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

## Release notes

- [ ] No release notes needed
- [x] Release notes needed (summarize user-visible changes below)

- Release note summary: Chore status sensors now expose the configured custom interval and unit (`custom_frequency_interval` / `custom_frequency_unit`) for all custom frequencies, not just the base `custom` frequency. The admin v1 dashboards show the interval (e.g. "Every 6 months") beneath the recurrence mode.

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)