### PR TITLE
fix: accept weekday names in chore applicable_days

### DIFF
--- a/custom_components/choreops/services.py
+++ b/custom_components/choreops/services.py
@@ -5,6 +5,7 @@ These services allow direct actions through scripts or automations.
 Includes UI editor support with selectors for dropdowns and text inputs.
 """
 
+from collections.abc import Iterable
 from copy import deepcopy
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -807,8 +808,9 @@ _OVERDUE_HANDLING_VALUES = [
     const.OVERDUE_HANDLING_AT_DUE_DATE_ALLOW_STEAL,
 ]
 
-# Days of week - using raw values since there are no individual DAY_* constants
-_DAY_OF_WEEK_VALUES = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+# Days of week - keyed off the same mapping used to coerce them to integers,
+# so the accepted values and the conversion cannot drift apart.
+_DAY_OF_WEEK_VALUES = list(const.WEEKDAY_NAME_TO_INT)
 
 CREATE_CHORE_SCHEMA = vol.Schema(
     _with_service_target_fields(
@@ -1131,6 +1133,49 @@ def _map_service_to_data_keys(
     }
 
 
+def _coerce_applicable_days(raw_days: Iterable[Any] | None) -> list[int]:
+    """Normalize applicable days to weekday integers (0=Mon...6=Sun).
+
+    The service selector offers weekday name strings ("mon", "wed"), while
+    storage and every consumer expect integers. Accept either form so that
+    chores already stored with strings by an earlier version keep working.
+
+    Args:
+        raw_days: Weekday names, weekday integers, or a mix of both.
+
+    Returns:
+        Weekday integers, with unrecognized values dropped.
+    """
+    if not raw_days:
+        return []
+
+    days: list[int] = []
+    for day in raw_days:
+        if isinstance(day, bool):
+            # bool is an int subclass; a boolean here is always a caller error.
+            continue
+        if isinstance(day, int):
+            if 0 <= day <= 6:
+                days.append(day)
+                continue
+            const.LOGGER.warning("Ignoring out-of-range applicable day: %s", day)
+            continue
+        mapped = const.WEEKDAY_NAME_TO_INT.get(str(day).strip().lower())
+        if mapped is not None:
+            days.append(mapped)
+            continue
+        const.LOGGER.warning("Ignoring unrecognized applicable day: %s", day)
+    return days
+
+
+def _normalize_chore_applicable_days(data_input: dict[str, Any]) -> None:
+    """Coerce applicable days in mapped chore data to integers, in place."""
+    if const.DATA_CHORE_APPLICABLE_DAYS in data_input:
+        data_input[const.DATA_CHORE_APPLICABLE_DAYS] = _coerce_applicable_days(
+            data_input[const.DATA_CHORE_APPLICABLE_DAYS]
+        )
+
+
 async def _sync_chore_select_selection(
     hass: HomeAssistant,
     coordinator: "ChoreOpsDataCoordinator",
@@ -1279,7 +1324,9 @@ def _ensure_per_assignee_due_dates(
         const.DATA_CHORE_APPLICABLE_DAYS,
         const.DEFAULT_APPLICABLE_DAYS,
     )
-    applicable_days: list[int] | None = [int(d) for d in raw_days] if raw_days else None
+    # Chores stored by an earlier version may hold weekday name strings here,
+    # so coerce rather than casting directly.
+    applicable_days: list[int] | None = _coerce_applicable_days(raw_days) or None
 
     for uid in assigned_assignee_ids:
         # 1. User-provided explicit due date wins
@@ -1418,6 +1465,8 @@ def async_setup_services(hass: HomeAssistant):
         data_input = _map_service_to_data_keys(
             dict(call.data), _SERVICE_TO_CHORE_DATA_MAPPING
         )
+        # The selector supplies weekday names; storage expects integers.
+        _normalize_chore_applicable_days(data_input)
         # Override assigned assignees with resolved UUIDs
         data_input[const.DATA_CHORE_ASSIGNED_USER_IDS] = assignee_ids
 
@@ -1602,6 +1651,8 @@ def async_setup_services(hass: HomeAssistant):
         data_input = _map_service_to_data_keys(
             service_data, _SERVICE_TO_CHORE_DATA_MAPPING
         )
+        # The selector supplies weekday names; storage expects integers.
+        _normalize_chore_applicable_days(data_input)
 
         # Apply assignment_action merge logic when updating assignees.
         # "add" / "remove" merge with existing list; "replace" (default)

--- a/tests/test_chore_crud_services.py
+++ b/tests/test_chore_crud_services.py
@@ -28,6 +28,10 @@ import pytest
 import voluptuous as vol
 
 from custom_components.choreops import const
+from custom_components.choreops.services import (
+    _DAY_OF_WEEK_VALUES,
+    _coerce_applicable_days,
+)
 from tests.helpers import (
     DOMAIN,
     SERVICE_CREATE_CHORE,
@@ -1241,3 +1245,160 @@ class TestAssignmentActionMerge:
             )
 
         assert _get_assigned_names(scenario_full.coordinator, chore_id) == ["Lila"]
+
+
+# ============================================================================
+# APPLICABLE DAYS COERCION (regression: issue #257)
+# ============================================================================
+
+
+class TestApplicableDaysCoercion:
+    """Weekday names from the service selector must become weekday integers.
+
+    ``services.yaml`` offers ``applicable_days`` as names ("mon", "wed"), while
+    storage and every consumer expect integers (0=Mon...6=Sun). Storing the raw
+    strings made any later ``update_chore`` raise
+    ``invalid literal for int() with base 10: 'wed'``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_stores_weekday_names_as_integers(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """create_chore converts selector day names to integers before storing."""
+        with patch.object(scenario_full.coordinator, "_persist", new=MagicMock()):
+            response = await hass.services.async_call(
+                DOMAIN,
+                SERVICE_CREATE_CHORE,
+                {
+                    "name": "Applicable Days Chore",
+                    "assigned_user_names": ["Zoë"],
+                    "frequency": "weekly",
+                    "applicable_days": ["mon", "wed"],
+                    "due_date": "2099-01-06T18:00:00",
+                },
+                blocking=True,
+                return_response=True,
+            )
+
+        assert response is not None
+        chore_id = response["id"]
+        stored = scenario_full.coordinator.chores_data[chore_id]
+        assert stored[const.DATA_CHORE_APPLICABLE_DAYS] == [0, 2]
+
+    @pytest.mark.asyncio
+    async def test_update_after_create_with_weekday_names(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Reproduces #257: a chore created with day names could not be updated."""
+        with patch.object(scenario_full.coordinator, "_persist", new=MagicMock()):
+            response = await hass.services.async_call(
+                DOMAIN,
+                SERVICE_CREATE_CHORE,
+                {
+                    "name": "Trash Day",
+                    "assigned_user_names": ["Zoë"],
+                    "frequency": "weekly",
+                    "applicable_days": ["wed"],
+                    "due_date": "2099-01-06T18:00:00",
+                },
+                blocking=True,
+                return_response=True,
+            )
+            assert response is not None
+            chore_id = response["id"]
+
+            # Before the fix this raised ValueError from int("wed").
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_CHORE,
+                {
+                    "id": chore_id,
+                    "assignment_action": "replace",
+                    "assigned_user_names": ["Max!"],
+                },
+                blocking=True,
+            )
+
+        assert _get_assigned_names(scenario_full.coordinator, chore_id) == ["Max!"]
+
+    @pytest.mark.asyncio
+    async def test_update_tolerates_legacy_string_days_in_storage(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Chores already stored with day names by an earlier version still update.
+
+        Uses an INDEPENDENT chore so the update path reaches
+        ``_ensure_per_assignee_due_dates``, which is where stored days are read
+        back. A shared chore never calls it, so it would not exercise the fix.
+        """
+        chore_id = scenario_full.chore_ids["Pick up Lëgo!"]
+        coordinator = scenario_full.coordinator
+        coordinator.chores_data[chore_id][const.DATA_CHORE_APPLICABLE_DAYS] = [
+            "wed",
+            "fri",
+        ]
+
+        with patch.object(coordinator, "_persist", new=MagicMock()):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_CHORE,
+                {
+                    "id": chore_id,
+                    "assignment_action": "replace",
+                    "assigned_user_names": ["Lila"],
+                },
+                blocking=True,
+            )
+
+        assert _get_assigned_names(coordinator, chore_id) == ["Lila"]
+
+    @pytest.mark.asyncio
+    async def test_update_rewrites_stored_days_to_integers(
+        self,
+        hass: HomeAssistant,
+        scenario_full: SetupResult,
+    ) -> None:
+        """Passing day names to update_chore stores integers, not strings."""
+        chore_id = scenario_full.chore_ids["Täke Öut Trash"]
+
+        with patch.object(scenario_full.coordinator, "_persist", new=MagicMock()):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_UPDATE_CHORE,
+                {
+                    "id": chore_id,
+                    "applicable_days": ["sat", "sun"],
+                },
+                blocking=True,
+            )
+
+        stored = scenario_full.coordinator.chores_data[chore_id]
+        assert stored[const.DATA_CHORE_APPLICABLE_DAYS] == [5, 6]
+
+    def test_coerce_accepts_names_integers_and_mixtures(self) -> None:
+        """The coercion helper accepts either convention, or both together."""
+        assert _coerce_applicable_days(["mon", "wed"]) == [0, 2]
+        assert _coerce_applicable_days([0, 2]) == [0, 2]
+        assert _coerce_applicable_days(["MON", " wed "]) == [0, 2]
+        assert _coerce_applicable_days([0, "wed"]) == [0, 2]
+
+    def test_coerce_drops_unusable_values(self) -> None:
+        """Unrecognized, out-of-range, and empty inputs are dropped, not raised."""
+        assert _coerce_applicable_days(None) == []
+        assert _coerce_applicable_days([]) == []
+        assert _coerce_applicable_days(["notaday"]) == []
+        assert _coerce_applicable_days([7, -1]) == []
+        assert _coerce_applicable_days([True]) == []
+        assert _coerce_applicable_days(["mon", "notaday"]) == [0]
+
+    def test_schema_day_values_match_the_coercion_mapping(self) -> None:
+        """Every value the schema accepts must be convertible."""
+        assert set(_DAY_OF_WEEK_VALUES) == set(const.WEEKDAY_NAME_TO_INT)
+        assert _coerce_applicable_days(_DAY_OF_WEEK_VALUES) == [0, 1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
## Summary

`applicable_days` is a select whose options are weekday **names** (`"mon"`, `"wed"`), but `create_chore` stored those strings unchanged and `update_chore` later cast them with `int()`. Any update to such a chore raised:

```
invalid literal for int() with base 10: 'wed'
```

Storing the names was silently wrong on its own, independent of the crash: consumers compare against weekday integers — `calendar.py` does `if current.weekday() in applicable_days:` — so a chore created through the service never matched a day.

Every other path in the codebase already converts or tolerates names:

| Path | Handling |
|---|---|
| `helpers/flow_helpers.py:1558` | maps via `WEEKDAY_NAME_TO_INT` |
| `options_flow.py:1179`, `:1517` | maps via `WEEKDAY_NAME_TO_INT` |
| `engines/chore_engine.py:1463` | `WEEKDAY_NAME_TO_INT.get(d.lower())` |
| `engines/schedule_engine.py:1209` | sniffs for `str` and maps |
| `migrations/pre_v50.py:2547` | rewrites stored names to integers |
| **`services.py`** | **missing — bare `int(d)`** |

So this is the one place that never got the conversion.

The change:

1. **Normalize at the service boundary** (`create_chore` and `update_chore`) so stored data is canonical integers, matching what the config flow already writes.
2. **Coerce on read** in `_ensure_per_assignee_due_dates`, so chores already stored with names by an earlier version stop failing without needing a migration.
3. Derive `_DAY_OF_WEEK_VALUES` from `WEEKDAY_NAME_TO_INT` rather than repeating the day literals, so the values the schema accepts and the values the conversion understands cannot drift apart. (This replaces the `# using raw values since there are no individual DAY_* constants` comment — the mapping constant already existed.)

Unrecognized or out-of-range values are dropped with a warning rather than raising, consistent with how `flow_helpers` and `chore_engine` already filter.

I did not touch `flow_helpers` or `options_flow`, which already convert correctly — happy to consolidate the four conversion sites into the shared helper as a follow-up refactor if you'd prefer that.

## Linked issue

- Closes #257

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [ ] Correct release-note label is applied for `.github/release.yml` categorization — **I don't have permission to set labels on this repo.** Suggested: `bug` + `area: automation/services`.
- [x] Excluded triage or status labels have been removed before merge (none were set)
- [x] PR title is suitable for generated release notes

## Change type

- [x] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Integration logic/state
- [ ] Dashboard/template behavior
- [x] Services/automations
- [ ] Documentation/wiki

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [ ] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards`

## Validation

- [x] `./utils/quick_lint.sh --fix` — ruff check, `ruff format`, `mypy --config-file mypy_quick.ini`, and `utils/check_boundaries.py` all clean
- [x] `python -m pytest tests/ -v --tb=line`

Tests were run on Linux CI rather than locally: the suite cannot run on Windows, because `homeassistant/runner.py` imports `fcntl` unconditionally and `pytest-homeassistant-custom-component` imports that runner. Results on `ubuntu-latest`, Python 3.13:

| | passed | skipped | errors |
|---|---|---|---|
| Before this change | 2015 | 4 | 1 |
| After this change | 2022 | 4 | 1 |

The 7 added tests are the new ones below. The 1 error is pre-existing on an unmodified `main` and unrelated to this change — `tests/test_workflow_gamification_pending_queue.py::test_achievement_selected_unassigned_chore_not_awarded` fails in teardown with `ValueError: Assignee non-existent-assignee does not exist (may have been deleted)`. Happy to open a separate issue for it.

### Tests added

Added `TestApplicableDaysCoercion` to `tests/test_chore_crud_services.py`, following `tests/SERVICE_TESTING_PATTERNS.md` (calls go through `hass.services.async_call` so the real schema validates):

- `test_create_stores_weekday_names_as_integers` — day names are stored as `[0, 2]`
- `test_update_after_create_with_weekday_names` — the #257 repro
- `test_update_tolerates_legacy_string_days_in_storage` — a chore already holding `["wed", "fri"]` still updates. Uses an INDEPENDENT chore deliberately: `_ensure_per_assignee_due_dates` is only reached for those, so a shared chore here passes without the fix and pins nothing.
- `test_update_rewrites_stored_days_to_integers` — `update_chore` also normalizes
- `test_coerce_accepts_names_integers_and_mixtures`
- `test_coerce_drops_unusable_values`
- `test_schema_day_values_match_the_coercion_mapping` — pins the constant the schema and conversion now share

I also ran these seven against **unmodified `main`** to confirm they actually catch the bug rather than passing vacuously: all 7 fail there, two of them with the reported `ValueError: invalid literal for int() with base 10: 'wed'`.

## Documentation impact

- [x] No documentation updates needed
- [ ] Documentation updated (README / wiki / inline docs)

`services.yaml` already documents the field as names (`example: "['mon', 'wed', 'fri']"`), which is now the behavior.

## Release notes

- [ ] No release notes needed
- [x] Release notes needed (summarize user-visible changes below)

- Release note summary: Fixed `create_chore` / `update_chore` failing with `invalid literal for int() with base 10` when `applicable_days` was set. Weekday names from the selector are now converted to weekday integers, and chores already saved with day names are repaired on the next update.

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change (describe migration or compatibility impact below)

Both conventions are accepted, so existing automations and stored chores keep working either way.
