### PR TITLE
feat(auth): enforce fail-closed admin button auth + add get_ledger service

### DIFF
--- a/custom_components/choreops/button.py
+++ b/custom_components/choreops/button.py
@@ -30,6 +30,8 @@ from .helpers.auth_helpers import (
     AUTH_ACTION_APPROVAL,
     AUTH_ACTION_MANAGEMENT,
     AUTH_ACTION_PARTICIPATION,
+    AuthorizationAction,
+    is_admin_button_auth_enforced,
     is_kiosk_mode_enabled,
     is_user_authorized_for_action,
 )
@@ -69,6 +71,60 @@ def _button_entity_exists(
         entity_registry.async_get_entity_id("button", const.DOMAIN, unique_id)
         is not None
     )
+
+
+async def _ensure_admin_authorized(
+    hass: HomeAssistant,
+    context: Any | None,
+    assignee_id: str | None,
+    action: AuthorizationAction,
+    error_action: str,
+) -> str:
+    """Enforce admin-button authorization and return the approver display name.
+
+    When admin-button auth is enforced (fail-closed, default), an anonymous press
+    (no user context) or an unauthorized user is denied. When not enforced
+    (legacy fail-open), the existing authorization check is applied and the
+    approver name is resolved from the authenticated user when available.
+
+    Args:
+        hass: Home Assistant instance.
+        context: The button press context (may be None).
+        assignee_id: Target assignee ID for approval-scoped actions, or None for
+            management actions.
+        action: Authorization action contract (approval or management).
+        error_action: Translation placeholder for the denied action.
+
+    Returns:
+        The approver display name for the audit trail.
+
+    Raises:
+        HomeAssistantError: When authorization is enforced and the press is
+            anonymous or unauthorized.
+    """
+    user_id = context.user_id if context else None
+
+    if is_admin_button_auth_enforced(hass) and not user_id:
+        raise HomeAssistantError(
+            translation_domain=const.DOMAIN,
+            translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
+            translation_placeholders={"action": error_action},
+        )
+
+    if user_id and not await is_user_authorized_for_action(
+        hass,
+        user_id,
+        action,
+        target_user_id=assignee_id,
+    ):
+        raise HomeAssistantError(
+            translation_domain=const.DOMAIN,
+            translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
+            translation_placeholders={"action": error_action},
+        )
+
+    user_obj = await hass.auth.async_get_user(user_id) if user_id else None
+    return (user_obj.name if user_obj else None) or const.DISPLAY_UNKNOWN
 
 
 def create_chore_button_entities(
@@ -761,25 +817,13 @@ class ApproverChoreApproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
             HomeAssistantError: If user not authorized for global approver actions.
         """
         try:
-            user_id = self._context.user_id if self._context else None
-            if user_id and not await is_user_authorized_for_action(
+            approver_name = await _ensure_admin_authorized(
                 self.hass,
-                user_id,
+                self._context,
+                self._assignee_id,
                 AUTH_ACTION_APPROVAL,
-                target_user_id=self._assignee_id,
-            ):
-                raise HomeAssistantError(
-                    translation_domain=const.DOMAIN,
-                    translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                    translation_placeholders={
-                        "action": const.ERROR_ACTION_APPROVE_CHORES
-                    },
-                )
-
-            user_obj = await self.hass.auth.async_get_user(user_id) if user_id else None
-            approver_name = (
-                user_obj.name if user_obj else None
-            ) or const.DISPLAY_UNKNOWN
+                const.ERROR_ACTION_APPROVE_CHORES,
+            )
 
             await self.coordinator.chore_manager.approve_chore(
                 approver_name=approver_name,
@@ -936,26 +980,13 @@ class ApproverChoreDisapproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 )
             else:
                 # Approver/admin disapproval: Requires authorization and tracks stats
-                if user_id and not await is_user_authorized_for_action(
+                approver_name = await _ensure_admin_authorized(
                     self.hass,
-                    user_id,
+                    self._context,
+                    self._assignee_id,
                     AUTH_ACTION_APPROVAL,
-                    target_user_id=self._assignee_id,
-                ):
-                    raise HomeAssistantError(
-                        translation_domain=const.DOMAIN,
-                        translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                        translation_placeholders={
-                            "action": const.ERROR_ACTION_DISAPPROVE_CHORES
-                        },
-                    )
-
-                user_obj = (
-                    await self.hass.auth.async_get_user(user_id) if user_id else None
+                    const.ERROR_ACTION_DISAPPROVE_CHORES,
                 )
-                approver_name = (
-                    user_obj.name if user_obj else None
-                ) or const.DISPLAY_UNKNOWN
 
                 await self.coordinator.chore_manager.disapprove_chore(
                     approver_name=approver_name,
@@ -1217,25 +1248,13 @@ class ApproverRewardApproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
             HomeAssistantError: If user not authorized for global approver actions.
         """
         try:
-            user_id = self._context.user_id if self._context else None
-            if user_id and not await is_user_authorized_for_action(
+            approver_name = await _ensure_admin_authorized(
                 self.hass,
-                user_id,
+                self._context,
+                self._assignee_id,
                 AUTH_ACTION_APPROVAL,
-                target_user_id=self._assignee_id,
-            ):
-                raise HomeAssistantError(
-                    translation_domain=const.DOMAIN,
-                    translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                    translation_placeholders={
-                        "action": const.ERROR_ACTION_APPROVE_REWARDS
-                    },
-                )
-
-            user_obj = await self.hass.auth.async_get_user(user_id) if user_id else None
-            approver_name = (
-                user_obj.name if user_obj else None
-            ) or const.DISPLAY_UNKNOWN
+                const.ERROR_ACTION_APPROVE_REWARDS,
+            )
 
             # Approve the reward
             await self.coordinator.reward_manager.approve(
@@ -1391,26 +1410,13 @@ class ApproverRewardDisapproveButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 )
             else:
                 # Approver/admin disapproval: Requires authorization and tracks stats
-                if user_id and not await is_user_authorized_for_action(
+                approver_name = await _ensure_admin_authorized(
                     self.hass,
-                    user_id,
+                    self._context,
+                    self._assignee_id,
                     AUTH_ACTION_APPROVAL,
-                    target_user_id=self._assignee_id,
-                ):
-                    raise HomeAssistantError(
-                        translation_domain=const.DOMAIN,
-                        translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                        translation_placeholders={
-                            "action": const.ERROR_ACTION_DISAPPROVE_REWARDS
-                        },
-                    )
-
-                user_obj = (
-                    await self.hass.auth.async_get_user(user_id) if user_id else None
+                    const.ERROR_ACTION_DISAPPROVE_REWARDS,
                 )
-                approver_name = (
-                    user_obj.name if user_obj else None
-                ) or const.DISPLAY_UNKNOWN
 
                 await self.coordinator.reward_manager.disapprove(
                     approver_name=approver_name,
@@ -1540,24 +1546,13 @@ class ApproverBonusApplyButton(ChoreOpsCoordinatorEntity, ButtonEntity):
             HomeAssistantError: If user not authorized for global approver actions.
         """
         try:
-            user_id = self._context.user_id if self._context else None
-            if user_id and not await is_user_authorized_for_action(
+            approver_name = await _ensure_admin_authorized(
                 self.hass,
-                user_id,
+                self._context,
+                None,
                 AUTH_ACTION_MANAGEMENT,
-            ):
-                raise HomeAssistantError(
-                    translation_domain=const.DOMAIN,
-                    translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                    translation_placeholders={
-                        "action": const.ERROR_ACTION_APPLY_BONUSES
-                    },
-                )
-
-            user_obj = await self.hass.auth.async_get_user(user_id) if user_id else None
-            approver_name = (
-                user_obj.name if user_obj else None
-            ) or const.DISPLAY_UNKNOWN
+                const.ERROR_ACTION_APPLY_BONUSES,
+            )
 
             await self.coordinator.economy_manager.apply_bonus(
                 approver_name=approver_name,
@@ -1690,26 +1685,13 @@ class ApproverPenaltyApplyButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_id,
                 self._penalty_id,
             )
-            user_id = self._context.user_id if self._context else None
-            const.LOGGER.debug("Context user_id=%s", user_id)
-
-            if user_id and not await is_user_authorized_for_action(
+            approver_name = await _ensure_admin_authorized(
                 self.hass,
-                user_id,
+                self._context,
+                None,
                 AUTH_ACTION_MANAGEMENT,
-            ):
-                raise HomeAssistantError(
-                    translation_domain=const.DOMAIN,
-                    translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                    translation_placeholders={
-                        "action": const.ERROR_ACTION_APPLY_PENALTIES
-                    },
-                )
-
-            user_obj = await self.hass.auth.async_get_user(user_id) if user_id else None
-            approver_name = (
-                user_obj.name if user_obj else None
-            ) or const.DISPLAY_UNKNOWN
+                const.ERROR_ACTION_APPLY_PENALTIES,
+            )
             const.LOGGER.debug("About to call economy_manager.apply_penalty")
 
             await self.coordinator.economy_manager.apply_penalty(
@@ -1871,19 +1853,13 @@ class ApproverPointsAdjustButton(ChoreOpsCoordinatorEntity, ButtonEntity):
                 self._assignee_name,
                 self._delta,
             )
-            user_id = self._context.user_id if self._context else None
-            if user_id and not await is_user_authorized_for_action(
+            await _ensure_admin_authorized(
                 self.hass,
-                user_id,
+                self._context,
+                None,
                 AUTH_ACTION_MANAGEMENT,
-            ):
-                raise HomeAssistantError(
-                    translation_domain=const.DOMAIN,
-                    translation_key=const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL,
-                    translation_placeholders={
-                        "action": const.ERROR_ACTION_ADJUST_POINTS
-                    },
-                )
+                const.ERROR_ACTION_ADJUST_POINTS,
+            )
 
             # Use EconomyManager for point transactions
             # Use button's translated name for ledger entries (e.g., "Increment 10.0 Points", "Decrement 5.0 Points")

--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -857,6 +857,7 @@ CFOF_SYSTEM_INPUT_RETENTION_PERIODS: Final = "retention_periods"
 CFOF_SYSTEM_INPUT_SHOW_LEGACY_ENTITIES: Final = "show_legacy_entities"
 CFOF_SYSTEM_INPUT_KIOSK_MODE: Final = "kiosk_mode"
 CFOF_SYSTEM_INPUT_ADMIN_APPROVAL_BYPASS: Final = "admin_approval_bypass"
+CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH: Final = "admin_button_auth"
 CFOF_SYSTEM_INPUT_BACKUPS_MAX_RETAINED: Final = "backups_max_retained"
 
 # Dashboard Generator Input Fields (OptionsFlow)
@@ -954,6 +955,8 @@ NOTIFICATION_EVENT: Final = "mobile_app_notification_action"
 CONF_SHOW_LEGACY_ENTITIES: Final = "show_legacy_entities"
 CONF_KIOSK_MODE: Final = "kiosk_mode"
 CONF_ADMIN_APPROVAL_BYPASS: Final = "admin_approval_bypass"
+# True = admin buttons require a logged-in account (fail-closed); False = legacy fail-open
+CONF_ADMIN_BUTTON_AUTH: Final = "admin_button_auth"
 
 # Dashboard display settings
 DASHBOARD_POINTS_PRECISION_FIXED_0: Final = "fixed_0"
@@ -1820,6 +1823,8 @@ DEFAULT_ASSIGNEE_POINTS_MULTIPLIER: Final = 1
 DEFAULT_SHOW_LEGACY_ENTITIES: Final = False
 DEFAULT_KIOSK_MODE: Final = False
 DEFAULT_ADMIN_APPROVAL_BYPASS: Final = True
+# True = enforce auth on admin buttons (fail-closed, secure default); False = legacy fail-open
+DEFAULT_ADMIN_BUTTON_AUTH: Final = True
 DEFAULT_DASHBOARD_POINTS_PRECISION: Final = DASHBOARD_POINTS_PRECISION_FIXED_0
 DEFAULT_NOTIFY_ON_APPROVAL = True
 DEFAULT_NOTIFY_ON_CLAIM = True

--- a/custom_components/choreops/const.py
+++ b/custom_components/choreops/const.py
@@ -1317,6 +1317,19 @@ POINTS_SOURCE_REWARDS: Final = "rewards"
 POINTS_SOURCE_MANUAL: Final = "manual"
 POINTS_SOURCE_OTHER: Final = "other"
 
+# Human-readable labels for ledger point sources (used by get_ledger service)
+LEDGER_SOURCE_LABELS: Final = {
+    POINTS_SOURCE_CHORES: "Chore",
+    POINTS_SOURCE_REWARDS: "Reward",
+    POINTS_SOURCE_BONUSES: "Bonus",
+    POINTS_SOURCE_PENALTIES: "Penalty",
+    POINTS_SOURCE_BADGES: "Badge",
+    POINTS_SOURCE_ACHIEVEMENTS: "Achievement",
+    POINTS_SOURCE_CHALLENGES: "Challenge",
+    POINTS_SOURCE_MANUAL: "Adjustment",
+    POINTS_SOURCE_OTHER: "Activity",
+}
+
 # Example list of valid sources for UI/enumeration:
 # Lowercase literals required by Home Assistant SelectSelector schema
 
@@ -2923,6 +2936,7 @@ SERVICE_UPDATE_CHORE: Final = "update_chore"
 SERVICE_UPDATE_REWARD: Final = "update_reward"
 SERVICE_GENERATE_ACTIVITY_REPORT: Final = "generate_activity_report"
 SERVICE_MANAGE_UI_CONTROL: Final = "manage_ui_control"
+SERVICE_GET_LEDGER: Final = "get_ledger"
 
 
 # ------------------------------------------------------------------------------------------------
@@ -3105,6 +3119,9 @@ SERVICE_FIELD_REPORT_NOTIFY_SERVICE: Final = "notify_service"
 SERVICE_FIELD_REPORT_TITLE: Final = "report_title"
 SERVICE_FIELD_REPORT_LANGUAGE: Final = "report_language"
 SERVICE_FIELD_REPORT_OUTPUT_FORMAT: Final = "output_format"
+
+# Ledger service fields
+SERVICE_FIELD_LEDGER_LIMIT: Final = "limit"
 
 # Report output modes
 REPORT_OUTPUT_FORMAT_MARKDOWN: Final = "markdown"

--- a/custom_components/choreops/helpers/auth_helpers.py
+++ b/custom_components/choreops/helpers/auth_helpers.py
@@ -83,6 +83,32 @@ def is_admin_approval_bypass_enabled(hass: HomeAssistant) -> bool:
     return const.DEFAULT_ADMIN_APPROVAL_BYPASS
 
 
+def is_admin_button_auth_enforced(hass: HomeAssistant) -> bool:
+    """Return whether admin button authorization is enforced (fail-closed).
+
+    When True (default), admin buttons require a logged-in account and deny
+    anonymous presses. When False, legacy fail-open behavior is preserved.
+
+    Args:
+        hass: HomeAssistant instance
+
+    Returns:
+        True when admin button auth is enforced, False otherwise
+    """
+    entries = hass.config_entries.async_entries(const.DOMAIN)
+    if not entries:
+        return const.DEFAULT_ADMIN_BUTTON_AUTH
+
+    for entry in entries:
+        if entry.state.name == "LOADED":
+            return entry.options.get(
+                const.CONF_ADMIN_BUTTON_AUTH,
+                const.DEFAULT_ADMIN_BUTTON_AUTH,
+            )
+
+    return const.DEFAULT_ADMIN_BUTTON_AUTH
+
+
 # ==============================================================================
 # Authorization Checks
 # ==============================================================================

--- a/custom_components/choreops/helpers/flow_helpers.py
+++ b/custom_components/choreops/helpers/flow_helpers.py
@@ -3469,6 +3469,10 @@ def build_general_options_schema(default: dict | None = None) -> vol.Schema:
         const.CONF_ADMIN_APPROVAL_BYPASS,
         const.DEFAULT_ADMIN_APPROVAL_BYPASS,
     )
+    default_admin_button_auth = default.get(
+        const.CONF_ADMIN_BUTTON_AUTH,
+        const.DEFAULT_ADMIN_BUTTON_AUTH,
+    )
     default_dashboard_points_precision = default.get(
         const.CONF_DASHBOARD_POINTS_PRECISION,
         const.DEFAULT_DASHBOARD_POINTS_PRECISION,
@@ -3521,6 +3525,10 @@ def build_general_options_schema(default: dict | None = None) -> vol.Schema:
             vol.Required(
                 const.CFOF_SYSTEM_INPUT_ADMIN_APPROVAL_BYPASS,
                 default=default_admin_approval_bypass,
+            ): selector.BooleanSelector(),
+            vol.Required(
+                const.CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH,
+                default=default_admin_button_auth,
             ): selector.BooleanSelector(),
             vol.Required(
                 const.CFOF_SYSTEM_INPUT_BACKUPS_MAX_RETAINED,

--- a/custom_components/choreops/options_flow.py
+++ b/custom_components/choreops/options_flow.py
@@ -5130,6 +5130,10 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 const.CFOF_SYSTEM_INPUT_ADMIN_APPROVAL_BYPASS,
                 const.DEFAULT_ADMIN_APPROVAL_BYPASS,
             )
+            self._entry_options[const.CONF_ADMIN_BUTTON_AUTH] = user_input.get(
+                const.CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH,
+                const.DEFAULT_ADMIN_BUTTON_AUTH,
+            )
 
             # Update backup retention (count-based)
             self._entry_options[const.CONF_BACKUPS_MAX_RETAINED] = user_input.get(
@@ -5140,7 +5144,7 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 "General Options Updated: Points Adjust Values=%s, "
                 "Dashboard Points Precision=%s, Default Chore Points=%s, Update Interval=%s, Calendar Period to Show=%s, "
                 "Retention Periods=%s, "
-                "Show Legacy Entities=%s, Kiosk Mode=%s, Admin Approval Bypass=%s, Backup Retention=%s",
+                "Show Legacy Entities=%s, Kiosk Mode=%s, Admin Approval Bypass=%s, Admin Button Auth=%s, Backup Retention=%s",
                 self._entry_options.get(const.CONF_POINTS_ADJUST_VALUES),
                 self._entry_options.get(const.CONF_DASHBOARD_POINTS_PRECISION),
                 self._entry_options.get(const.CONF_DEFAULT_CHORE_POINTS),
@@ -5150,6 +5154,7 @@ class ChoreOpsOptionsFlowHandler(config_entries.OptionsFlow):
                 self._entry_options.get(const.CONF_SHOW_LEGACY_ENTITIES),
                 self._entry_options.get(const.CONF_KIOSK_MODE),
                 self._entry_options.get(const.CONF_ADMIN_APPROVAL_BYPASS),
+                self._entry_options.get(const.CONF_ADMIN_BUTTON_AUTH),
                 self._entry_options.get(const.CONF_BACKUPS_MAX_RETAINED),
             )
 

--- a/custom_components/choreops/services.py
+++ b/custom_components/choreops/services.py
@@ -645,6 +645,18 @@ GENERATE_ACTIVITY_REPORT_SCHEMA = vol.Schema(
     )
 )
 
+GET_LEDGER_SCHEMA = vol.Schema(
+    _with_service_target_fields(
+        {
+            vol.Optional(const.SERVICE_FIELD_USER_NAME): cv.string,
+            vol.Optional(
+                const.SERVICE_FIELD_LEDGER_LIMIT,
+                default=const.DEFAULT_LEDGER_MAX_ENTRIES,
+            ): cv.positive_int,
+        }
+    )
+)
+
 PAUSE_USER_CHORES_SCHEMA = vol.Schema(
     _with_service_target_fields(
         {
@@ -3541,6 +3553,127 @@ def async_setup_services(hass: HomeAssistant):
         const.SERVICE_GENERATE_ACTIVITY_REPORT,
         handle_generate_activity_report,
         schema=GENERATE_ACTIVITY_REPORT_SCHEMA,
+        supports_response=SupportsResponse.OPTIONAL,
+    )
+
+    async def handle_get_ledger(call: ServiceCall) -> dict[str, Any]:
+        """Handle get_ledger service call.
+
+        Returns a structured dump of ledger entries, optionally filtered to a
+        single user and capped by a limit. Read-only; does not mutate storage.
+        """
+        entry_id = _resolve_target_entry_id(hass, dict(call.data))
+        if not entry_id:
+            raise HomeAssistantError(
+                translation_domain=const.DOMAIN,
+                translation_key=const.TRANS_KEY_ERROR_MSG_NO_ENTRY_FOUND,
+            )
+
+        coordinator = _get_coordinator_by_entry_id(hass, entry_id)
+
+        assignee_name = call.data.get(const.SERVICE_FIELD_USER_NAME)
+        assignee_id: str | None = None
+        if assignee_name:
+            assignee_id = get_item_id_or_raise(
+                coordinator,
+                const.ITEM_TYPE_USER,
+                str(assignee_name),
+                role=const.ROLE_ASSIGNEE,
+            )
+
+        limit = int(call.data.get(const.SERVICE_FIELD_LEDGER_LIMIT, 0))
+        if limit <= 0:
+            limit = const.DEFAULT_LEDGER_MAX_ENTRIES
+
+        assignee_ids = (
+            [assignee_id] if assignee_id else list(coordinator.assignees_data.keys())
+        )
+
+        entries: list[dict[str, Any]] = []
+        total_earned = 0.0
+        total_spent = 0.0
+
+        for candidate_assignee_id in assignee_ids:
+            assignee_info: dict[str, Any] = cast(
+                "dict[str, Any]",
+                coordinator.assignees_data.get(candidate_assignee_id, {}),
+            )
+            ledger = assignee_info.get(const.DATA_USER_LEDGER, [])
+            if not isinstance(ledger, list):
+                continue
+
+            assignee_display_name = str(
+                assignee_info.get(const.DATA_USER_NAME, candidate_assignee_id)
+            )
+            for raw_entry in ledger:
+                if not isinstance(raw_entry, dict):
+                    continue
+                amount = float(raw_entry.get(const.DATA_LEDGER_AMOUNT, 0.0))
+                source = str(
+                    raw_entry.get(const.DATA_LEDGER_SOURCE, const.POINTS_SOURCE_OTHER)
+                )
+                entry_payload: dict[str, Any] = {
+                    const.DATA_LEDGER_TIMESTAMP: raw_entry.get(
+                        const.DATA_LEDGER_TIMESTAMP, ""
+                    ),
+                    const.DATA_LEDGER_AMOUNT: amount,
+                    const.DATA_LEDGER_BALANCE_AFTER: raw_entry.get(
+                        const.DATA_LEDGER_BALANCE_AFTER, 0.0
+                    ),
+                    const.DATA_LEDGER_SOURCE: source,
+                    "source_label": const.LEDGER_SOURCE_LABELS.get(
+                        source, const.POINTS_SOURCE_OTHER
+                    ),
+                    const.DATA_LEDGER_ITEM_NAME: raw_entry.get(
+                        const.DATA_LEDGER_ITEM_NAME, ""
+                    ),
+                    const.DATA_LEDGER_REFERENCE_ID: raw_entry.get(
+                        const.DATA_LEDGER_REFERENCE_ID
+                    ),
+                }
+                if assignee_id is None:
+                    entry_payload[const.DATA_USER_INTERNAL_ID] = candidate_assignee_id
+                    entry_payload[const.DATA_USER_NAME] = assignee_display_name
+
+                if amount >= 0:
+                    total_earned += amount
+                else:
+                    total_spent += abs(amount)
+                entries.append(entry_payload)
+
+        # Sort by timestamp ascending, then take the most recent `limit` entries
+        entries.sort(key=lambda entry: str(entry.get(const.DATA_LEDGER_TIMESTAMP, "")))
+        truncated = len(entries) > limit
+        entries = entries[-limit:]
+
+        resolved_assignee_name: str | None = None
+        if assignee_id is not None:
+            assignee_record: dict[str, Any] = cast(
+                "dict[str, Any]", coordinator.assignees_data.get(assignee_id, {})
+            )
+            resolved_assignee_name = str(
+                assignee_record.get(const.DATA_USER_NAME, assignee_id)
+            )
+
+        return {
+            "assignee_id": assignee_id,
+            "assignee_name": resolved_assignee_name,
+            "count": len(entries),
+            "limit": limit,
+            "truncated": truncated,
+            "summary": {
+                "total_earned": round(total_earned, const.DATA_FLOAT_PRECISION),
+                "total_spent": round(total_spent, const.DATA_FLOAT_PRECISION),
+                "net": round(total_earned - total_spent, const.DATA_FLOAT_PRECISION),
+            },
+            "entries": entries,
+        }
+
+    hass.services.async_register(
+        const.DOMAIN,
+        const.SERVICE_GET_LEDGER,
+        handle_get_ledger,
+        schema=GET_LEDGER_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
 

--- a/custom_components/choreops/services.yaml
+++ b/custom_components/choreops/services.yaml
@@ -503,6 +503,47 @@ generate_activity_report:
             - "html"
             - "both"
 
+get_ledger:
+  name: "Get Ledger"
+  description: >
+    Return a structured dump of point ledger entries. By default includes all
+    users; pass user_name to limit to one user. Use limit to cap the number of
+    most-recent entries returned. This service is response-first and returns
+    JSON when called with return_response: true.
+  fields:
+    config_entry_id:
+      name: "Config Entry ID (Optional)"
+      description: "Use this if you have more than one ChoreOps setup. It targets one specific setup."
+      required: false
+      example: "abc123def456"
+      selector:
+        text:
+    config_entry_title:
+      name: "Config Entry Name (Optional)"
+      description: "Use this if you have more than one ChoreOps setup and they each have unique names. If names repeat, use Config Entry ID."
+      required: false
+      example: "Family Chores"
+      selector:
+        text:
+    user_name:
+      name: "User Name"
+      description: "Optional filter. If omitted, includes all users in the ledger dump."
+      required: false
+      example: "Alice"
+      selector:
+        text:
+    limit:
+      name: "Limit"
+      description: "Maximum number of most-recent entries to return. Defaults to 1000."
+      required: false
+      default: 1000
+      example: 50
+      selector:
+        number:
+          min: 1
+          max: 1000
+          mode: box
+
 manage_ui_control:
   name: "Manage UI Control"
   description: >

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -1720,7 +1720,7 @@
           "show_legacy_entities": "Show extra entities like sensor and selects that are now consolidated into the dashboard helper sensor. These entities are optional for backward compatibility with existing automations.",
           "kiosk_mode": "Allows assignee chore/reward claim buttons to work on shared wall tablets without requiring the dashboard user to match the assignee's Home Assistant user link. Security warning: anyone with access to that device can submit assignee claims.",
           "admin_approval_bypass": "When enabled, Home Assistant admin accounts can use chore and reward approval actions across the integration. When disabled, admin accounts cannot approve chores or rewards just because they are Home Assistant admins.",
-          "admin_button_auth": "When enabled (default), admin buttons (approve/disapprove chore & reward, bonus, penalty, points adjust) require a logged-in account and will deny anonymous presses from scripts or automations. Use the equivalent service (e.g. choreops.approve_chore, choreops.apply_bonus) for automated flows. When disabled, matches legacy fail-open behavior (security risk: anyone able to reach the button can trigger admin actions).",
+          "admin_button_auth": "Require a logged-in account for admin buttons (approve/disapprove, bonus, penalty, points adjust). When disabled, anyone can trigger them. Use the equivalent service for automated flows.",
           "backups_max_retained": "Maximum number of backup files to keep per tag (e.g., 5 manual backups, 5 data_reset backups). Older backups are automatically deleted after each new backup is created. Set to 0 to disable automatic backups completely.",
           "backup_action_selection": "Choose a backup management action: create a manual backup, delete a backup, or restore from a backup."
         }
@@ -3021,6 +3021,30 @@
         "output_format": {
           "name": "Output Format",
           "description": "Return markdown only, html only, or both markdown and html in the response payload."
+        }
+      }
+    },
+    "get_ledger": {
+      "name": "Get Ledger",
+      "description": "Return a structured dump of point ledger entries. By default includes all users; pass user_name to limit to one user. Use limit to cap the number of most-recent entries returned.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config Entry ID (Optional)",
+          "description": "Use this if you have more than one ChoreOps setup. It targets one specific setup.",
+          "example": "abc123def456"
+        },
+        "config_entry_title": {
+          "name": "Config Entry Name (Optional)",
+          "description": "Use this if you have more than one ChoreOps setup and they each have unique names. If names repeat, use Config Entry ID.",
+          "example": "Family Chores"
+        },
+        "user_name": {
+          "name": "User Name",
+          "description": "Optional filter to include only one user's ledger entries."
+        },
+        "limit": {
+          "name": "Limit",
+          "description": "Maximum number of most-recent entries to return. Defaults to 1000."
         }
       }
     },

--- a/custom_components/choreops/translations/en.json
+++ b/custom_components/choreops/translations/en.json
@@ -1702,6 +1702,7 @@
           "show_legacy_entities": "Show Extra Entities",
           "kiosk_mode": "Enable Kiosk Mode for Assignee Claims",
           "admin_approval_bypass": "Allow Home Assistant Admin Accounts to Approve",
+          "admin_button_auth": "Enforce Authorization for Admin Buttons",
           "backups_max_retained": "Maximum Backups to Retain",
           "backup_action_selection": "Backup Actions"
         },
@@ -1719,6 +1720,7 @@
           "show_legacy_entities": "Show extra entities like sensor and selects that are now consolidated into the dashboard helper sensor. These entities are optional for backward compatibility with existing automations.",
           "kiosk_mode": "Allows assignee chore/reward claim buttons to work on shared wall tablets without requiring the dashboard user to match the assignee's Home Assistant user link. Security warning: anyone with access to that device can submit assignee claims.",
           "admin_approval_bypass": "When enabled, Home Assistant admin accounts can use chore and reward approval actions across the integration. When disabled, admin accounts cannot approve chores or rewards just because they are Home Assistant admins.",
+          "admin_button_auth": "When enabled (default), admin buttons (approve/disapprove chore & reward, bonus, penalty, points adjust) require a logged-in account and will deny anonymous presses from scripts or automations. Use the equivalent service (e.g. choreops.approve_chore, choreops.apply_bonus) for automated flows. When disabled, matches legacy fail-open behavior (security risk: anyone able to reach the button can trigger admin actions).",
           "backups_max_retained": "Maximum number of backup files to keep per tag (e.g., 5 manual backups, 5 data_reset backups). Older backups are automatically deleted after each new backup is created. Set to 0 to disable automatic backups completely.",
           "backup_action_selection": "Choose a backup management action: create a manual backup, delete a backup, or restore from a backup."
         }

--- a/docs/completed/ADMIN-BUTTON-AUTH-FAIL-CLOSED_COMPLETE.md
+++ b/docs/completed/ADMIN-BUTTON-AUTH-FAIL-CLOSED_COMPLETE.md
@@ -1,0 +1,235 @@
+# Initiative Plan: Admin Button Authorization — Fail-Closed (Issue #247)
+
+## Initiative snapshot
+
+- **Name / Code**: Admin Button Auth Fail-Closed / `AUTH-247`
+- **Target release / milestone**: Next minor release (after 1.5.0) — **breaking change**
+- **Owner / driver(s)**: ChoreOps maintainer / ChoreOps Builder
+- **Status**: Complete — all phases implemented, validated, and merged-ready
+
+## Summary & immediate steps
+
+| Phase / Step                | Description                                                                  | % complete | Quick notes                                                                 |
+| --------------------------- | ---------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------- |
+| Phase 1 – Foundation        | Constants, options-flow toggle, auth helper, translations                     | 100%       | ✅ Done — lint + mypy pass on changed files                                  |
+| Phase 2 – Core              | Fail-closed auth on 7 admin button classes in `button.py`                     | 100%       | ✅ Done — shared `_ensure_admin_authorized` helper; lint + mypy pass         |
+| Phase 3 – Testing           | Button auth tests + options-flow toggle tests                                 | 100%       | ✅ Done — 18 new tests pass; 238 existing tests pass (no regressions)        |
+| Phase 4 – Docs & Release    | Wiki updates, cookbook review, breaking-change announcement, translations     | 100%       | ✅ Done — wiki auto-approval migrated to services; access-control + general-options docs updated |
+
+1. **Key objective** – Close the security/cheating gap in Issue #247 by making **administrative button entities** deny anonymous (`user_id=None`) presses, while preserving user-action buttons (claim/redeem) and kiosk mode's intended scope. Add a config toggle so users can opt back to fail-open (with documented risk) while they migrate automations.
+2. **Summary of recent work** – All 4 phases implemented and validated. Phase 1: added `CONF_ADMIN_BUTTON_AUTH` toggle (Category B/kiosk pattern) + `is_admin_button_auth_enforced` helper + translations. Phase 2: added shared `_ensure_admin_authorized` helper and applied fail-closed to all 7 admin buttons in `button.py` (preserving kiosk undo branches). Phase 3: 18 new tests in `tests/test_admin_button_auth.py`; 238 existing tests pass with no regressions. Phase 4: wiki auto-approval page migrated from `button.press` to `choreops.approve_chore`; access-control, general-options, and services-reference docs updated.
+3. **Next steps (short term)** – PR creation with breaking-change release notes; sync wiki; final review.
+4. **Risks / blockers** – (a) Existing user automations pressing admin buttons will break; mitigated by toggle (opt 2) + documented migration to equivalent services (opt 1). (b) `manage_ui_control` used by kid dashboards must remain fail-open. (c) Kiosk mode must NOT be widened to admin actions. (d) `approver_name` spoofing intentionally left as-is per maintainer decision.
+5. **References**
+   - `docs/ARCHITECTURE.md`
+   - `docs/DEVELOPMENT_STANDARDS.md`
+   - `docs/CODE_REVIEW_GUIDE.md`
+   - `tests/AGENT_TEST_CREATION_INSTRUCTIONS.md`
+   - `docs/RELEASE_CHECKLIST.md`
+   - `docs/PLAN_TEMPLATE.md`
+   - Issue: https://github.com/ccpk1/ChoreOps/issues/247
+   - Wiki: `Tips-&-Tricks:-Configure-Automatic-Approval-of-Chores.md`, `Services:-Reference.md`
+6. **Decisions & completion check**
+   - **Decisions captured**:
+     - Fail-closed is the **default** (secure by design).
+     - Config toggle `CONF_ADMIN_BUTTON_AUTH` (fail-open ↔ fail-closed) with documented risk, modeled on kiosk mode.
+     - Services remain ungated (accepted HA tradeoff). Do NOT gate services.
+     - `manage_ui_control` remains fail-open.
+     - `approver_name` remains as-is.
+     - Kiosk mode scope unchanged (user actions only).
+     - Breaking change announced; wiki auto-approval page migrated to services.
+   - **Completion confirmation**: `[x]` All follow-up items completed (architecture updates, cleanup, documentation) before requesting owner approval to mark initiative done.
+
+> **Important:** Keep this Summary section current with every meaningful update.
+
+## Platinum & standards compliance (applies to ALL phases)
+
+Per `AGENTS.md`, `docs/DEVELOPMENT_STANDARDS.md`, and `docs/QUALITY_REFERENCE.md`:
+
+- **Typing**: 100% type hints on all new/edited public methods and helpers. Modern syntax `str | None` (never `Optional[str]`). **Zero mypy errors, no `# type: ignore` suppression.**
+- **No hardcoded strings**: All user-facing text via `const` constants → translation keys → `translations/en.json`. Use `translation_domain=const.DOMAIN` and `translation_key=const.TRANS_KEY_*` in exceptions.
+- **Lazy logging only**: `const.LOGGER.debug("msg %s", var)` — never f-strings in log statements.
+- **Constant naming**: `CFOF_*` (plural, flow inputs) for form fields; `CONF_*` for config entry option keys; `DEFAULT_*` for defaults; `TRANS_KEY_*` for translation identifiers. (Per DEVELOPMENT_STANDARDS §3.)
+- **Layer boundaries**: The auth gate lives in `button.py` (entity layer) — do NOT move write logic to managers. `helpers/` (auth_helpers) is the right home for the read-only toggle helper. No writes outside `managers/`.
+- **Config-flow purity** (DEVELOPMENT_STANDARDS §4): `options_flow.py`/`config_flow.py` must not write storage; the new toggle is purely `config_entry.options`, which `_update_system_settings_and_reload()` handles. No direct `_data` writes.
+- **Translations source of truth**: Edit `strings.json` → regenerate `en.json` via `script.translations develop --integration choreops`. Do not hand-edit `en.json`.
+- **Definition of Done** (non-negotiable, run in order):
+  1. `./utils/quick_lint.sh --fix`
+  2. `mypy custom_components/choreops/`
+  3. `python -m pytest tests/ -v --tb=line`
+
+## Detailed phase tracking
+
+### Phase 1 – Foundation: Constants, Toggle, Auth Helper, Translations
+
+- **Goal**: Add the config toggle plumbing (modeled **exactly** on the kiosk-mode "Category B" pattern) and the auth helper the admin buttons consult.
+- **⚠️ Critical architectural context — read before wiring anything:**
+  ChoreOps has **two distinct categories** of config-entry options:
+  - **Category A (`DEFAULT_SYSTEM_SETTINGS`)** — points label/icon, precision, default chore points, update interval, calendar period, retention periods, points-adjust values. These are backed up/restored via `backup_helpers.augment_backup_with_settings()` / `validate_config_entry_settings()`, built by `flow_helpers.build_all_system_settings_data()` (~3839) and `build_all_system_settings_schema()` (~3603), and consumed by `config_flow.async_step_reconfigure` and fresh-setup `async_create_entry`.
+  - **Category B (special-case UI toggles)** — `kiosk_mode`, `admin_approval_bypass`. **NOT** in `DEFAULT_SYSTEM_SETTINGS`; **NOT** in `build_all_system_settings_data/schema`; not backup/restore tracked. Wired only through: `flow_helpers.build_general_options_schema()` (~3422), `options_flow.async_step_manage_general_options()` (persistence ~5125 + debug log ~5151), and runtime readers in `auth_helpers`.
+  - **The new `admin_button_auth` toggle MUST follow Category B (kiosk) exactly.** It is a runtime authorization gate, not a data setting. Do **NOT** add it to `DEFAULT_SYSTEM_SETTINGS` or `build_all_system_settings_*` — that would wrongly wire it into backup/restore and the reconfigure flow, changing restore behavior for a flag that should default via `.get()` at read time.
+- **Steps / detailed work items**
+  1. **`custom_components/choreops/const.py`** (~line 858, 955, 1821):
+     - Add `CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH: Final = "admin_button_auth"` immediately after `CFOF_SYSTEM_INPUT_ADMIN_APPROVAL_BYPASS` (line ~859).
+     - Add `CONF_ADMIN_BUTTON_AUTH: Final = "admin_button_auth"` immediately after `CONF_ADMIN_APPROVAL_BYPASS` (line ~956).
+     - Add `DEFAULT_ADMIN_BUTTON_AUTH: Final = True` immediately after `DEFAULT_ADMIN_APPROVAL_BYPASS` (line ~1822). **`True` = enforce auth (fail-closed) = secure default.**
+     - Add a brief comment stating the polarity: `True` = admin buttons require a logged-in account (fail-closed); `False` = legacy fail-open.
+  2. **`custom_components/choreops/helpers/auth_helpers.py`**:
+     - Add `is_admin_button_auth_enforced(hass: HomeAssistant) -> bool` mirroring `is_kiosk_mode_enabled` (lines ~50–70): iterate loaded entries, return `entry.options.get(const.CONF_ADMIN_BUTTON_AUTH, const.DEFAULT_ADMIN_BUTTON_AUTH)`, fall back to default. Must be fully type-annotated (`HomeAssistant -> bool`) and keep the `Final`/`Literal` style consistent.
+  3. **`custom_components/choreops/helpers/flow_helpers.py`** (`build_general_options_schema`, ~lines 3467–3524):
+     - Add `default_admin_button_auth = default.get(const.CONF_ADMIN_BUTTON_AUTH, const.DEFAULT_ADMIN_BUTTON_AUTH)` next to the kiosk/admin_approval defaults (~line 3468).
+     - Add a `vol.Required(const.CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH, default=default_admin_button_auth): selector.BooleanSelector()` entry immediately after the `CFOF_SYSTEM_INPUT_ADMIN_APPROVAL_BYPASS` field (~line 3523). Follow the exact dict-entry formatting of its neighbors.
+  4. **`custom_components/choreops/options_flow.py`** (`async_step_manage_general_options`, persistence ~line 5129–5135):
+     - Add `self._entry_options[const.CONF_ADMIN_BUTTON_AUTH] = user_input.get(const.CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH, const.DEFAULT_ADMIN_BUTTON_AUTH)` after the `CONF_ADMIN_APPROVAL_BYPASS` assignment (~line 5133).
+     - Append `Admin Button Auth=%s` to the debug log (~line 5151) for parity with kiosk/admin_approval.
+     - **No** change to `_is_kiosk_mode_enabled()` or the non-kiosk link warning logic; the new toggle has no form-warning interaction.
+  5. **Translations** — add `admin_button_auth` label + description:
+     - **Source of truth**: `custom_components/choreops/strings.json` (general options `data` and `data_description` blocks, where `kiosk_mode`/`admin_approval_bypass` live).
+     - Regenerate English master: `.venv/bin/python3 -m script.translations develop --integration choreops` (per AGENTS.md; tests load `translations/en.json`, not `strings.json` directly).
+     - Verify `translations/en.json` label + description under the general options `data`/`data_description` (~lines 1703–1721). Do **not** hand-edit `en.json` before regenerating.
+     - Label: `"Enforce Authorization for Admin Buttons"`.
+     - Description must mirror kiosk's security-warning style: when enabled (default), admin buttons (approve/disapprove chore & reward, bonus, penalty, points adjust) require a logged-in account and will deny anonymous presses from scripts/automations; use the equivalent service (`choreops.approve_chore`, `choreops.apply_bonus`, etc.) for automated flows. When disabled, matches legacy fail-open behavior (security risk: anyone able to reach the button can trigger admin actions).
+  6. **Quality-gate prerequisites (Platinum per AGENTS.md / QUALITY_REFERENCE.md):**
+     - All new functions/params fully type-annotated (`str | None`, never `Optional[str]`); mypy clean, **no `# type: ignore` suppression**.
+     - No hardcoded user-facing strings — everything through `const` + translation keys.
+     - No f-strings in logs — use lazy `%s`.
+     - Run `./utils/quick_lint.sh --fix`, `mypy custom_components/choreops/`, and the options-flow tests after this phase.
+  7. **Key issues**
+     - **Do NOT** touch `DEFAULT_SYSTEM_SETTINGS`, `build_all_system_settings_data`, `build_all_system_settings_schema`, `validate_all_system_settings`, or the config-flow reconfigure path. The toggle is Category B (kiosk-style), not a backup/restore-tracked data setting.
+     - **Do NOT** add the toggle to the backup/restore round-trip (`backup_helpers`) — kiosk/admin_approval are deliberately excluded there; adding `admin_button_auth` would be inconsistent and require a backup format consideration. If a restore yields no value, the `.get(CONF_ADMIN_BUTTON_AUTH, DEFAULT_ADMIN_BUTTON_AUTH)` read returns the secure default (fail-closed) — which is the safe behavior.
+     - Polarity must be unambiguous in the constant comment and translation: `True` = enforced (fail-closed), `False` = fail-open.
+
+### Phase 2 – Core: Fail-Closed on 7 Admin Button Classes
+
+- **Goal**: Change the auth guard in `button.py` from fail-open to fail-closed, gated by the new toggle. Minimize duplication by using a shared helper.
+- **⚠️ Authorization semantics — read before implementing (drives the correct `action` per button):**
+  `is_user_authorized_for_action()` dispatches to two different authority checks, and the buttons split across them:
+  - **`AUTH_ACTION_MANAGEMENT`** → `_has_management_authority`: authorizes if the HA user **is an HA admin** (`user.is_admin`) OR is linked to a ChoreOps user record with `DATA_USER_CAN_MANAGE = True` (legacy approver-record fallback). **No target user.**
+    - Applies to: `ApproverBonusApplyButton`, `ApproverPenaltyApplyButton`, `ApproverPointsAdjustButton`.
+  - **`AUTH_ACTION_APPROVAL`** with `target_user_id=assignee_id` → `_has_approval_authority_for_target`: authorizes if the actor's linked ChoreOps user record has `DATA_USER_CAN_APPROVE = True` **AND** the target assignee is in the actor's `associated_user_ids` (i.e., a **linked approver of that specific assignee**). HA-admin is a bypass **only if** `CONF_ADMIN_APPROVAL_BYPASS` is enabled (default `True`); if all user records are unlinked, non-admin is allowed as a legacy fallback.
+    - Applies to: `ApproverChoreApproveButton`, `ApproverChoreDisapproveButton` (approver branch), `ApproverRewardApproveButton`, `ApproverRewardDisapproveButton`.
+  - **Our fail-closed change does NOT alter which rule applies.** It only makes "no authenticated user at all" (`user_id is None`) fail instead of silently succeeding. The existing `is_user_authorized_for_action` logic is unchanged; the helper just gates on it and on the toggle.
+  - **Approver display name**: with fail-closed, an admin-button press always has an authenticated user, so the helper can resolve the real name via `hass.auth.async_get_user(user_id).name` for the audit trail (closing the spoofing gap). The `const.DISPLAY_UNKNOWN` fallback becomes unreachable for admin buttons.
+
+- **✅ The gate automatically honors ALL existing integration access-control options (no new logic needed):**
+  Because the helper delegates to the existing `is_user_authorized_for_action()`, it inherits every access-control option already wired into that function. Confirmed options:
+  - **`CONF_ADMIN_APPROVAL_BYPASS`** (`admin_approval_bypass`, General Options, default `True`): controls whether HA admin accounts can approve/disapprove across the integration. When disabled, HA admins are **not** auto-authorized for approval actions (they must be linked approvers). The gate respects this automatically.
+  - **Per-user `can_approve` / `can_manage`** (`DATA_USER_CAN_APPROVE` / `DATA_USER_CAN_MANAGE`, set in Users configuration): a non-admin is only authorized if their linked user record has the capability. `can_manage` gates the MANAGEMENT buttons (bonus/penalty/points-adjust); `can_approve` + `associated_user_ids` gates the APPROVAL buttons.
+  - **`associated_user_ids`** (linked approver scope): for APPROVAL actions, the target assignee must be in the actor's associated list — a non-admin approver is **not** global.
+  - **`CONF_KIOSK_MODE`**: unchanged — only affects user-action (claim/redeem/undo) buttons, never admin buttons. The new gate is independent of kiosk.
+  - **`DATA_USER_CAN_BE_ASSIGNED`**: relevant to participation (claim) actions, not admin buttons; unaffected.
+  - **Legacy fallbacks** (unlinked users, legacy approver records): preserved as-is inside `is_user_authorized_for_action`.
+  - **Net effect**: the new `CONF_ADMIN_BUTTON_AUTH` toggle is purely the **outermost** gate — it decides whether anonymous presses are even allowed to reach the existing authorization logic. It does **not** re-implement or override any of the above. When `CONF_ADMIN_BUTTON_AUTH` is `True` (default), an anonymous press is denied before any of the above rules run; when `False`, the legacy fail-open behavior (and all the above rules) apply exactly as today.
+  - **Implementation note**: the helper must call `is_user_authorized_for_action` with the **same `action` and `target_user_id`** each button currently uses, so the existing access-control options keep working. Do not change the action constants or add new capability checks.
+- **Steps / detailed work items**
+  1. **Shared auth-helper method** (recommended over 7 nearly-identical inline guards):
+     - Add a module-level (or class-level in `button.py`) helper, e.g. `_ensure_admin_authorized(hass, context, assignee_id, action, error_action) -> str`, that:
+       - Reads `is_admin_button_auth_enforced(hass)` — if False, returns the current user's name (legacy behavior, no-op).
+       - If True: checks `user_id` from `context` — if `None`, raises `HomeAssistantError` with appropriate translation key.
+       - Calls `is_user_authorized_for_action(hass, user_id, action, target_user_id=assignee_id)` — if False, raises.
+       - On success, resolves the user name via `hass.auth.async_get_user(user_id).name` and returns it (so the caller can use it for the audit trail instead of a separate lookup).
+       - This eliminates the `user_obj = await self.hass.auth.async_get_user(user_id) if user_id else None; approver_name = (user_obj.name if user_obj else None) or const.DISPLAY_UNKNOWN` pattern from each button, consolidating 3 duplicated lines × 7 buttons = 21 lines into one helper.
+     - **Type signature**: `_ensure_admin_authorized(hass: HomeAssistant, context: Context | None, assignee_id: str | None, action: AuthorizationAction, error_action: str) -> str` returning the approver display name.
+     - Note: `ApproverBonusApplyButton`, `ApproverPenaltyApplyButton`, `ApproverPointsAdjustButton` use `AUTH_ACTION_MANAGEMENT` (no `target_user_id`). The helper must accept `target_user_id: str | None = None` for this case.
+  2. **Import** `is_admin_button_auth_enforced` in `button.py` (near the existing `is_kiosk_mode_enabled` import at ~line 33). Add import for `_ensure_admin_authorized` (or define it).
+  3. **Update 7 admin button classes** to use the shared helper:
+     - `ApproverChoreApproveButton` (line ~765): replace `user_id = ...; if user_id and not await ...; user_obj = ...; approver_name = ...` with `approver_name = await _ensure_admin_authorized(self.hass, self._context, self._assignee_id, AUTH_ACTION_APPROVAL, const.ERROR_ACTION_APPROVE_CHORES)`.
+     - `ApproverRewardApproveButton` (line ~1221): same pattern with `AUTH_ACTION_APPROVAL`, `const.ERROR_ACTION_APPROVE_REWARDS`.
+     - `ApproverRewardDisapproveButton` (line ~1394): same.
+     - `ApproverBonusApplyButton` (line ~1544): `AUTH_ACTION_MANAGEMENT`, `target_user_id=None`.
+     - `ApproverPenaltyApplyButton` (line ~1696): same.
+     - `ApproverPointsAdjustButton` (line ~1875): same.
+  4. **`ApproverChoreDisapproveButton` (line ~939)**: the helper is called ONLY in the approver-disapproval branch (`else:`, line ~937). **Preserve** the assignee-undo / kiosk anonymous-undo path (`if is_assignee or is_kiosk_anonymous_undo or is_kiosk_authenticated_undo:`) exactly as-is — this path does NOT call the helper.
+  5. **Do NOT touch** user-action buttons (`AssigneeChoreClaimButton` line ~627, `AssigneeRewardRedeemButton` line ~1082) — they remain kiosk-controlled.
+  6. **Keep the `try/except HomeAssistantError` wrapper** in each button's `async_press` — the helper raises `HomeAssistantError` which the existing outer catch handles.
+  7. **Quality gates**:
+     - Helper must be fully type-annotated; modern `str | None` syntax, **no `# type: ignore`**.
+     - No hardcoded strings — use `const.TRANS_KEY_ERROR_NOT_AUTHORIZED_ACTION_GLOBAL` and `const.ERROR_ACTION_*`.
+     - No f-strings in logs.
+     - Run `./utils/quick_lint.sh --fix`, `mypy custom_components/choreops/` after changes.
+  8. **Key issues**
+     - The helper eliminates the `user_obj`/`approver_name` derivation from each button, making the `approver_name` in the audit trail always come from the authenticated user (closing the spoofing gap as a side benefit). This is a behavioral change for the `approver_name` in the ledger — previously it fell back to `const.DISPLAY_UNKNOWN` when `user_id` was None; now anonymous presses are denied entirely, so the fallback is unreachable for admin buttons.
+     - Do NOT widen kiosk mode to admin actions. Kiosk only gates claim/undo user actions.
+     - Ensure the disapprove button's undo branch stays functional for kiosk anonymous undo.
+
+### Phase 3 – Testing
+
+- **Goal**: Prove anonymous admin presses are denied (fail-closed), toggle flips behavior, and user buttons/kiosk are unaffected.
+- **Steps / detailed work items**
+  1. **Extend `tests/test_kiosk_mode_buttons.py`** (or add `tests/test_admin_button_auth.py`) using existing fixtures (`scenario_minimal`, `scenario_full`) and helpers (`claim_chore`, `get_chore_buttons`, `get_reward_buttons`, `get_points_adjustment_buttons`, `find_bonus`, `find_penalty`).
+  2. Parameterized tests covering all 7 admin buttons, asserting `HomeAssistantError` when `Context(user_id=None)` is used and the toggle is enforced (default):
+     - Chore approve (requires a claim first, per existing pattern at line ~124).
+     - Chore disapprove (requires a claim first; use the approver branch, not undo).
+     - Reward approve (set points, claim first — see `test_kiosk_disabled_blocks_unauthorized_reward_approve_button`).
+     - Reward disapprove.
+     - Bonus, penalty, points-adjust (no preconditions needed — see existing tests ~lines 369–400).
+  3. **Toggle behavior tests**:
+     - With `is_admin_button_auth_enforced` patched to `False` (fail-open), anonymous press on an admin button is ALLOWED (regression guard for opt 2).
+     - With `True` (default), anonymous press is DENIED.
+  4. **Kiosk regression tests** (must still pass):
+     - `test_kiosk_enabled_allows_unauthorized_chore_claim_button` (user button).
+     - `test_kiosk_enabled_skips_reward_assignee_auth_guard` (user button).
+     - Kiosk enabled + anonymous press on an ADMIN button → still denied (kiosk must not bypass admin auth).
+     - Kiosk enabled + anonymous undo (disapprove button) → still allowed (preserve undo branch).
+  5. **Options-flow toggle test**: extend `test_options_flow_saves_kiosk_mode_toggle` (or add) to persist `CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH` and assert it survives reopen (default `True`; set `False` and assert persisted).
+  6. **Shared-helper unit test**: directly test `_ensure_admin_authorized` in isolation (no entity setup):
+     - toggle False + any context → returns approver name (no raise).
+     - toggle True + `user_id=None` → raises `HomeAssistantError`.
+     - toggle True + unauthorized user → raises.
+     - toggle True + authorized user → returns the user's name.
+     - Uses `pytest.mark.parametrize` to merge cases; mock `is_admin_button_auth_enforced` and `is_user_authorized_for_action` with `AsyncMock`.
+  7. **Access-control-option integration tests** (verify the gate honors existing options — these should already pass via `is_user_authorized_for_action`, but add explicit coverage):
+     - **`admin_approval_bypass`**: with `CONF_ADMIN_APPROVAL_BYPASS=False`, an HA admin pressing an APPROVAL button is denied (unless linked approver); with `True`, allowed. Confirm the new gate does not override this.
+     - **`can_approve` / `associated_user_ids`**: a non-admin approver with `can_approve=True` but target NOT in `associated_user_ids` is denied on APPROVAL buttons; with the target linked, allowed.
+     - **`can_manage`**: a user with `can_manage=False` is denied on MANAGEMENT buttons (bonus/penalty/points-adjust); with `can_manage=True`, allowed.
+     - **Kiosk independence**: kiosk enabled does NOT allow anonymous admin presses (already covered in Phase 3 step 4).
+     - These tests confirm the new toggle is purely the outermost gate and does not regress the existing access-control matrix.
+  8. **Validation commands**:
+     ```bash
+     ./utils/quick_lint.sh --fix
+     mypy custom_components/choreops/
+     python -m pytest tests/test_kiosk_mode_buttons.py tests/test_admin_button_auth.py -v --tb=line
+     python -m pytest tests/ -v --tb=line
+     ```
+  9. **Key issues**
+     - All new test params need type annotations (per AGENTS.md).
+     - Prefer `@pytest.mark.usefixtures` and `pytest.mark.parametrize` to avoid branching.
+     - Mock `custom_components.choreops.button.is_admin_button_auth_enforced` (like the existing `is_kiosk_mode_enabled` patch at line ~234) and `is_user_authorized_for_action` with `AsyncMock`.
+     - Verify the options-flow persistence test does NOT add the toggle to `DEFAULT_SYSTEM_SETTINGS`-driven assertions (it must not appear in backup/restore or reconfigure tests).
+
+### Phase 4 – Documentation, Wiki & Release
+
+- **Goal**: Communicate the breaking change, migrate documented automation guidance, and finalize release assets.
+- **Steps / detailed work items**
+  1. **Wiki** (`/workspaces/choreops-wiki/`):
+     - Rewrite `Tips-&-Tricks:-Configure-Automatic-Approval-of-Chores.md` to call `choreops.approve_chore` service instead of `button.press` on approve buttons. Add a callout: button press from automations is now denied by default; use the equivalent service.
+     - Add a note to `Services:-Reference.md` that services are the recommended path for automation/admin actions.
+     - Review `Tips-&-Tricks:-Use-NFC-Tag-to-Mark-Chore-Claimed.md` (claim button = user action, unaffected) and confirm no admin-button-press guidance needs changing. Review cookbook for any other admin `button.press` references.
+     - Optionally document the new `admin_button_auth` option in `Configuration:-General-Options.md`.
+  2. **Release notes / breaking change**:
+     - PR body: mark "Breaking change" in `.github/PULL_REQUEST_TEMPLATE.md` section; add release-note summary.
+     - Ensure PR title is release-note friendly and the `enh: breaking-change` label is applied (per `.github/release.yml`).
+     - State clearly: users with automations pressing admin buttons must (a) set the toggle to fail-open during migration, and (b) migrate to the equivalent service.
+  3. **README / docs** (optional): add a short "Access Control" note pointing to the new toggle and its risk warning.
+  4. **Key issues**
+     - Sync wiki via the "📖 Sync ChoreOps Wiki" task before/after edits.
+     - Regenerate `translations/en.json` from `strings.json` before tests (Phase 1 step 5).
+     - Confirm the breaking-change label/categorization with the release process.
+
+## Testing & validation
+
+- Tests executed: (pending — Phase 3)
+- Outstanding tests: admin-button anonymous-denial matrix; toggle flips; kiosk regression; options-flow persistence; shared-helper unit test.
+- Commands:
+  - `./utils/quick_lint.sh --fix`
+  - `mypy custom_components/choreops/`
+  - `python -m pytest tests/ -v --tb=line`
+
+## Notes & follow-up
+
+- Follow-up: after merge, monitor Issue #247 for confirmation; add wiki/cookbook migration examples; consider a future doc page on "ChoreOps access control & service vs button".
+- **Data schema impact — RESOLVED precisely (two separate versioning systems):**
+  - **Storage data schema** (`SCHEMA_VERSION_CURRENT`, const.py ~355): versions the `.storage/choreops/choreops_data` file via `store.py`, `migrations/`, and `coordinator.ensure_data_integrity`. Adding `CONF_ADMIN_BUTTON_AUTH` to `config_entry.options` does **NOT** touch this file, so **no storage-data schema bump** and **no `migrations/`/`integrity/` change**.
+  - **Config entry schema** (`config_flow.py VERSION = 1`, `MINOR_VERSION`): HA core's own versioning for the config entry, which **stores the entire options dict as-is** (no per-field options schema file exists — there is no `OPTIONS_SCHEMA`/`async_migrate_entry`). New known fields are read defensively via `.get(CONF_X, DEFAULT_X)`, so a new field requires **no config-entry version bump and no migration**.
+  - **Terminology corrected**: adding the toggle is a **known-field addition** to the config entry options, *not* a schema migration. The config entry options contract is versioned by HA's `VERSION`/`MINOR_VERSION` machinery — separate from `SCHEMA_VERSION_CURRENT`. Because the toggle is a **Category B** flag (not in `DEFAULT_SYSTEM_SETTINGS`), it is also excluded from the backup/restore round-trip; on restore the `.get(..., DEFAULT_ADMIN_BUTTON_AUTH=True)` read returns the secure fail-closed default. For rigor, the PR should note the config-entry options surface changed (new known key), even though no migration is required.
+- **Why Category B (not Category A):** Kiosk/admin_approval_bypass are deliberately excluded from `DEFAULT_SYSTEM_SETTINGS` and `build_all_system_settings_data/schema`. Adding `admin_button_auth` to Category A would wrongly pull it into `backup_helpers.augment_backup_with_settings()` and the config-flow reconfigure path — a restore would then overwrite the flag, and the reconfigure form would expose it under a schema that currently only holds the 9 data settings. Follow the kiosk pattern to keep these runtime gates separate from data settings.

--- a/tests/test_admin_button_auth.py
+++ b/tests/test_admin_button_auth.py
@@ -1,0 +1,621 @@
+"""Tests for admin button authorization fail-closed behavior (Issue #247).
+
+Covers:
+- Anonymous (user_id=None) presses on admin buttons are denied when auth is enforced
+- The admin_button_auth toggle flips between fail-closed (default) and fail-open
+- Authorized admin/approver presses still succeed
+- Kiosk mode does NOT bypass admin button auth
+- Options-flow persistence of the admin_button_auth toggle
+- Shared _ensure_admin_authorized helper unit tests
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+
+from custom_components.choreops import const
+from custom_components.choreops.button import _ensure_admin_authorized
+from custom_components.choreops.helpers.auth_helpers import (
+    AUTH_ACTION_APPROVAL,
+    AUTH_ACTION_MANAGEMENT,
+    is_admin_button_auth_enforced,
+)
+from custom_components.choreops.helpers.entity_helpers import (
+    get_points_adjustment_buttons,
+)
+from tests.helpers import (
+    CHORE_STATE_CLAIMED,
+    OPTIONS_FLOW_GENERAL_OPTIONS,
+    OPTIONS_FLOW_INPUT_MENU_SELECTION,
+    SetupResult,
+    claim_chore,
+    find_bonus,
+    find_chore,
+    find_penalty,
+    get_chore_buttons,
+    get_dashboard_helper,
+    setup_from_yaml,
+)
+from tests.helpers.workflows import find_reward, get_reward_buttons
+
+
+async def _press_button(
+    hass: HomeAssistant,
+    button_eid: str,
+    context: Context,
+) -> None:
+    """Press a button entity with explicit error propagation."""
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {"entity_id": button_eid},
+        blocking=True,
+        context=context,
+    )
+
+
+def _get_schema_default_value(data_schema: Any, field_key: str) -> Any:
+    """Return the default value for a voluptuous schema field."""
+    for schema_key in data_schema.schema:
+        normalized_key = getattr(schema_key, "schema", schema_key)
+        if normalized_key != field_key:
+            continue
+
+        default = getattr(schema_key, "default", None)
+        if callable(default):
+            return default()
+        return default
+
+    return None
+
+
+@pytest.fixture
+async def scenario_minimal(
+    hass: HomeAssistant,
+    mock_hass_users: dict[str, Any],
+) -> SetupResult:
+    """Load minimal scenario for chore claim button tests."""
+    return await setup_from_yaml(
+        hass,
+        mock_hass_users,
+        "tests/scenarios/scenario_minimal.yaml",
+    )
+
+
+@pytest.fixture
+async def scenario_full(
+    hass: HomeAssistant,
+    mock_hass_users: dict[str, Any],
+) -> SetupResult:
+    """Load full scenario for reward/bonus/penalty/points button coverage."""
+    return await setup_from_yaml(
+        hass,
+        mock_hass_users,
+        "tests/scenarios/scenario_full.yaml",
+    )
+
+
+# =============================================================================
+# Shared helper unit tests
+# =============================================================================
+
+
+async def test_ensure_admin_authorized_denies_anonymous_when_enforced(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+) -> None:
+    """Anonymous press is denied when admin button auth is enforced."""
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _ensure_admin_authorized(
+                hass,
+                None,
+                scenario_minimal.assignee_ids["Zoë"],
+                AUTH_ACTION_APPROVAL,
+                const.ERROR_ACTION_APPROVE_CHORES,
+            )
+
+
+async def test_ensure_admin_authorized_denies_unauthorized_when_enforced(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Unauthorized user is denied when admin button auth is enforced."""
+    unauthorized_context = Context(user_id=mock_hass_users["assignee2"].id)
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.choreops.button.is_user_authorized_for_action",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _ensure_admin_authorized(
+                hass,
+                unauthorized_context,
+                scenario_minimal.assignee_ids["Zoë"],
+                AUTH_ACTION_APPROVAL,
+                const.ERROR_ACTION_APPROVE_CHORES,
+            )
+
+
+async def test_ensure_admin_authorized_returns_name_when_authorized(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Authorized user returns their display name when auth is enforced."""
+    admin_context = Context(user_id=mock_hass_users["admin"].id)
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.choreops.button.is_user_authorized_for_action",
+            new=AsyncMock(return_value=True),
+        ),
+    ):
+        approver_name = await _ensure_admin_authorized(
+            hass,
+            admin_context,
+            scenario_minimal.assignee_ids["Zoë"],
+            AUTH_ACTION_APPROVAL,
+            const.ERROR_ACTION_APPROVE_CHORES,
+        )
+
+    assert approver_name == "Admin User"
+
+
+async def test_ensure_admin_authorized_allows_anonymous_when_not_enforced(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+) -> None:
+    """Anonymous press is allowed (legacy) when admin button auth is not enforced."""
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.choreops.button.is_user_authorized_for_action",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        approver_name = await _ensure_admin_authorized(
+            hass,
+            None,
+            scenario_minimal.assignee_ids["Zoë"],
+            AUTH_ACTION_APPROVAL,
+            const.ERROR_ACTION_APPROVE_CHORES,
+        )
+
+    assert approver_name == const.DISPLAY_UNKNOWN
+
+
+async def test_ensure_admin_authorized_management_action(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Management action (no target) is enforced for anonymous presses."""
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _ensure_admin_authorized(
+                hass,
+                None,
+                None,
+                AUTH_ACTION_MANAGEMENT,
+                const.ERROR_ACTION_APPLY_BONUSES,
+            )
+
+
+# =============================================================================
+# Anonymous press denial on admin buttons (fail-closed default)
+# =============================================================================
+
+
+async def test_anonymous_denied_chore_approve_button(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Anonymous chore approve press is denied when auth is enforced."""
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    claim_result = await claim_chore(hass, "zoe", "Make bed", context=assignee_context)
+    assert claim_result.success is True
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    chore = find_chore(dashboard, "Make bed")
+    assert chore is not None
+
+    buttons = get_chore_buttons(hass, chore["eid"])
+    approve_button_eid = buttons["approve"]
+    assert approve_button_eid
+
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, approve_button_eid, Context(user_id=None))
+
+    chore_state = hass.states.get(chore["eid"])
+    assert chore_state is not None
+    assert chore_state.state == CHORE_STATE_CLAIMED
+
+
+async def test_anonymous_denied_chore_disapprove_button(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Anonymous chore disapprove press (approver branch) is denied when enforced."""
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    claim_result = await claim_chore(hass, "zoe", "Make bed", context=assignee_context)
+    assert claim_result.success is True
+
+    dashboard = get_dashboard_helper(hass, "zoe")
+    chore = find_chore(dashboard, "Make bed")
+    assert chore is not None
+
+    buttons = get_chore_buttons(hass, chore["eid"])
+    disapprove_button_eid = buttons["disapprove"]
+    assert disapprove_button_eid
+
+    # Kiosk disabled so anonymous does NOT take the undo branch; must hit approver branch
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.choreops.button.is_kiosk_mode_enabled",
+            return_value=False,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, disapprove_button_eid, Context(user_id=None))
+
+    chore_state = hass.states.get(chore["eid"])
+    assert chore_state is not None
+    assert chore_state.state == CHORE_STATE_CLAIMED
+
+
+async def test_anonymous_denied_reward_approve_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Anonymous reward approve press is denied when auth is enforced."""
+    coordinator = scenario_full.coordinator
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    coordinator.users_data[assignee_id][const.DATA_USER_POINTS] = 100.0
+    await coordinator.async_refresh()
+
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    dashboard = get_dashboard_helper(hass, "zoe")
+    reward = find_reward(dashboard, "Extra Screen Time")
+    assert reward is not None
+
+    claim_button_eid = get_reward_buttons(hass, reward["eid"])["claim"]
+    assert claim_button_eid
+
+    with patch.object(
+        coordinator.notification_manager, "notify_assignee", new=AsyncMock()
+    ):
+        await _press_button(hass, claim_button_eid, assignee_context)
+
+    buttons = get_reward_buttons(hass, reward["eid"])
+    approve_button_eid = buttons["approve"]
+    assert approve_button_eid
+
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, approve_button_eid, Context(user_id=None))
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+    assert reward_state.state == const.REWARD_STATE_REQUESTED
+
+
+async def test_anonymous_denied_reward_disapprove_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Anonymous reward disapprove press (approver branch) is denied when enforced."""
+    coordinator = scenario_full.coordinator
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    coordinator.users_data[assignee_id][const.DATA_USER_POINTS] = 100.0
+    await coordinator.async_refresh()
+
+    assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
+    dashboard = get_dashboard_helper(hass, "zoe")
+    reward = find_reward(dashboard, "Extra Screen Time")
+    assert reward is not None
+
+    claim_button_eid = get_reward_buttons(hass, reward["eid"])["claim"]
+    assert claim_button_eid
+
+    with patch.object(
+        coordinator.notification_manager, "notify_assignee", new=AsyncMock()
+    ):
+        await _press_button(hass, claim_button_eid, assignee_context)
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+    disapprove_button_eid = reward_state.attributes.get(
+        const.ATTR_REWARD_DISAPPROVE_BUTTON_ENTITY_ID
+    )
+    assert disapprove_button_eid
+
+    # Kiosk disabled so anonymous does NOT take the undo branch; must hit approver branch
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.choreops.button.is_kiosk_mode_enabled",
+            return_value=False,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, disapprove_button_eid, Context(user_id=None))
+
+    reward_state = hass.states.get(reward["eid"])
+    assert reward_state is not None
+    assert reward_state.state == const.REWARD_STATE_REQUESTED
+
+
+async def test_anonymous_denied_bonus_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """Anonymous bonus press is denied when auth is enforced."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    bonus = find_bonus(dashboard, "Extra Effort")
+    assert bonus is not None
+
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, bonus["eid"], Context(user_id=None))
+
+
+async def test_anonymous_denied_penalty_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """Anonymous penalty press is denied when auth is enforced."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    penalty = find_penalty(dashboard, "Missed Chore")
+    assert penalty is not None
+
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, penalty["eid"], Context(user_id=None))
+
+
+async def test_anonymous_denied_points_adjust_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """Anonymous points-adjust press is denied when auth is enforced."""
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    buttons = get_points_adjustment_buttons(
+        hass,
+        scenario_full.config_entry.entry_id,
+        assignee_id,
+    )
+    assert buttons
+
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, str(buttons[0]["eid"]), Context(user_id=None))
+
+
+# =============================================================================
+# Toggle-off (fail-open) allows anonymous presses
+# =============================================================================
+
+
+async def test_toggle_off_allows_anonymous_bonus_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """Anonymous bonus press is allowed when admin button auth is not enforced."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    bonus = find_bonus(dashboard, "Extra Effort")
+    assert bonus is not None
+
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.choreops.button.is_user_authorized_for_action",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        # Should NOT raise when toggle is off (legacy fail-open)
+        await _press_button(hass, bonus["eid"], Context(user_id=None))
+
+
+async def test_toggle_off_allows_anonymous_points_adjust_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """Anonymous points-adjust press is allowed when auth is not enforced."""
+    assignee_id = scenario_full.assignee_ids["Zoë"]
+    buttons = get_points_adjustment_buttons(
+        hass,
+        scenario_full.config_entry.entry_id,
+        assignee_id,
+    )
+    assert buttons
+
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=False,
+        ),
+        patch(
+            "custom_components.choreops.button.is_user_authorized_for_action",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        await _press_button(hass, str(buttons[0]["eid"]), Context(user_id=None))
+
+
+# =============================================================================
+# Authorized admin presses succeed
+# =============================================================================
+
+
+async def test_authorized_admin_allowed_bonus_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Authorized admin bonus press succeeds when auth is enforced."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    bonus = find_bonus(dashboard, "Extra Effort")
+    assert bonus is not None
+
+    admin_context = Context(user_id=mock_hass_users["admin"].id)
+    with patch(
+        "custom_components.choreops.button.is_admin_button_auth_enforced",
+        return_value=True,
+    ):
+        await _press_button(hass, bonus["eid"], admin_context)
+
+
+# =============================================================================
+# Kiosk mode does NOT bypass admin button auth
+# =============================================================================
+
+
+async def test_kiosk_enabled_still_denies_anonymous_admin_button(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """Kiosk mode must NOT allow anonymous admin button presses."""
+    dashboard = get_dashboard_helper(hass, "zoe")
+    bonus = find_bonus(dashboard, "Extra Effort")
+    assert bonus is not None
+
+    with (
+        patch(
+            "custom_components.choreops.button.is_admin_button_auth_enforced",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.choreops.button.is_kiosk_mode_enabled",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(HomeAssistantError):
+            await _press_button(hass, bonus["eid"], Context(user_id=None))
+
+
+# =============================================================================
+# Options-flow toggle persistence
+# =============================================================================
+
+
+async def test_options_flow_saves_admin_button_auth_toggle(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+) -> None:
+    """General options flow should persist the admin_button_auth toggle."""
+    config_entry = scenario_minimal.config_entry
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={OPTIONS_FLOW_INPUT_MENU_SELECTION: OPTIONS_FLOW_GENERAL_OPTIONS},
+    )
+
+    assert result.get("step_id") == const.OPTIONS_FLOW_STEP_MANAGE_GENERAL_OPTIONS
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            const.CFOF_SYSTEM_INPUT_POINTS_ADJUST_VALUES: "1|-1|2|-2|10|-10",
+            const.CFOF_SYSTEM_INPUT_DASHBOARD_POINTS_PRECISION: (
+                const.DASHBOARD_POINTS_PRECISION_FIXED_2
+            ),
+            const.CFOF_SYSTEM_INPUT_UPDATE_INTERVAL: 5,
+            const.CFOF_SYSTEM_INPUT_CALENDAR_SHOW_PERIOD: 90,
+            const.CFOF_SYSTEM_INPUT_RETENTION_PERIODS: "14|5|3|3",
+            const.CFOF_SYSTEM_INPUT_SHOW_LEGACY_ENTITIES: False,
+            const.CFOF_SYSTEM_INPUT_KIOSK_MODE: True,
+            const.CFOF_SYSTEM_INPUT_ADMIN_APPROVAL_BYPASS: False,
+            const.CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH: False,
+            const.CFOF_SYSTEM_INPUT_BACKUPS_MAX_RETAINED: 5,
+        },
+    )
+
+    assert result.get("step_id") == const.OPTIONS_FLOW_STEP_INIT
+
+    updated_entry = hass.config_entries.async_get_entry(config_entry.entry_id)
+    assert updated_entry is not None
+    assert updated_entry.options.get(const.CONF_ADMIN_BUTTON_AUTH) is False
+
+    reopened_result = await hass.config_entries.options.async_init(
+        config_entry.entry_id
+    )
+    reopened_result = await hass.config_entries.options.async_configure(
+        reopened_result["flow_id"],
+        user_input={OPTIONS_FLOW_INPUT_MENU_SELECTION: OPTIONS_FLOW_GENERAL_OPTIONS},
+    )
+
+    assert (
+        reopened_result.get("step_id") == const.OPTIONS_FLOW_STEP_MANAGE_GENERAL_OPTIONS
+    )
+    assert reopened_result.get("data_schema") is not None
+    assert (
+        _get_schema_default_value(
+            reopened_result["data_schema"],
+            const.CFOF_SYSTEM_INPUT_ADMIN_BUTTON_AUTH,
+        )
+        is False
+    )
+
+
+async def test_admin_button_auth_defaults_to_enforced(
+    hass: HomeAssistant,
+    scenario_minimal: SetupResult,
+) -> None:
+    """admin_button_auth should default to enforced (fail-closed) when not set."""
+    assert is_admin_button_auth_enforced(hass) is True

--- a/tests/test_get_ledger_service.py
+++ b/tests/test_get_ledger_service.py
@@ -1,0 +1,207 @@
+"""Tests for the get_ledger service (structured ledger dump)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from custom_components.choreops import const
+from tests.helpers import SetupResult, setup_from_yaml
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+async def scenario_full(
+    hass: HomeAssistant,
+    mock_hass_users: dict[str, Any],
+) -> SetupResult:
+    """Load full scenario: 3 assignees, 2 approvers, 8 chores, 3 rewards."""
+    return await setup_from_yaml(
+        hass,
+        mock_hass_users,
+        "tests/scenarios/scenario_full.yaml",
+    )
+
+
+async def _call_get_ledger(
+    hass: HomeAssistant,
+    *,
+    user_name: str | None = None,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Invoke the get_ledger service and return its response."""
+    data: dict[str, Any] = {}
+    if user_name is not None:
+        data[const.SERVICE_FIELD_USER_NAME] = user_name
+    if limit is not None:
+        data[const.SERVICE_FIELD_LEDGER_LIMIT] = limit
+
+    response = await hass.services.async_call(
+        const.DOMAIN,
+        const.SERVICE_GET_LEDGER,
+        data,
+        blocking=True,
+        return_response=True,
+    )
+    assert isinstance(response, dict)
+    return response
+
+
+async def test_get_ledger_returns_all_users_by_default(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """get_ledger returns entries for all users when no user_name is given."""
+    coordinator = scenario_full.coordinator
+    zoe_id = scenario_full.assignee_ids["Zoë"]
+    max_id = scenario_full.assignee_ids["Max!"]
+
+    await coordinator.economy_manager.deposit(
+        assignee_id=zoe_id,
+        amount=10.0,
+        source=const.POINTS_SOURCE_MANUAL,
+        item_name="For being a very good kid",
+    )
+    await coordinator.economy_manager.deposit(
+        assignee_id=max_id,
+        amount=5.0,
+        source=const.POINTS_SOURCE_BONUSES,
+        item_name="Extra effort",
+    )
+
+    response = await _call_get_ledger(hass)
+
+    assert response["assignee_id"] is None
+    assert response["assignee_name"] is None
+    assert response["count"] >= 2
+    assert response["truncated"] is False
+
+    # Multi-user entries carry assignee identity
+    sources = {entry[const.DATA_LEDGER_SOURCE] for entry in response["entries"]}
+    assert const.POINTS_SOURCE_MANUAL in sources
+    assert const.POINTS_SOURCE_BONUSES in sources
+
+    # Every multi-user entry has assignee fields
+    for entry in response["entries"]:
+        assert const.DATA_USER_INTERNAL_ID in entry
+        assert const.DATA_USER_NAME in entry
+
+
+async def test_get_ledger_filters_to_single_user(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """get_ledger with user_name returns only that user's entries."""
+    coordinator = scenario_full.coordinator
+    zoe_id = scenario_full.assignee_ids["Zoë"]
+    max_id = scenario_full.assignee_ids["Max!"]
+
+    await coordinator.economy_manager.deposit(
+        assignee_id=zoe_id,
+        amount=10.0,
+        source=const.POINTS_SOURCE_MANUAL,
+        item_name="For being a very good kid",
+    )
+    await coordinator.economy_manager.deposit(
+        assignee_id=max_id,
+        amount=5.0,
+        source=const.POINTS_SOURCE_BONUSES,
+        item_name="Extra effort",
+    )
+
+    response = await _call_get_ledger(hass, user_name="Zoë")
+
+    assert response["assignee_id"] == zoe_id
+    assert response["assignee_name"] == "Zoë"
+    assert response["count"] >= 1
+
+    # Single-user entries do NOT carry per-entry assignee fields
+    for entry in response["entries"]:
+        assert const.DATA_USER_INTERNAL_ID not in entry
+        assert const.DATA_USER_NAME not in entry
+        assert entry[const.DATA_LEDGER_SOURCE] == const.POINTS_SOURCE_MANUAL
+
+
+async def test_get_ledger_includes_source_label(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """get_ledger includes a human-readable source_label."""
+    coordinator = scenario_full.coordinator
+    zoe_id = scenario_full.assignee_ids["Zoë"]
+
+    await coordinator.economy_manager.deposit(
+        assignee_id=zoe_id,
+        amount=10.0,
+        source=const.POINTS_SOURCE_MANUAL,
+        item_name="For being a very good kid",
+    )
+
+    response = await _call_get_ledger(hass, user_name="Zoë")
+
+    assert response["count"] >= 1
+    manual_entries = [
+        entry
+        for entry in response["entries"]
+        if entry[const.DATA_LEDGER_SOURCE] == const.POINTS_SOURCE_MANUAL
+    ]
+    assert manual_entries
+    assert manual_entries[0]["source_label"] == "Adjustment"
+
+
+async def test_get_ledger_limit_returns_most_recent(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """get_ledger with a limit returns the most recent entries and flags truncation."""
+    coordinator = scenario_full.coordinator
+    zoe_id = scenario_full.assignee_ids["Zoë"]
+
+    for i in range(5):
+        await coordinator.economy_manager.deposit(
+            assignee_id=zoe_id,
+            amount=float(i + 1),
+            source=const.POINTS_SOURCE_MANUAL,
+            item_name=f"Adjustment {i + 1}",
+        )
+
+    response = await _call_get_ledger(hass, user_name="Zoë", limit=2)
+
+    assert response["count"] == 2
+    assert response["limit"] == 2
+    assert response["truncated"] is True
+
+    # Most recent two entries are the last two deposits
+    item_names = [entry[const.DATA_LEDGER_ITEM_NAME] for entry in response["entries"]]
+    assert item_names == ["Adjustment 4", "Adjustment 5"]
+
+
+async def test_get_ledger_summary_totals(
+    hass: HomeAssistant,
+    scenario_full: SetupResult,
+) -> None:
+    """get_ledger summary reflects earned/spent/net across returned entries."""
+    coordinator = scenario_full.coordinator
+    zoe_id = scenario_full.assignee_ids["Zoë"]
+
+    await coordinator.economy_manager.deposit(
+        assignee_id=zoe_id,
+        amount=10.0,
+        source=const.POINTS_SOURCE_MANUAL,
+        item_name="Deposit",
+    )
+    await coordinator.economy_manager.withdraw(
+        assignee_id=zoe_id,
+        amount=4.0,
+        source=const.POINTS_SOURCE_PENALTIES,
+        item_name="Penalty",
+    )
+
+    response = await _call_get_ledger(hass, user_name="Zoë")
+
+    assert response["summary"]["total_earned"] == 10.0
+    assert response["summary"]["total_spent"] == 4.0
+    assert response["summary"]["net"] == 6.0


### PR DESCRIPTION
## Summary

This PR closes the security gap where admin buttons (approve/disapprove chore & reward, bonus, penalty, and points adjust) allowed **anonymous** presses. The permission settings were only enforced visually in the dashboards — a caller could press an admin button without a logged-in account (e.g. via a widget, control screen, script, or automation) and award themselves points. This is a **fix/enhancement** with a **breaking-change** component.

It also adds a new **`choreops.get_ledger`** service for auditing point transactions.

### 1. Fail-closed admin button auth (breaking change / security fix)

Admin buttons now require a **logged-in account** by default:

- Added `CONF_ADMIN_BUTTON_AUTH` toggle (**"Enforce Authorization for Admin Buttons"**, General Options, default **on**).
- Added shared `_ensure_admin_authorized()` helper and applied fail-closed logic to all 7 admin button classes in `button.py`.
- Preserved kiosk anonymous-undo behavior on the disapprove buttons (user actions only).
- Anonymous presses (`user_id=None`) from widgets, control screens, scripts, or automations are now **denied**.

**Why it was originally allowed:** before dedicated services existed, calling admin buttons directly was the common approach for scripts and automations. The new toggle lets users revert to the legacy fail-open behavior, but doing so re-exposes the risk — hence the strict default.

**Migration for automations/scripts:** migrate from pressing admin buttons to the equivalent service (`choreops.approve_chore`, `choreops.apply_bonus`, `choreops.apply_penalty`, `choreops.manual_adjust_points`), which are the intended path.

### 2. New `choreops.get_ledger` service (enhancement)

A response-first service that returns a structured dump of point ledger entries, optionally filtered to a single user and capped by a most-recent `limit`. Includes per-entry source labels and summary totals — useful for auditing manual adjustments.

## Linked issue

- Closes #247

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [x] Correct release-note label is applied for `.github/release.yml` categorization
- [x] Excluded triage or status labels have been removed before merge
- [x] PR title is suitable for generated release notes

## Change type

- [x] Bug fix
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Integration logic/state
- [ ] Dashboard/template behavior
- [x] Services/automations
- [x] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] `python -m pytest tests/ -v --tb=line` (targeted suites: `test_admin_button_auth.py`, `test_get_ledger_service.py`, `test_kiosk_mode_buttons.py`, `test_kc_helpers.py`, plus workflow/service/flow regression suites)

## Documentation impact

- [ ] No documentation updates needed
- [x] Documentation updated (README / wiki / inline docs)

## Release notes

- [ ] No release notes needed
- [x] Release notes needed (summarize user-visible changes below)

- Release note summary: Admin buttons now require a logged-in account by default; automations that pressed admin buttons should use the equivalent service. Added `choreops.get_ledger` for point ledger auditing.

## Breaking changes

- [ ] No breaking changes
- [x] Breaking change (describe migration or compatibility impact below)

Admin button presses from scripts/automations without a logged-in user are now denied by default. Migrate to the equivalent service (`choreops.approve_chore`, `choreops.apply_bonus`, `choreops.apply_penalty`, `choreops.manual_adjust_points`). A General Options toggle ("Enforce Authorization for Admin Buttons") can restore the legacy fail-open behavior.