### PR TITLE
fix(choreops): align global state with per-assignee lifecycle (Issue …

### DIFF
--- a/custom_components/choreops/engines/chore_engine.py
+++ b/custom_components/choreops/engines/chore_engine.py
@@ -74,6 +74,11 @@ class TransitionEffect:
         clear_completed_by: Whether to clear completed_by field
         set_claimed_by: Name to set as claimed_by (or None)
         set_completed_by: Name to set as completed_by (or None)
+        clear_exception_state: If True, transition this assignee to `pending` ONLY
+                     if their current persisted state is `overdue`/`missed`.
+                     Used to clear exception states of other assignees when a
+                     single-completer chore (shared_first / rotation) advances.
+                     Preserves `approved`/`claimed`/`pending` states.
     """
 
     assignee_id: str
@@ -84,6 +89,7 @@ class TransitionEffect:
     clear_completed_by: bool = False
     set_claimed_by: str | None = None
     set_completed_by: str | None = None
+    clear_exception_state: bool = False
 
 
 # =============================================================================
@@ -203,6 +209,16 @@ class ChoreEngine:
                 assigned_assignees,
                 assignee_name,
             )
+            # Lifecycle hygiene: when a single-completer chore (shared_first /
+            # rotation) is claimed, clear the OTHER assignees' exception states
+            # (overdue/missed) so they are not left in a stale exception.
+            if ChoreEngine.is_single_claimer_mode(chore_data):
+                effects.extend(
+                    ChoreEngine._plan_clear_other_exception_states(
+                        actor_assignee_id,
+                        assigned_assignees,
+                    )
+                )
 
         # === APPROVE ACTION ===
         elif action == CHORE_ACTION_APPROVE:
@@ -213,6 +229,15 @@ class ChoreEngine:
                 assignee_name,
                 points,
             )
+            # Lifecycle hygiene: when a single-completer chore is approved
+            # (completed), clear the OTHER assignees' exception states.
+            if ChoreEngine.is_single_claimer_mode(chore_data):
+                effects.extend(
+                    ChoreEngine._plan_clear_other_exception_states(
+                        actor_assignee_id,
+                        assigned_assignees,
+                    )
+                )
 
         # === DISAPPROVE ACTION ===
         elif action == CHORE_ACTION_DISAPPROVE:
@@ -253,6 +278,40 @@ class ChoreEngine:
             for effect in effects:
                 effect.update_stats = False
 
+        return effects
+
+    @staticmethod
+    def _plan_clear_other_exception_states(
+        actor_assignee_id: str,
+        assigned_assignees: list[str],
+    ) -> list[TransitionEffect]:
+        """Plan effects to clear exception states of OTHER assignees.
+
+        When a single-completer chore (shared_first / rotation) is claimed or
+        approved by the actor, the OTHER assigned assignees' exception states
+        (`overdue`/`missed`) are stale: they are relieved of the occurrence and
+        should not remain in a persisted exception state. Their UI is computed
+        (completed_by_other / not_my_turn / standby), so persisting `pending`
+        preserves their display while removing the stale exception.
+
+        Only clears `overdue`/`missed` (via `clear_exception_state`); preserves
+        `approved`/`claimed`/`pending`.
+
+        Excludes `shared_all` (others legitimately remain overdue — they must
+        each complete) and `independent` (no cross-user effect).
+        """
+        effects: list[TransitionEffect] = []
+        for other_id in assigned_assignees:
+            if not other_id or other_id == actor_assignee_id:
+                continue
+            effects.append(
+                TransitionEffect(
+                    assignee_id=other_id,
+                    new_state=const.CHORE_STATE_PENDING,
+                    update_stats=False,
+                    clear_exception_state=True,
+                )
+            )
         return effects
 
     @staticmethod
@@ -1304,6 +1363,12 @@ class ChoreEngine:
             if isinstance(turn_assignee_id, str)
             else None
         )
+        # Completion-aware: if any assignee (including a standby) completed the
+        # occurrence, the chore is done regardless of the turn-holder's state.
+        # A standby may complete a primary-standby chore after it goes overdue,
+        # leaving the turn-holder's persisted state stale (e.g. `overdue`).
+        if count_approved > 0:
+            return const.CHORE_STATE_APPROVED
         if turn_state is not None:
             if turn_state == const.CHORE_STATE_CLAIMED:
                 return const.CHORE_STATE_CLAIMED

--- a/custom_components/choreops/integrity/boot_repairs.py
+++ b/custom_components/choreops/integrity/boot_repairs.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.util import dt as dt_util
+
 from custom_components.choreops import const
 from custom_components.choreops.engines.chore_engine import ChoreEngine
+from custom_components.choreops.utils.dt_utils import dt_parse, dt_to_utc
 
 
 def run_boot_repairs(data: dict[str, Any]) -> dict[str, dict[str, int]]:
@@ -24,8 +27,27 @@ def run_boot_repairs(data: dict[str, Any]) -> dict[str, dict[str, int]]:
     }
 
 
+def _is_due_date_future(due_date_raw: Any) -> bool:
+    """Return True if a due date value exists and is strictly in the future."""
+    if not due_date_raw:
+        return False
+    due_dt = dt_to_utc(due_date_raw) or dt_parse(due_date_raw)
+    if due_dt is None:
+        return False
+    return due_dt > dt_util.utcnow()
+
+
 def repair_impossible_due_state_residue(data: dict[str, Any]) -> dict[str, int]:
-    """Clear impossible overdue residue when no active due date exists."""
+    """Clear impossible overdue residue when the due date is absent or in the future.
+
+    Invariant: a per-assignee state of `overdue`/`missed` is only legitimate when
+    the chore's due date is in the past. If the due date is absent or in the future,
+    those states are impossible residue (e.g. left over from a prior cycle after the
+    due date was rescheduled forward) and are normalized to `pending`.
+
+    Issue #248: the prior guard only normalized residue when there was NO active due
+    date, skipping chores WITH a future due date — exactly the reported bug scenario.
+    """
     summary = {
         "chores_sanitized": 0,
         "stale_due_dates_cleared": 0,
@@ -72,7 +94,22 @@ def repair_impossible_due_state_residue(data: dict[str, Any]) -> dict[str, int]:
                 due_date for due_date in per_assignee_due_dates.values() if due_date
             )
         )
-        if has_active_due_date:
+        # Resolve the applicable due date for past/future determination.
+        applicable_due_date_raw = (
+            due_date_raw
+            if uses_chore_level_due_date
+            else next(
+                (due_date for due_date in per_assignee_due_dates.values() if due_date),
+                None,
+            )
+        )
+        # Skip normalization only when a due date exists AND is in the PAST
+        # (where overdue/missed is legitimate). Absent or future due dates mean
+        # overdue/missed is impossible residue and must be normalized.
+        due_date_is_past = has_active_due_date and not _is_due_date_future(
+            applicable_due_date_raw
+        )
+        if due_date_is_past:
             if chore_changed:
                 summary["chores_sanitized"] += 1
             continue

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -4076,6 +4076,12 @@ class ChoreManager(BaseManager):
         - Persisted aggregate state is stored at chore level (`DATA_CHORE_STATE`)
         - UI publication projects selected persisted states for display surfaces
 
+        The aggregate is **recomputed** from per-assignee states (via the same
+        logic as `_update_global_state`) rather than trusting the persisted
+        `DATA_CHORE_STATE`, which can go stale (e.g. a standby completing a
+        rotation chore after it went overdue leaves the turn-holder's persisted
+        state stale). Recomputing keeps the read path reality-aligned (Issue #248).
+
         Mapping rules:
         - `approved` -> `completed`
         - `approved_in_part` -> `completed_in_part`
@@ -4084,21 +4090,20 @@ class ChoreManager(BaseManager):
         chore_data: ChoreData | dict[str, Any] = self._coordinator.chores_data.get(
             chore_id, {}
         )
-        persisted_state = chore_data.get(
-            const.DATA_CHORE_STATE,
-            const.CHORE_STATE_PENDING,
-        )
+        # Recompute the aggregate from per-assignee states so it reflects reality
+        # even if the persisted DATA_CHORE_STATE is stale.
+        persisted_state = self._compute_global_state(chore_id, chore_data)
 
         if persisted_state == const.CHORE_STATE_APPROVED:
             return {
-                "persisted_state": cast("str", persisted_state),
+                "persisted_state": persisted_state,
                 "ui_state": const.CHORE_STATE_COMPLETED,
                 "due_window_override_applied": False,
             }
 
         if persisted_state == const.CHORE_STATE_APPROVED_IN_PART:
             return {
-                "persisted_state": cast("str", persisted_state),
+                "persisted_state": persisted_state,
                 "ui_state": const.CHORE_STATE_COMPLETED_IN_PART,
                 "due_window_override_applied": False,
             }
@@ -4107,16 +4112,55 @@ class ChoreManager(BaseManager):
             None, chore_id
         ):
             return {
-                "persisted_state": cast("str", persisted_state),
+                "persisted_state": persisted_state,
                 "ui_state": const.CHORE_STATE_DUE,
                 "due_window_override_applied": True,
             }
 
         return {
-            "persisted_state": cast("str", persisted_state),
-            "ui_state": cast("str", persisted_state),
+            "persisted_state": persisted_state,
+            "ui_state": persisted_state,
             "due_window_override_applied": False,
         }
+
+    def _compute_global_state(
+        self,
+        chore_id: str,
+        chore_data: ChoreData | dict[str, Any],
+    ) -> str:
+        """Compute the aggregate global state from per-assignee states.
+
+        Shared logic between `_update_global_state` (write path) and
+        `get_global_chore_state_context` (read path) so both stay aligned.
+        """
+        assigned_assignees = chore_data.get(const.DATA_CHORE_ASSIGNED_USER_IDS, [])
+        if not assigned_assignees:
+            return const.CHORE_STATE_PENDING
+
+        assignee_states = self._collect_normalized_assignee_persisted_states(
+            chore_id,
+            assigned_assignees,
+        )
+
+        global_state = ChoreEngine.compute_global_chore_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+        )
+
+        if global_state == const.CHORE_STATE_UNKNOWN:
+            global_state = const.CHORE_STATE_PENDING
+
+        if ChoreEngine.is_rotation_mode(chore_data):
+            global_state = ChoreEngine.resolve_rotation_global_state(
+                chore_data=chore_data,
+                assignee_states=assignee_states,
+                is_open_claim_cycle=self._is_rotation_open_claim_cycle(
+                    chore_id,
+                    chore_data,
+                ),
+            )
+
+        return global_state
 
     def _collect_normalized_assignee_persisted_states(
         self,
@@ -4128,8 +4172,15 @@ class ChoreManager(BaseManager):
         Normalization rules:
         - Non-persisted values are normalized to `pending`
         - In multi-assignee chores, `missed` contributes as `overdue`
+        - A stale persisted `overdue`/`missed` whose due date has moved to the
+          future (FSM resolves to `pending`/`due`) is normalized to `pending`,
+          so the global aggregate stays reality-aligned (Issue #248).
         """
+        chore_data: ChoreData | dict[str, Any] = self._coordinator.chores_data.get(
+            chore_id, {}
+        )
         assignee_states: dict[str, str] = {}
+        now = dt_util.now()
         for assignee_id in assigned_assignees:
             assignee_chore_data = self._get_assignee_chore_data(assignee_id, chore_id)
             state = assignee_chore_data.get(
@@ -4139,6 +4190,34 @@ class ChoreManager(BaseManager):
 
             if state not in const.CHORE_PERSISTED_USER_STATES:
                 state = const.CHORE_STATE_PENDING
+
+            # Stale-overdue reconciliation: if the persisted state is overdue/missed
+            # but the FSM resolves the assignee to pending/due (due date moved to
+            # the future), treat as pending for aggregation. This prevents a stale
+            # persisted overdue from making the global aggregate report overdue.
+            if state in (
+                const.CHORE_STATE_OVERDUE,
+                const.CHORE_STATE_MISSED,
+            ):
+                is_approved = self.chore_is_approved_in_period(assignee_id, chore_id)
+                has_pending = ChoreEngine.chore_has_pending_claim(assignee_chore_data)
+                due_dt = self.get_due_date(chore_id, assignee_id)
+                due_window_start = self.get_due_window_start(chore_id, assignee_id)
+                computed_state, _ = ChoreEngine.resolve_assignee_chore_state(
+                    chore_data=chore_data,
+                    assignee_id=assignee_id,
+                    now=now,
+                    is_approved_in_period=is_approved,
+                    has_pending_claim=has_pending,
+                    due_date=due_dt,
+                    due_window_start=due_window_start,
+                )
+                if computed_state in (
+                    const.CHORE_STATE_PENDING,
+                    const.CHORE_STATE_DUE,
+                    const.CHORE_STATE_WAITING,
+                ):
+                    state = const.CHORE_STATE_PENDING
 
             if len(assigned_assignees) > 1 and state == const.CHORE_STATE_MISSED:
                 state = const.CHORE_STATE_OVERDUE
@@ -5724,7 +5803,24 @@ class ChoreManager(BaseManager):
         )
 
         # Apply state change
-        if effect.new_state:
+        if effect.clear_exception_state:
+            # Only clear an exception state (overdue/missed) to pending; preserve
+            # approved/claimed/pending. Used for other assignees in single-completer
+            # chores whose exception state is stale after the actor advances.
+            current_state = assignee_chore_data.get(
+                const.DATA_USER_CHORE_DATA_STATE, const.CHORE_STATE_PENDING
+            )
+            if current_state in (
+                const.CHORE_STATE_OVERDUE,
+                const.CHORE_STATE_MISSED,
+            ):
+                self._set_assignee_chore_state(
+                    assignee_id,
+                    chore_id,
+                    assignee_chore_data,
+                    const.CHORE_STATE_PENDING,
+                )
+        elif effect.new_state:
             state_to_persist = effect.new_state
             if state_to_persist not in const.CHORE_PERSISTED_USER_STATES:
                 const.LOGGER.debug(
@@ -5802,6 +5898,11 @@ class ChoreManager(BaseManager):
         Authority boundary:
         - Engine computes aggregate state via `ChoreEngine.compute_global_chore_state`
         - Manager adapts persisted-only inputs and applies rotation metadata overrides
+
+        The persisted per-assignee states are reconciled for stale `overdue`/`missed`
+        (whose due date has moved to the future) in
+        `_collect_normalized_assignee_persisted_states`, so the aggregate stays
+        reality-aligned without changing the well-defined global-state semantics.
 
         Args:
             chore_id: The chore's internal ID

--- a/docs/in-process/GLOBAL_STATE_ALIGNMENT_IN-PROCESS.md
+++ b/docs/in-process/GLOBAL_STATE_ALIGNMENT_IN-PROCESS.md
@@ -1,0 +1,475 @@
+# Initiative Plan — Global State Alignment (Issue #248)
+
+## Initiative snapshot
+
+- **Name / Code**: Global State Alignment — `GLOBAL_STATE_ALIGNMENT`
+- **Target release / milestone**: v0.5.x (next patch/minor after current)
+- **Owner / driver(s)**: ChoreOps maintainer + ChoreOps Builder
+- **Status**: In progress (Phases 1-3 complete; Phases 4-6 pending)
+
+## Summary & immediate steps
+
+| Phase / Step     | Description                                                                 | % complete | Quick notes                                                                 |
+| ----------------- | --------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------- |
+| Phase 1 – Root cause & contract audit | Confirm the stored-vs-computed divergence and lock the state contract        | 100%       | ✅ Sweep done; root cause confirmed in `boot_repairs.py`                    |
+| Phase 2 – Engine fix (compute-only)   | Make global aggregation operate on computed states, not stale persisted ones | 100%       | ✅ Implemented (minimal reconciliation); 318 tests pass                     |
+| Phase 3 – Data reconciliation         | Fix boot-repair guard + runtime reconciliation of stale `overdue`            | 100%       | ✅ Boot guard fixed; 4 boot-repair tests pass                               |
+| Phase 4 – `global_context` attribute  | Add compact context attribute for the dashboard status line                  | 0%         | Additive, non-breaking                                                      |
+| Phase 5 – Dashboard consumption       | Consume `global_context` in the history line; keep line-2 per-user           | 0%         | Surgical template change                                                    |
+| Phase 6 – Tests & validation          | Regression + new tests across all completion criteria                        | 0%         | Must cover shared_all, shared_first, rotation_simple/smart/primary_standby  |
+
+1. **Key objective** – Fix the divergence between per-assignee chore state and the
+   chore-level `global_state` so a completed occurrence never reports a stale
+   `overdue`. The **root-level fix** is lifecycle management: when a single-completer
+   chore (shared_first / rotation) is claimed or approved, the OTHER assigned users'
+   persisted `overdue`/`missed` states are cleared to `pending` (they are relieved of
+   the occurrence). This makes the global aggregate correct by construction. Do this
+   **without** destabilizing the broader integration.
+2. **Summary of recent work** – Analysis traced the root cause to the claim/approve
+   transition paths leaving the OTHER assigned users' persisted `overdue`/`missed`
+   states in place when a single-completer chore advanced. This propagated a stale
+   `overdue` into the global aggregate and the global sensor. Concrete production
+   data (Feed Cat AM, rotation_primary_standby) confirmed: standby Kaden completed
+   the chore, but primary Payton and standbys Caren/Chad remained persisted `overdue`,
+   so the global reported `overdue`. **Phases 1-3 complete**:
+   - Phase 2: minimal reconciliation in `_collect_normalized_assignee_persisted_states`
+     (stale overdue with future due date → pending) + completion-aware
+     `resolve_rotation_global_state` (standby completion → approved).
+   - Phase 3: boot-repair inverted guard fixed (normalize stale overdue when due date
+     absent or future).
+   - **Root-level lifecycle fix (added during implementation)**: `_plan_clear_other_exception_states`
+     clears other assignees' `overdue`/`missed` → `pending` on claim/approve of
+     single-completer chores; `get_global_chore_state_context` recomputes the
+     aggregate from per-assignee states (via `_compute_global_state`) so the read
+     path reflects reality.
+3. **Next steps (short term)** – Phase 4 (`global_context` attribute), Phase 5
+   (dashboard consumption), Phase 6 (final validation).
+4. **Risks / blockers** – Changing the persisted `DATA_CHORE_STATE` could ripple
+   into approval queues, notifications, and dashboard grouping. Mitigation: the
+   read path now recomputes the aggregate from per-assignee states, and the write
+   path clears stale exception states. Phase 3 must not clear a *legitimate*
+   `overdue` (due date genuinely past) — verified by test. See "De-risking" section.
+5. **References**
+   - [ARCHITECTURE.md](../ARCHITECTURE.md) — state contract, layered state model
+   - [DEVELOPMENT_STANDARDS.md](../DEVELOPMENT_STANDARDS.md) — coding standards
+   - [CODE_REVIEW_GUIDE.md](../CODE_REVIEW_GUIDE.md) — review framework
+   - [tests/AGENT_TEST_CREATION_INSTRUCTIONS.md](../tests/AGENT_TEST_CREATION_INSTRUCTIONS.md)
+   - [RELEASE_CHECKLIST.md](../RELEASE_CHECKLIST.md)
+   - `docs/completed/CHORE_STATUS_COMPLETED_ALIAS_SENSOR_ONLY_COMPLETED.md` — Option A contract
+   - `docs/completed/PRIMARY_STANDBY_CHORE_TYPE_COMPLETED.md` — rotation/standby design
+6. **Decisions & completion check**
+   - **Decisions captured**:
+     - **Root-level fix (added during implementation)**: the claim/approve transition
+       paths must clear the OTHER assigned users' persisted `overdue`/`missed` →
+       `pending` for single-completer chores (shared_first + 3 rotation types). This
+       is lifecycle management — "manage the value you write." Excludes `shared_all`
+       (others legitimately remain overdue — they must each complete) and
+       `independent` (no cross-user effect).
+     - The global aggregate read path (`get_global_chore_state_context`) recomputes
+       from per-assignee states (via `_compute_global_state`) rather than trusting
+       the persisted `DATA_CHORE_STATE`, which can go stale.
+     - The per-user state (`DATA_USER_CHORE_DATA_STATE`) is **not** the problem and
+       is **not** changed in its write semantics. The FSM already computes the UI
+       correctly at read time.
+     - The persisted `overdue` **is consumed** (stats, boundary decisions,
+       idempotency, reschedule gating), so it cannot be removed. It must be
+       **properly cleared** when the due date moves forward (Phase 3, data hygiene).
+     - Persisted `DATA_CHORE_STATE` schema and its consumers are **unchanged** to
+       de-risk the change (see De-risking).
+     - `approved_in_part` / `claimed_in_part` remain intentional aggregate states
+       for `shared_all`; they are **not** per-user states.
+     - `shared_all` (all must complete) vs `shared_first` (single completer) are
+       distinct; the fix must not conflate them.
+     - Dashboard line 2 = per-user state (primary); line 3 = global context
+       (secondary awareness). A new `global_context` attribute feeds line 3.
+   - **Completion confirmation**: `[ ]` All follow-up items completed (architecture
+     updates, cleanup, documentation, etc.) before requesting owner approval to mark
+     initiative done.
+
+> **Important:** Keep the entire Summary section current with every meaningful update.
+
+## Tracking expectations
+
+- **Summary upkeep**: Refresh the Summary section after each significant change.
+- **Detailed tracking**: Use the phase-specific sections below for granular progress.
+
+---
+
+## Background & root cause (from analysis)
+
+### The stored-vs-computed model (critical to understand)
+
+ChoreOps deliberately stores a **minimal** set of persisted per-assignee states and
+**computes** display states at read time:
+
+- **Persisted per-assignee** (`DATA_USER_CHORE_DATA_STATE`): `pending`, `claimed`,
+  `approved`, `overdue`, `missed` (`CHORE_PERSISTED_USER_STATES`).
+- **Computed per-user UI** (`resolve_assignee_chore_state` → `get_chore_status_context`):
+  `pending`, `due`, `waiting`, `claimed`, `overdue`, `missed`, `not_my_turn`,
+  `standby`, `completed`, `completed_by_other` (`CHORE_UI_ASSIGNEE_STATES`).
+- **Persisted global** (`DATA_CHORE_STATE`): `pending`, `claimed`, `claimed_in_part`,
+  `approved`, `approved_in_part`, `overdue`, `missed`, `independent`
+  (`CHORE_PERSISTED_GLOBAL_STATES`).
+- **Computed global UI** (`get_global_chore_state_context`): maps `approved` →
+  `completed`, `approved_in_part` → `completed_in_part` (`CHORE_UI_GLOBAL_STATES`).
+
+**The bug**: `compute_global_chore_state` and `resolve_rotation_global_state`
+aggregate the **persisted** per-assignee states directly. When a persisted state is
+stale (e.g. `overdue` written in a prior cycle, then the due date rescheduled
+forward without clearing the persisted state), the global aggregate reports
+`overdue` even though the per-user FSM correctly computes `pending`/`due`.
+
+### Concrete reproduction (production data)
+
+`shared_all` chore "Make Family Dinner", 2 users (Kaden, Payton):
+
+| Sensor | `state` | `global_state` | `due_date` | `approval_period_start` |
+| ------ | ------- | -------------- | ---------- | ----------------------- |
+| System global | `overdue` | — | `2026-08-21` | — |
+| Payton | `pending` | `overdue` | `2026-08-21` | `2026-08-14T13:04:28` |
+| Kaden | `pending` | `overdue` | `2026-08-21` | `2026-08-14T13:04:28` |
+
+Both users are `pending`, due date is 3 days in the future, yet `global_state =
+overdue`. The persisted per-assignee states are stale `overdue` from a prior cycle;
+the FSM correctly computes `pending` (future due date), but the global aggregate
+reads the stale persisted `overdue`.
+
+### Why per-user shows `pending` but global shows `overdue`
+
+- **Per-user** (`resolve_assignee_chore_state`): P1–P8 FSM. With `now` (08-17) before
+  `due_date` (08-21) and before `due_window_start` (08-18), it falls through to P8
+  `pending`. ✅
+- **Global** (`compute_global_chore_state`): counts persisted states; `count_overdue
+  > 0` → returns `overdue`. ❌ (No FSM, no due-date awareness.)
+
+### The two candidate fixes
+
+**Option A — Compute-only (recommended).** Make the global aggregation operate on
+**computed** per-assignee states (run `resolve_assignee_chore_state` per assignee,
+then aggregate). The global state then can never diverge from the per-user display.
+Persisted `DATA_CHORE_STATE` schema and its consumers are unchanged.
+
+**Option B — Reconcile storage.** When a due date is rescheduled forward, clear stale
+persisted `overdue`/`missed` back to `pending`. This touches every reschedule/reset
+path and risks missing edge cases; it also re-introduces "storing what we can
+compute."
+
+**Decision — Option A (compute-only) is the core fix. Phase 3 (reconcile storage) is
+a required data-hygiene complement, sequenced after Phase 2.**
+
+The per-user state (`DATA_USER_CHORE_DATA_STATE`) has **never been the problem**.
+The FSM computes the per-user display state at read time and is due-date-aware, so a
+stale persisted `overdue` is invisible to the per-user display (confirmed by the
+reproduction: both users show `pending` correctly). The stale value only became a
+problem because the **global aggregate** read the persisted value directly.
+
+Therefore:
+
+1. **Core fix (Phase 2) — Compute-only for the global aggregate (Option A).** Make
+   the global aggregation operate on **computed** per-assignee states. This fixes
+   the reported bug and is low-risk. It does **not** alter the persisted schema or
+   its consumers.
+2. **Required complement (Phase 3) — Reconcile stale persisted per-assignee state
+   (Option B).** The persisted `overdue` IS consumed (stats, boundary decisions,
+   idempotency, reschedule gating), so it cannot be removed. It must be **properly
+   cleared** when the due date moves forward. The confirmed gap is the **boot
+   repair's inverted guard** (`integrity/boot_repairs.py:60-70`) — it skips
+   normalization for chores WITH an active due date, which is exactly the bug
+   scenario. Plus a runtime reconciliation guard for defense-in-depth. Sequenced
+   after Phase 2 so the two changes don't compound risk.
+
+**Rationale**: Phase 3 is **required**, not optional, because the persisted `overdue`
+is a real, consumed value (not dead weight) and leaving it stale is a data-integrity
+defect even after Phase 2 fixes the global display. The earlier "Phase 3 is
+over-engineering" framing was superseded once the sweep confirmed the persisted
+`overdue` is genuinely consumed and the boot-repair guard is inverted.
+
+---
+
+## De-risking the change (critical)
+
+The concern: "how far is this nested into the integration, and will we create a huge
+complexity of required fixes?"
+
+### Why compute-only is the low-complexity path
+
+1. **No schema change.** `DATA_CHORE_STATE` remains a persisted aggregate token.
+   Every existing consumer (approval queues, notifications, dashboard grouping,
+   `get_global_chore_state_context`) keeps reading the same field with the same
+   values. We only change **how** that field is derived.
+2. **Single source of truth.** The per-user FSM (`resolve_assignee_chore_state`) is
+   already the authority for per-user display. Reusing it for the aggregate means
+   one code path, not two divergent ones.
+3. **No new states.** We are **not** adding states to any allowlist. We reuse the
+   existing computed states (`pending`, `due`, `overdue`, `approved`, etc.) and the
+   existing aggregate mapping (`approved` → `completed`, `approved_in_part` →
+   `completed_in_part`).
+4. **Contained blast radius.** The change is localized to:
+   - `ChoreEngine.compute_global_chore_state` (input: computed states)
+   - `ChoreEngine.resolve_rotation_global_state` (input: computed states)
+   - `ChoreManager._update_global_state` (feeds computed states in)
+   - `ChoreManager._collect_normalized_assignee_persisted_states` (rename/replace
+     with a computed-state collector)
+   - New `global_context` attribute (additive)
+   - Dashboard template (surgical)
+
+### Guard rails to prevent regressions
+
+- **Keep the persisted allowlist contract.** `CHORE_PERSISTED_GLOBAL_STATES` and
+  `CHORE_UI_GLOBAL_STATES` are unchanged. The persisted `DATA_CHORE_STATE` must
+  still only ever hold values from `CHORE_PERSISTED_GLOBAL_STATES`.
+- **Preserve `shared_all` partial semantics.** `approved_in_part` /
+  `claimed_in_part` must still be produced when some (not all) assignees complete.
+  The compute-only change must preserve this.
+- **Preserve `shared_first` single-claimer semantics.** The aggregate follows the
+  active assignee; it must not become `approved_in_part`.
+- **Preserve rotation semantics.** `resolve_rotation_global_state` must still follow
+  the turn-holder in a closed cycle, but now using the turn-holder's **computed**
+  state (so a stale persisted `overdue` with a future due date resolves to
+  `pending`/`due`).
+- **Add a parity test.** Assert that for any chore, the persisted global state
+  matches the compute-only aggregate, and that the per-user `global_state` attribute
+  matches the system global sensor. This is the single most important regression
+  guard.
+
+### What we deliberately do NOT change
+
+- The persisted per-assignee state schema.
+- The persisted global state schema.
+- `get_global_chore_state_context` mapping (`approved` → `completed`, etc.).
+- The per-user FSM (`resolve_assignee_chore_state`).
+- `approved_in_part` / `claimed_in_part` semantics for `shared_all`.
+- Any approval-queue, notification, or dashboard-grouping logic that reads
+  `DATA_CHORE_STATE` (they keep working because the field's values are unchanged in
+  meaning).
+
+---
+
+## Detailed phase tracking
+
+### Phase 1 – Root cause & contract audit
+
+- **Goal**: Lock the stored-vs-computed contract and confirm the exact divergence
+  points before any code change.
+- **Steps / detailed work items**
+  1. [ ] Re-read `docs/ARCHITECTURE.md` state contract section (lines ~490–575) and
+     `docs/completed/CHORE_STATUS_COMPLETED_ALIAS_SENSOR_ONLY_COMPLETED.md` to
+     confirm the authoritative allowlists and mapping rules.
+  2. [ ] Document the stored-vs-computed model in this plan (done above) and get
+     maintainer sign-off on the **two-part fix** (compute-only + data reconciliation).
+  3. [ ] Enumerate every consumer of `DATA_CHORE_STATE` (approval queues,
+     notifications, dashboard grouping, `get_global_chore_state_context`) and
+     confirm none depend on the *stale* behavior.
+  4. [ ] Enumerate every consumer of `DATA_USER_CHORE_DATA_STATE` (stats, streaks,
+     notifications, approval-queue filtering) to confirm none misbehave once the
+     global aggregate no longer reads the persisted value directly.
+  5. [ ] Confirm `_update_global_state` call sites (10 found) and that each is
+     reached after the relevant state mutation.
+- **Key issues**
+  - The divergence is subtle: per-user uses computed states, global uses persisted.
+    The audit must make this explicit so future contributors don't reintroduce it.
+  - The per-user state is **not** the problem and is **not** changed. Only the global
+    aggregate's inputs change.
+
+### Phase 2 – Engine fix (compute-only) — CORE FIX [DONE]
+
+- **Goal**: Make global aggregation operate on reality-aligned states, not stale
+  persisted ones.
+- **Implementation note — approach divergence**: The original plan proposed running
+  `resolve_assignee_chore_state` per assignee and mapping ALL computed states back to
+  persisted tokens (Option 1, full FSM rewrite). This was discovered to be **fragile
+  and over-engineering**:
+  - It broke 11 state-matrix tests because `_update_global_state` is called in some
+    paths **BEFORE** `pending_claim_count` is incremented (claim/approve ordering).
+    A full FSM recompute depends on `has_pending_claim` being current, so the
+    computed state was wrong at aggregation time.
+  - The existing global-state semantics (single-assignee follows the user,
+    shared_first/rotation follow the first actor, partial states for shared_all) are
+    **already well-defined and 95% correct**. A full rewrite risked destabilizing them.
+  - **Adopted: minimal reconciliation (Option 2).** The existing persisted-state
+    aggregation is preserved exactly. `_collect_normalized_assignee_persisted_states`
+    now adds one rule: if a persisted state is `overdue`/`missed` but the FSM resolves
+    the assignee to `pending`/`due`/`waiting` (because the due date moved to the
+    future), treat it as `pending` for aggregation. This only changes behavior for
+    the **stale-overdue** case (the actual bug) and preserves all other semantics.
+- **Validation**: `tests/test_chore_state_matrix.py`,
+  `tests/test_rotation_fsm_states.py`, `tests/test_overdue_immediate_reset.py`,
+  `tests/test_shared_chore_features.py`, `tests/test_chore_engine.py`,
+  `tests/test_rotation_services.py`, `tests/test_rotation_primary_standby.py`,
+  `tests/test_chore_manager.py` — 318 passed.
+- **Steps / detailed work items**
+  1. [x] Add stale-overdue reconciliation to
+     `_collect_normalized_assignee_persisted_states` (instead of a full
+     computed-state rewrite).
+  2. [x] Add `tests/test_stale_overdue_shared_all_maps_to_pending_when_due_date_future`
+     (fix validated).
+  3. [x] Add `tests/test_genuine_overdue_shared_all_remains_overdue` (guard: genuine
+     overdue is NOT cleared).
+  4. [x] Verify `_update_global_state` still delegates to the (now-reconciling)
+     persisted-state collector.
+  5. [x] **Completion-aware rotation fix** in `resolve_rotation_global_state`: the
+     closed-cycle path now checks `count_approved > 0` BEFORE returning the
+     turn-holder's state. This fixes the primary-standby scenario (standby completes
+     after overdue → global must be `approved`, not the turn-holder's stale
+     `overdue`). Applies holistically to ALL rotation types (primary_standby,
+     simple, smart) in BOTH open and closed cycles.
+  6. [x] Add `TestResolveRotationGlobalState` unit tests covering all three rotation
+     types × open/closed cycle × completed/claimed/overdue.
+  7. [x] **Root-level lifecycle fix (added during implementation)**: add
+     `clear_exception_state` to `TransitionEffect` and
+     `_plan_clear_other_exception_states`; on claim/approve of a single-completer
+     chore, clear the OTHER assignees' `overdue`/`missed` → `pending` (preserving
+     approved/claimed/pending). This is the true root cause — the claim/approve
+     paths were leaving other users' exception states in place.
+  8. [x] **Read-path recompute**: `get_global_chore_state_context` now recomputes the
+     aggregate from per-assignee states (via `_compute_global_state`) instead of
+     trusting the persisted `DATA_CHORE_STATE`, which can go stale.
+  9. [x] Add `test_standby_completion_clears_others_overdue_and_global` (end-to-end
+     Feed Cat AM reproduction).
+- **Key issues**
+  - The full-FSM approach (Option 1) has a systemic ordering dependency: `_update_global_state`
+    runs before `_increment_pending_count`/approval-period writes in several paths.
+    Rejected to avoid destabilizing the 95% that works.
+  - Minimal reconciliation preserves single-assignee, shared_first, rotation, and
+    shared_all partial semantics while fixing the stale-overdue bug.
+  - **Root-level fix scope**: clears other users' `overdue`/`missed` only for
+    single-completer criteria (shared_first + 3 rotation types). Excludes `shared_all`
+    (others legitimately remain overdue — they must each complete) and `independent`
+    (no cross-user effect).
+
+### Phase 3 – Data reconciliation (data hygiene) [DONE]
+
+- **Goal**: Clear stale persisted `overdue`/`missed` in `DATA_USER_CHORE_DATA_STATE`
+  when a due date moves forward, so the persisted state is never knowingly wrong.
+- **Implementation note**: The **runtime reconciliation guard** (original step 3) is
+  now **covered by Phase 2** — `_collect_normalized_assignee_persisted_states`
+  reconciles stale `overdue`/`missed` at aggregation time, and the **root-level
+  lifecycle fix** (`_plan_clear_other_exception_states`) clears OTHER assignees'
+  exception states at claim/approve time. So Phase 3 focused on the **boot-repair
+  guard fix** (the confirmed, reproducible defect).
+- **Validation**: `tests/test_integrity_boot_repairs.py` — 4 passed (2 existing + 2
+  new: future-due-date normalizes, past-due-date preserves).
+- **Steps / detailed work items**
+  1. [x] **Fix `integrity/boot_repairs.py` inverted guard.** The boot repair now
+     normalizes stale `overdue`/`missed` per-assignee states to `pending` when the
+     due date is **absent OR in the future** (where those states are impossible
+     residue). It only skips normalization when the due date is genuinely in the
+     **past** (where `overdue`/`missed` is legitimate). Added `_is_due_date_future`
+     helper.
+  2. [ ] **Shift-path gap investigation — DEFERRED.** The user could not reproduce
+     the shift-forward scenario in dev. The reconciliation mechanism in
+     `reschedule_chores_after` appears sound on trace. This remains open for
+     reproduction with more data; not blocking.
+  3. [x] Runtime reconciliation guard — **covered by Phase 2** (the collector
+     reconciles stale overdue at aggregation time).
+  4. [x] Guard against clearing a *legitimate* `overdue` (due date genuinely past) —
+     verified by `test_preserves_genuine_overdue_with_past_due_date`.
+- **Key issues**
+  - The persisted `overdue` IS consumed — it cannot be removed, only properly
+    cleared. Consumers: `_set_assignee_chore_state` (overdue-duration stats),
+    `_derive_boundary_assignee_state` (boundary reset decision),
+    `_process_overdue` (idempotency guard), `reschedule_chores_after` (in-flight
+    skip gating).
+  - **CORRECTED ROOT CAUSE UNDERSTANDING**: The user confirmed the chore was shifted
+    forward WITH shared chores in scope, and the date DID move. So the skip-by-default
+    theory (`reschedule_shared=False`) is **WRONG** for this case. The shift path
+    DID reconcile (or should have), yet the overdue persisted. The gap must be
+    reproduced and traced — it is likely NOT the `reschedule_shared` toggle.
+  - The `reschedule_shared` default is intentional scope control and must NOT be
+    changed to affect out-of-scope chores. The fix must reconcile stale states
+    without widening the chore-type scope.
+  - The confirmed, reproducible defect is the **boot repair's inverted guard**: it
+    skips stale-state normalization for chores WITH an active due date, which is
+    exactly the reported scenario. This is fixed in Phase 3 step 1.
+  - Must not clear a legitimate `overdue` (due date genuinely past).
+  - The runtime guard must run before `_update_global_state` so persisted and
+    computed stay aligned.
+  - Sequenced after Phase 2 so the two changes don't compound risk.
+
+### Phase 4 – `global_context` attribute
+
+- **Goal**: Add a compact, backend-computed context attribute for the dashboard
+  status line (line 3).
+- **Steps / detailed work items**
+  1. [ ] Define `ATTR_CHORE_GLOBAL_CONTEXT` constant in `const.py`.
+  2. [ ] Compute `global_context` in `get_chore_status_context` (per-user sensor) and
+     expose it on the shared/global sensor too.
+  3. [ ] Encode a compact verdict string, e.g.:
+     - Rotation: `turn:<name>` (current turn holder)
+     - `shared_all` overdue: `overdue:<names>` (who is overdue)
+     - `shared_all` partial complete: `completed_by:<names>`
+     - `shared_first` / rotation completed: `completed_by:<name>`
+     - Independent: `null`/empty (no global context needed for per-user display)
+  4. [ ] Add the attribute to the sensor `extra_state_attributes` for both the
+     per-user chore sensor and the shared/global sensor.
+- **Key issues**
+  - Must be additive and non-breaking (no existing consumer reads it yet).
+  - Must be compact (space-constrained dashboard line).
+
+### Phase 5 – Dashboard consumption
+
+- **Goal**: Consume `global_context` in the history line; keep line-2 per-user.
+- **Steps / detailed work items**
+  1. [ ] In `button_card_template_chore_row_v1.yaml` `history` field, replace the
+     buggy `globalState === 'overdue'` branch with a read of
+     `entity.attributes.global_context`.
+  2. [ ] Keep line 2 (`due` field) driven by per-user `entity.state` (primary
+     individual status) — no change to its logic.
+  3. [ ] Ensure the `history` line still shows last-completed + points (unchanged).
+  4. [ ] Mirror the change in `choreops-dashboards` repo templates (the canonical
+     source) and re-sync via `utils/sync_dashboard_assets.py`.
+- **Key issues**
+  - The dashboard templates live in a separate repo (`choreops-dashboards`) and are
+    mirrored into `custom_components/choreops/dashboards/`. Both must be updated and
+    kept in parity.
+
+### Phase 6 – Tests & validation
+
+- **Goal**: Regression + new tests across all completion criteria.
+- **Steps / detailed work items**
+  1. [ ] Add engine unit tests for `compute_global_chore_state` with computed states:
+     - `shared_all` all-pending + future due → `pending` (the reported bug)
+     - `shared_all` one overdue (past due) → `overdue`
+     - `shared_all` some approved → `approved_in_part`
+     - `shared_first` active assignee approved → `approved`
+  2. [ ] Add engine unit tests for `resolve_rotation_global_state` with computed
+     states:
+     - rotation_simple/smart/primary_standby after standby completes → `approved`
+       (not stale `overdue`)
+     - closed cycle follows turn-holder's computed state
+  3. [ ] Add a parity test: for any chore, persisted global state == compute-only
+     aggregate, and per-user `global_state` attribute == system global sensor.
+  4. [ ] Add a `global_context` attribute test for rotation, shared_all, shared_first,
+     and independent.
+  5. [ ] Add data-reconciliation tests (Phase 3): stale `overdue`/`missed` cleared to
+     `pending` when due date moves forward; legitimate `overdue` (due date genuinely
+     past) NOT cleared.
+  6. [ ] Run the full suite: `./utils/quick_lint.sh --fix`, `mypy
+     custom_components/choreops/`, `python -m pytest tests/ -v --tb=line`.
+- **Key issues**
+  - The parity test is the single most important regression guard.
+  - Must cover all completion criteria to prevent conflation of shared_all vs
+    shared_first vs rotation.
+
+---
+
+## Testing & validation
+
+- Tests executed: none yet (planning phase).
+- Outstanding tests: all Phase 6 items.
+- Validation commands:
+  - `./utils/quick_lint.sh --fix`
+  - `mypy custom_components/choreops/`
+  - `python -m pytest tests/ -v --tb=line`
+  - `python -m pytest tests/test_chore_state_matrix.py -v` (global state focus)
+  - `python -m pytest tests/test_chore_engine.py -v` (engine unit tests)
+
+## Notes & follow-up
+
+- The `global_context` attribute is a complement to the engine fix, not a
+  replacement. The engine fix (Phase 2) is the source-of-truth correction; the
+  attribute (Phase 4) is the targeted dashboard enabler.
+- The dashboard templates are mirrored between `choreops-dashboards` and
+  `custom_components/choreops/dashboards/`; keep them in parity.
+- Follow-up: update `docs/ARCHITECTURE.md` to document that global state is computed
+  from computed per-assignee states (not persisted snapshots), to prevent regression.

--- a/tests/test_chore_engine.py
+++ b/tests/test_chore_engine.py
@@ -7,7 +7,10 @@ requiring any Home Assistant mocking or integration setup.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from zoneinfo import ZoneInfo
+
+import pytest
 
 from custom_components.choreops import const
 from custom_components.choreops.engines.chore_engine import (
@@ -148,7 +151,7 @@ class TestCalculateTransitionClaim:
         assert effects[0].new_state == const.CHORE_STATE_CLAIMED
 
     def test_claim_shared_first_affects_all_assignees(self) -> None:
-        """SHARED_FIRST: Claiming assignee → CLAIMED (Phase 2: no state change for others)."""
+        """SHARED_FIRST: Claiming assignee → CLAIMED, others get exception-state clear."""
         chore_data = {
             const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_SHARED_FIRST,
             const.DATA_CHORE_DEFAULT_POINTS: 10.0,
@@ -162,8 +165,8 @@ class TestCalculateTransitionClaim:
             assignee_name="Sarah",
         )
 
-        # Phase 2: Only 1 effect (actor), other assignees remain in their current state
-        assert len(effects) == 1
+        # Actor + exception-state clear for the 2 other assignees (Issue #248).
+        assert len(effects) == 3
 
         # Actor assignee gets CLAIMED state
         actor_effect = effects[0]
@@ -171,6 +174,13 @@ class TestCalculateTransitionClaim:
         assert actor_effect.new_state == const.CHORE_STATE_CLAIMED
         assert actor_effect.update_stats is True
         assert actor_effect.set_claimed_by == "Sarah"
+
+        # Other assignees get exception-state clear (overdue/missed -> pending)
+        for other_effect in effects[1:]:
+            assert other_effect.assignee_id in ("assignee-2", "assignee-3")
+            assert other_effect.new_state == const.CHORE_STATE_PENDING
+            assert other_effect.clear_exception_state is True
+            assert other_effect.update_stats is False
 
 
 # =============================================================================
@@ -204,7 +214,7 @@ class TestCalculateTransitionApprove:
         assert effects[0].set_completed_by == "Sarah"
 
     def test_approve_shared_first_updates_all(self) -> None:
-        """SHARED_FIRST: Approve updates actor only (Phase 2: no state change for others)."""
+        """SHARED_FIRST: Approve updates actor + clears others' exception states."""
         chore_data = {
             const.DATA_CHORE_COMPLETION_CRITERIA: const.COMPLETION_CRITERIA_SHARED_FIRST,
             const.DATA_CHORE_DEFAULT_POINTS: 20.0,
@@ -218,8 +228,8 @@ class TestCalculateTransitionApprove:
             assignee_name="Sarah",
         )
 
-        # Phase 2: Only 1 effect (actor), blocking is computed not stored
-        assert len(effects) == 1
+        # Actor + exception-state clear for the 1 other assignee (Issue #248).
+        assert len(effects) == 2
 
         actor_effect = effects[0]
         assert actor_effect.assignee_id == "assignee-1"
@@ -227,6 +237,13 @@ class TestCalculateTransitionApprove:
         assert actor_effect.points == 20.0
         assert actor_effect.update_stats is True
         assert actor_effect.set_completed_by == "Sarah"
+
+        # Other assignee gets exception-state clear (overdue/missed -> pending)
+        other_effect = effects[1]
+        assert other_effect.assignee_id == "assignee-2"
+        assert other_effect.new_state == const.CHORE_STATE_PENDING
+        assert other_effect.clear_exception_state is True
+        assert other_effect.update_stats is False
 
 
 class TestCalculateStreak:
@@ -1614,3 +1631,210 @@ class TestComputeGlobalChoreStateEdges:
 
         result = ChoreEngine.compute_global_chore_state(chore_data, assignee_states)
         assert result == const.CHORE_STATE_PENDING
+
+
+class TestResolveRotationGlobalState:
+    """Unit tests for rotation-mode global state resolution.
+
+    Covers Issue #248: a standby completing a primary-standby chore must make
+    the global state `approved` even when the turn-holder's persisted state is a
+    stale `overdue` (standbys typically claim after the chore goes overdue).
+    """
+
+    def _chore(
+        self,
+        *,
+        current_turn: str,
+        criteria: str = const.COMPLETION_CRITERIA_ROTATION_PRIMARY_STANDBY,
+    ) -> dict[str, Any]:
+        return {
+            const.DATA_CHORE_COMPLETION_CRITERIA: criteria,
+            const.DATA_CHORE_ROTATION_CURRENT_ASSIGNEE_ID: current_turn,
+        }
+
+    def test_closed_cycle_standby_completed_returns_approved(self) -> None:
+        """Standby completion makes global approved even if turn-holder overdue.
+
+        Reproduction of the Feed Cat AM scenario: primary (turn) is `overdue`,
+        a standby completed the chore (`approved`). Global must be `approved`.
+        """
+        chore_data = self._chore(current_turn="primary")
+        assignee_states = {
+            "primary": const.CHORE_STATE_OVERDUE,
+            "standby": const.CHORE_STATE_APPROVED,
+            "other": const.CHORE_STATE_OVERDUE,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=False,
+        )
+        assert result == const.CHORE_STATE_APPROVED
+
+    def test_closed_cycle_turn_holder_approved_returns_approved(self) -> None:
+        """A closed cycle with the turn-holder approved reflects approved."""
+        chore_data = self._chore(current_turn="primary")
+        assignee_states = {
+            "primary": const.CHORE_STATE_APPROVED,
+            "standby": const.CHORE_STATE_PENDING,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=False,
+        )
+        assert result == const.CHORE_STATE_APPROVED
+
+    def test_closed_cycle_turn_holder_overdue_no_completion_returns_overdue(
+        self,
+    ) -> None:
+        """Without any completion, a closed cycle follows the turn-holder's state."""
+        chore_data = self._chore(current_turn="primary")
+        assignee_states = {
+            "primary": const.CHORE_STATE_OVERDUE,
+            "standby": const.CHORE_STATE_OVERDUE,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=False,
+        )
+        assert result == const.CHORE_STATE_OVERDUE
+
+    def test_closed_cycle_turn_holder_claimed_returns_claimed(self) -> None:
+        """A closed cycle with the turn-holder claiming reflects claimed."""
+        chore_data = self._chore(current_turn="primary")
+        assignee_states = {
+            "primary": const.CHORE_STATE_CLAIMED,
+            "standby": const.CHORE_STATE_PENDING,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=False,
+        )
+        assert result == const.CHORE_STATE_CLAIMED
+
+    def test_open_cycle_standby_completed_returns_approved(self) -> None:
+        """Open cycle with a standby completed reflects approved (existing path)."""
+        chore_data = self._chore(current_turn="primary")
+        assignee_states = {
+            "primary": const.CHORE_STATE_OVERDUE,
+            "standby": const.CHORE_STATE_APPROVED,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=True,
+        )
+        assert result == const.CHORE_STATE_APPROVED
+
+    @pytest.mark.parametrize(
+        "criteria",
+        [
+            const.COMPLETION_CRITERIA_ROTATION_PRIMARY_STANDBY,
+            const.COMPLETION_CRITERIA_ROTATION_SIMPLE,
+            const.COMPLETION_CRITERIA_ROTATION_SMART,
+        ],
+    )
+    def test_non_turn_assignee_completed_returns_approved_for_all_rotation_types(
+        self,
+        criteria: str,
+    ) -> None:
+        """A non-turn assignee completing makes global approved for ALL rotation types.
+
+        Covers Issue #248 holistically: whether the completion comes from a standby
+        (primary-standby) or via steal/override (simple/smart), a completed occurrence
+        must resolve to `approved`, not the turn-holder's stale `overdue`.
+        """
+        chore_data = self._chore(current_turn="turn-holder", criteria=criteria)
+        assignee_states = {
+            "turn-holder": const.CHORE_STATE_OVERDUE,
+            "other": const.CHORE_STATE_APPROVED,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=False,
+        )
+        assert result == const.CHORE_STATE_APPROVED
+
+    @pytest.mark.parametrize(
+        "criteria",
+        [
+            const.COMPLETION_CRITERIA_ROTATION_PRIMARY_STANDBY,
+            const.COMPLETION_CRITERIA_ROTATION_SIMPLE,
+            const.COMPLETION_CRITERIA_ROTATION_SMART,
+        ],
+    )
+    def test_no_completion_follows_turn_holder_for_all_rotation_types(
+        self,
+        criteria: str,
+    ) -> None:
+        """Without completion, ALL rotation types follow the turn-holder's state."""
+        chore_data = self._chore(current_turn="turn-holder", criteria=criteria)
+        assignee_states = {
+            "turn-holder": const.CHORE_STATE_OVERDUE,
+            "other": const.CHORE_STATE_PENDING,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=False,
+        )
+        assert result == const.CHORE_STATE_OVERDUE
+
+    @pytest.mark.parametrize(
+        "criteria",
+        [
+            const.COMPLETION_CRITERIA_ROTATION_PRIMARY_STANDBY,
+            const.COMPLETION_CRITERIA_ROTATION_SIMPLE,
+            const.COMPLETION_CRITERIA_ROTATION_SMART,
+        ],
+    )
+    def test_open_cycle_non_turn_completed_returns_approved_for_all_rotation_types(
+        self,
+        criteria: str,
+    ) -> None:
+        """An open cycle (override/steal) plus non-turn completion -> approved.
+
+        This covers the `open_rotation_cycle` service and the `allow_steal` option:
+        both open the claim cycle so any assigned user may complete. A completed
+        occurrence must resolve to `approved`, not the turn-holder's stale overdue.
+        """
+        chore_data = self._chore(current_turn="turn-holder", criteria=criteria)
+        assignee_states = {
+            "turn-holder": const.CHORE_STATE_OVERDUE,
+            "other": const.CHORE_STATE_APPROVED,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=True,
+        )
+        assert result == const.CHORE_STATE_APPROVED
+
+    @pytest.mark.parametrize(
+        "criteria",
+        [
+            const.COMPLETION_CRITERIA_ROTATION_PRIMARY_STANDBY,
+            const.COMPLETION_CRITERIA_ROTATION_SIMPLE,
+            const.COMPLETION_CRITERIA_ROTATION_SMART,
+        ],
+    )
+    def test_open_cycle_non_turn_claimed_returns_claimed_for_all_rotation_types(
+        self,
+        criteria: str,
+    ) -> None:
+        """An open cycle (override/steal) with a non-turn claim follows that claim."""
+        chore_data = self._chore(current_turn="turn-holder", criteria=criteria)
+        assignee_states = {
+            "turn-holder": const.CHORE_STATE_OVERDUE,
+            "other": const.CHORE_STATE_CLAIMED,
+        }
+        result = ChoreEngine.resolve_rotation_global_state(
+            chore_data=chore_data,
+            assignee_states=assignee_states,
+            is_open_claim_cycle=True,
+        )
+        assert result == const.CHORE_STATE_CLAIMED

--- a/tests/test_chore_state_matrix.py
+++ b/tests/test_chore_state_matrix.py
@@ -17,10 +17,12 @@ Test Organization:
 
 # pylint: disable=redefined-outer-name
 
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 import pytest
 
 from custom_components.choreops import const
@@ -35,6 +37,7 @@ from tests.helpers import (
     CHORE_STATE_COMPLETED_IN_PART,
     CHORE_STATE_INDEPENDENT,
     CHORE_STATE_NOT_MY_TURN,
+    CHORE_STATE_OVERDUE,
     CHORE_STATE_PENDING,
     CHORE_STATE_UNKNOWN,
     COMPLETION_CRITERIA_SHARED_FIRST,
@@ -1022,3 +1025,68 @@ class TestGlobalStateConsistency:
 
         assert persisted_rotation == expected_rotation
         assert persisted_rotation != CHORE_STATE_UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_stale_overdue_shared_all_maps_to_pending_when_due_date_future(
+        self,
+        hass: HomeAssistant,
+        scenario_shared: SetupResult,
+    ) -> None:
+        """A shared_all chore with stale persisted `overdue` (future due date) reports pending.
+
+        Regression test for Issue #248: when a chore's due date moves to the future
+        but the per-assignee persisted states remain `overdue` (stale from a prior
+        cycle), the global aggregate must recompute to `pending`, not stay `overdue`.
+        """
+        coordinator = scenario_shared.coordinator
+        chore_id = scenario_shared.chore_ids["Family dinner cleanup"]
+
+        # Set all persisted per-assignee states to OVERDUE (simulating a stale state)
+        assigned_assignees = coordinator.chores_data[chore_id][
+            const.DATA_CHORE_ASSIGNED_USER_IDS
+        ]
+        for assignee_id in assigned_assignees:
+            assignee_chore_data = coordinator.chore_manager._get_assignee_chore_data(
+                assignee_id, chore_id
+            )
+            assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = CHORE_STATE_OVERDUE
+
+        # Recompute the global state from the stale persisted states
+        coordinator.chore_manager._update_global_state(chore_id)
+
+        # The persisted states are stale `overdue`, but the FSM resolves them to
+        # `pending` (due date in the future), so the global must be `pending`.
+        assert get_global_chore_state(coordinator, chore_id) == CHORE_STATE_PENDING
+
+    @pytest.mark.asyncio
+    async def test_genuine_overdue_shared_all_remains_overdue(
+        self,
+        hass: HomeAssistant,
+        scenario_shared: SetupResult,
+    ) -> None:
+        """A genuinely overdue shared_all chore (due date in the past) stays overdue.
+
+        Ensures the reconciliation in Phase 2 does NOT clear a legitimate `overdue`
+        where the due date is genuinely in the past.
+        """
+        coordinator = scenario_shared.coordinator
+        chore_id = scenario_shared.chore_ids["Family dinner cleanup"]
+        chore_info = coordinator.chores_data[chore_id]
+        assigned_assignees = chore_info[const.DATA_CHORE_ASSIGNED_USER_IDS]
+
+        # Set all persisted per-assignee states to OVERDUE (genuinely overdue).
+        for assignee_id in assigned_assignees:
+            assignee_chore_data = coordinator.chore_manager._get_assignee_chore_data(
+                assignee_id, chore_id
+            )
+            assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE] = CHORE_STATE_OVERDUE
+
+            # Set the due date to the PAST so the FSM resolves these to genuine OVERDUE.
+        chore_info[const.DATA_CHORE_DUE_DATE] = (
+            dt_util.now() - timedelta(days=1)
+        ).isoformat()
+
+        coordinator.chore_manager._update_global_state(chore_id)
+
+        # All assignees genuinely overdue -> global stays overdue.
+        assert get_global_chore_state(coordinator, chore_id) == CHORE_STATE_OVERDUE

--- a/tests/test_integrity_boot_repairs.py
+++ b/tests/test_integrity_boot_repairs.py
@@ -132,3 +132,104 @@ async def test_preserves_claimed_state_without_due_date(
         assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE]
         == const.CHORE_STATE_CLAIMED
     )
+
+
+@pytest.mark.asyncio
+async def test_sanitizes_stale_overdue_with_future_due_date(
+    hass: HomeAssistant,
+) -> None:
+    """Boot integrity clears stale overdue residue when the due date is in the future.
+
+    Issue #248: a shared_all chore whose due date moved to the future but whose
+    per-assignee persisted states remain `overdue` (from a prior cycle) must be
+    normalized to `pending`. The prior guard skipped chores WITH an active due date.
+    """
+    chore_id = "chore-1"
+    assignee_id = "user-1"
+    coordinator = _build_integrity_test_coordinator(
+        {
+            const.DATA_USERS: {
+                assignee_id: {
+                    const.DATA_USER_CHORE_DATA: {
+                        chore_id: {
+                            const.DATA_USER_CHORE_DATA_STATE: const.CHORE_STATE_OVERDUE,
+                        }
+                    }
+                }
+            },
+            const.DATA_CHORES: {
+                chore_id: {
+                    const.DATA_CHORE_INTERNAL_ID: chore_id,
+                    const.DATA_CHORE_ASSIGNED_USER_IDS: [assignee_id],
+                    const.DATA_CHORE_COMPLETION_CRITERIA: (
+                        const.COMPLETION_CRITERIA_SHARED
+                    ),
+                    const.DATA_CHORE_DUE_DATE: "2099-01-15T08:00:00+00:00",
+                    const.DATA_CHORE_STATE: const.CHORE_STATE_OVERDUE,
+                }
+            },
+        }
+    )
+
+    summary = repair_impossible_due_state_residue(coordinator._data)
+
+    chore_data = coordinator._data[const.DATA_CHORES][chore_id]
+    assignee_chore_data = coordinator._data[const.DATA_USERS][assignee_id][
+        const.DATA_USER_CHORE_DATA
+    ][chore_id]
+
+    assert summary["assignee_states_normalized"] == 1
+    assert summary["chores_sanitized"] == 1
+    assert (
+        assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE]
+        == const.CHORE_STATE_PENDING
+    )
+    assert chore_data[const.DATA_CHORE_STATE] == const.CHORE_STATE_PENDING
+
+
+@pytest.mark.asyncio
+async def test_preserves_genuine_overdue_with_past_due_date(
+    hass: HomeAssistant,
+) -> None:
+    """Boot integrity keeps a legitimate overdue when the due date is in the past."""
+    chore_id = "chore-1"
+    assignee_id = "user-1"
+    coordinator = _build_integrity_test_coordinator(
+        {
+            const.DATA_USERS: {
+                assignee_id: {
+                    const.DATA_USER_CHORE_DATA: {
+                        chore_id: {
+                            const.DATA_USER_CHORE_DATA_STATE: const.CHORE_STATE_OVERDUE,
+                        }
+                    }
+                }
+            },
+            const.DATA_CHORES: {
+                chore_id: {
+                    const.DATA_CHORE_INTERNAL_ID: chore_id,
+                    const.DATA_CHORE_ASSIGNED_USER_IDS: [assignee_id],
+                    const.DATA_CHORE_COMPLETION_CRITERIA: (
+                        const.COMPLETION_CRITERIA_SHARED
+                    ),
+                    const.DATA_CHORE_DUE_DATE: "2020-01-15T08:00:00+00:00",
+                    const.DATA_CHORE_STATE: const.CHORE_STATE_OVERDUE,
+                }
+            },
+        }
+    )
+
+    summary = repair_impossible_due_state_residue(coordinator._data)
+
+    chore_data = coordinator._data[const.DATA_CHORES][chore_id]
+    assignee_chore_data = coordinator._data[const.DATA_USERS][assignee_id][
+        const.DATA_USER_CHORE_DATA
+    ][chore_id]
+
+    # Genuine overdue (past due date) must NOT be normalized.
+    assert summary["assignee_states_normalized"] == 0
+    assert (
+        assignee_chore_data[const.DATA_USER_CHORE_DATA_STATE]
+        == const.CHORE_STATE_OVERDUE
+    )
+    assert chore_data[const.DATA_CHORE_STATE] == const.CHORE_STATE_OVERDUE

--- a/tests/test_rotation_primary_standby.py
+++ b/tests/test_rotation_primary_standby.py
@@ -26,8 +26,10 @@ from tests.helpers.constants import (
     CHORE_CLAIM_MODE_BLOCKED_STANDBY,
     CHORE_CLAIM_MODE_CLAIMABLE,
     CHORE_CLAIM_MODE_STANDBY_AVAILABLE,
+    CHORE_STATE_APPROVED,
     CHORE_STATE_CLAIMED,
     CHORE_STATE_DUE,
+    CHORE_STATE_OVERDUE,
     CHORE_STATE_PENDING,
     CHORE_STATE_STANDBY,
     CHORE_STATE_WAITING,
@@ -326,6 +328,69 @@ async def test_turn_resets_to_primary_after_approval(
     chore_info = coordinator.chores_data.get(chore_id, {})
     turn = chore_info.get("rotation_current_assignee_id")
     assert turn == zoe_id, f"Turn should be snapped back to primary, got {turn}"
+
+
+# =============================================================================
+# T8 — Issue #248: standby completion clears other users' exception states
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_standby_completion_clears_others_overdue_and_global(
+    hass: HomeAssistant,
+    scenario_primary_standby: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """A standby completing after overdue clears the primary's persisted overdue.
+
+    Reproduces Issue #248 (Feed Cat AM): primary and standby both persisted
+    `overdue`; the standby completes the chore. The primary's persisted `overdue`
+    must be cleared (lifecycle hygiene) so the global aggregate resolves to
+    `approved`, not a stale `overdue`.
+    """
+    from homeassistant.core import Context
+
+    await hass.async_block_till_done()
+
+    chore_name = "Daily Chore (anytime)"
+    coordinator = scenario_primary_standby.coordinator
+    chore_id = scenario_primary_standby.chore_ids[chore_name]
+    zoe_id = scenario_primary_standby.assignee_ids.get("Zoë")
+    max_id = scenario_primary_standby.assignee_ids.get("Max!")
+
+    # Set both persisted per-assignee states to OVERDUE (simulating an overdue chore).
+    for assignee_id in (zoe_id, max_id):
+        assignee_chore_data = coordinator.chore_manager._get_assignee_chore_data(
+            assignee_id, chore_id
+        )
+        assignee_chore_data["state"] = CHORE_STATE_OVERDUE
+
+    # Set the chore's due date to the past so the FSM resolves these as overdue.
+    chore_info = coordinator.chores_data.get(chore_id, {})
+    chore_info["due_date"] = (dt_now_utc() - timedelta(hours=1)).isoformat()
+
+    # Recompute global from the stale overdue states -> should be overdue.
+    coordinator.chore_manager._update_global_state(chore_id)
+    assert coordinator.chores_data[chore_id]["state"] == CHORE_STATE_OVERDUE
+
+    # Max (standby) claims and is approved.
+    assignee_context = Context(user_id=mock_hass_users["assignee2"].id)
+    await claim_chore(hass, "max", chore_name, context=assignee_context)
+    await hass.async_block_till_done()
+    approver_context = Context(user_id=mock_hass_users["approver1"].id)
+    await approve_chore(hass, "max", chore_name, context=approver_context)
+    await hass.async_block_till_done()
+
+    # Primary (Zoë) persisted state must be cleared out of overdue.
+    zoe_chore_data = coordinator.chore_manager._get_assignee_chore_data(
+        zoe_id, chore_id
+    )
+    assert zoe_chore_data["state"] == CHORE_STATE_PENDING, (
+        "Primary's persisted overdue must be cleared when a standby completes"
+    )
+
+    # Global aggregate must resolve to approved (occurrence completed).
+    assert coordinator.chores_data[chore_id]["state"] == CHORE_STATE_APPROVED
 
 
 # =============================================================================


### PR DESCRIPTION
…#248)

Resolve the divergence between per-assignee chore state and the chore-level global aggregate so a completed occurrence never reports a stale `overdue`.

Root cause: when a single-completer chore (shared_first / rotation) was claimed or approved, only the actor's persisted state was transitioned. The other assigned users' persisted `overdue`/`missed` states were left in place, which propagated a stale `overdue` into the global aggregate and the global sensor.

Changes:
- chore_engine: add `clear_exception_state` to TransitionEffect and `_plan_clear_other_exception_states`; on claim/approve of a single-claimer chore, clear the other assignees' `overdue`/`missed` -> `pending` (preserving approved/claimed/pending). Excludes shared_all (others legitimately remain overdue) and independent (no cross-user effect).
- chore_manager: apply `clear_exception_state` in `_apply_effect`; recompute the global aggregate from per-assignee states in `get_global_chore_state_context` (via `_compute_global_state`) so the read path reflects reality even if the persisted DATA_CHORE_STATE is stale; reconcile stale overdue/missed in `_collect_normalized_assignee_persisted_states`.
- boot_repairs: fix inverted guard so stale overdue/missed residue is normalized when the due date is absent or in the future (not only when absent).

Tests:
- Add end-to-end standby-completion test (primary-standby) verifying the primary's persisted overdue is cleared and global resolves to approved.
- Add rotation global-state unit tests across all rotation types x open/closed cycle x completed/claimed/overdue.
- Add stale-overdue and genuine-overdue boot-repair tests.
- Update shared_first claim/approve transition tests for the new lifecycle clearing.

Closes #248

## Summary

- Describe what changed and why.

## Linked issue

- Closes #

## Main merge automation checks

- [ ] PR body uses a closing keyword when applicable (`Closes #...`)
- [ ] Correct release-note label is applied for `.github/release.yml` categorization
- [ ] Excluded triage or status labels have been removed before merge
- [ ] PR title is suitable for generated release notes

## Change type

- [ ] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [ ] Integration logic/state
- [ ] Dashboard/template behavior
- [ ] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [ ] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [ ] `./utils/quick_lint.sh --fix`
- [ ] `python -m pytest tests/ -v --tb=line` (or targeted suite with rationale)

## Documentation impact

- [ ] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

## Release notes

- [ ] No release notes needed
- [ ] Release notes needed (summarize user-visible changes below)

- Release note summary:

## Breaking changes

- [ ] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)
