### PR TITLE
fix: standby claim-window gating and midnight reset overdue flash

### DIFF
--- a/.github/agents/maintainer.agent.md
+++ b/.github/agents/maintainer.agent.md
@@ -2,20 +2,7 @@
 name: ChoreOps Maintainer
 description: Ad-hoc assistant for debugging, analysis, cleanup, and small fixes
 tools:
-  [
-    vscode,
-    execute,
-    read,
-    agent,
-    vscodeGeneral/rename,
-    vscodeGeneral/usages,
-    vscodeNotebooks/createJupyterNotebook,
-    vscodeNotebooks/editNotebook,
-    edit,
-    search,
-    web,
-    todo,
-  ]
+  [vscode, execute, read, agent, browser, vscodeGeneral/rename, vscodeGeneral/usages, vscodeNotebooks/createJupyterNotebook, vscodeNotebooks/editNotebook, GitHub.vscode-pull-request-github/issue_fetch, GitHub.vscode-pull-request-github/labels_fetch, GitHub.vscode-pull-request-github/notification_fetch, GitHub.vscode-pull-request-github/doSearch, GitHub.vscode-pull-request-github/activePullRequest, GitHub.vscode-pull-request-github/pullRequestStatusChecks, GitHub.vscode-pull-request-github/openPullRequest, GitHub.vscode-pull-request-github/create_pull_request, GitHub.vscode-pull-request-github/resolveReviewThread, ms-python.python/getPythonEnvironmentInfo, ms-python.python/getPythonExecutableCommand, ms-python.python/installPythonPackage, ms-python.python/configurePythonEnvironment, edit, search, web, 'pylance-mcp-server/*', todo]
 handoffs:
   - label: Escalate to Strategist
     agent: ChoreOps Strategist

--- a/.github/workflows/lint-validation.yaml
+++ b/.github/workflows/lint-validation.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff==0.15.16 mypy pytest pytest-asyncio pytest-homeassistant-custom-component
+          pip install ruff==0.16.3 mypy pytest pytest-asyncio pytest-homeassistant-custom-component
           pip install types-python-dateutil types-PyYAML
 
       - name: Brand regression guard

--- a/custom_components/choreops/engines/chore_engine.py
+++ b/custom_components/choreops/engines/chore_engine.py
@@ -533,6 +533,8 @@ class ChoreEngine:
         if resolved_state == const.CHORE_STATE_STANDBY:
             if lock_reason == const.CHORE_STATE_STANDBY:
                 return (False, const.TRANS_KEY_ERROR_CHORE_STANDBY)
+            if lock_reason == const.CHORE_STATE_WAITING:
+                return (False, const.TRANS_KEY_ERROR_CHORE_WAITING)
             # lock_reason is None → allow claim, fall through
 
         # Check multi-claim allowed
@@ -762,6 +764,25 @@ class ChoreEngine:
                     completion_criteria
                     == const.COMPLETION_CRITERIA_ROTATION_PRIMARY_STANDBY
                 ):
+                    # Closed claim window blocks standbys too, regardless of
+                    # standby_claim_mode — the window gate outranks eligibility
+                    claim_lock_until_window = bool(
+                        chore_data.get(
+                            const.DATA_CHORE_CLAIM_LOCK_UNTIL_WINDOW,
+                            const.DEFAULT_CHORE_CLAIM_LOCK_UNTIL_WINDOW,
+                        )
+                    )
+                    if (
+                        claim_lock_until_window
+                        and due_window_start is not None
+                        and due_date is not None
+                        and now < due_window_start
+                    ):
+                        return (
+                            const.CHORE_STATE_STANDBY,
+                            const.CHORE_STATE_WAITING,
+                        )
+
                     standby_claim_mode = chore_data.get(
                         const.DATA_CHORE_STANDBY_CLAIM_MODE,
                         const.STANDBY_CLAIM_MODE_ANYTIME,

--- a/custom_components/choreops/helpers/report_helpers.py
+++ b/custom_components/choreops/helpers/report_helpers.py
@@ -822,8 +822,10 @@ def _render_assignee_markdown(
         f"# {title}",
         translations["intro"].format(assignee_heading=assignee_heading),
         translations["section_weekly_summary"],
-        f"- {translations['range_label']}: "
-        f"{translations['range_short'].format(start_date=start_short, end_date=end_short)}",
+        (
+            f"- {translations['range_label']}: "
+            f"{translations['range_short'].format(start_date=start_short, end_date=end_short)}"
+        ),
         f"- {translations['completed_chores_week']}: {completed_chores}",
         f"- {translations['avg_points_per_day']}: {avg_points_per_day}",
         f"- {translations['avg_chores_per_day']}: {avg_chores_per_day}",
@@ -840,8 +842,10 @@ def _render_assignee_markdown(
         ),
         best_day_line,
         translations["section_daily_activity"],
-        f"{translations['range_label']}: "
-        f"{translations['range_short'].format(start_date=start_short, end_date=end_short)}",
+        (
+            f"{translations['range_label']}: "
+            f"{translations['range_short'].format(start_date=start_short, end_date=end_short)}"
+        ),
     ]
 
     if not daily_blocks:

--- a/custom_components/choreops/managers/chore_manager.py
+++ b/custom_components/choreops/managers/chore_manager.py
@@ -177,6 +177,10 @@ class ChoreManager(BaseManager):
         ] = {}
         self._max_due_cache_entries = 2048
         self._pending_overdue_resolution_signals: list[dict[str, Any]] = []
+        self._pending_overdue_signals: list[dict[str, Any]] = []
+        self._pending_boundary_rotation_payloads: list[dict[str, Any]] = []
+        self._pending_boundary_reset_events: set[tuple[str, str, str]] = set()
+        self._pending_boundary_approval_plans: list[ApprovalSignalPlan] = []
 
     async def async_setup(self) -> None:
         """Set up the ChoreManager.
@@ -454,6 +458,7 @@ class ChoreManager(BaseManager):
                 try:
                     self._coordinator._persist()
                     self._coordinator.async_set_updated_data(self._coordinator._data)
+                    self._flush_pending_boundary_signals()
                 except Exception:
                     const.LOGGER.exception(
                         "ChoreManager: Critical - failed to persist midnight changes"
@@ -532,6 +537,7 @@ class ChoreManager(BaseManager):
                 try:
                     self._coordinator._persist()
                     self._coordinator.async_set_updated_data(self._coordinator._data)
+                    self._flush_pending_boundary_signals()
                 except Exception:
                     const.LOGGER.exception(
                         "ChoreManager: Critical - failed to persist periodic changes"
@@ -1260,6 +1266,13 @@ class ChoreManager(BaseManager):
                     reset_decision == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
                 )
 
+            if (
+                should_reschedule_chore
+                and not should_clear_due_date_after_immediate_reset
+            ):
+                # Reschedule before transitions (midnight-flash invariant)
+                self._reschedule_chore_due(chore_id)
+
             for reset_assignee_id in reset_targets:
                 self._apply_reset_action(
                     {
@@ -1274,12 +1287,6 @@ class ChoreManager(BaseManager):
 
             if reset_targets:
                 self._update_global_state(chore_id)
-
-            if (
-                should_reschedule_chore
-                and not should_clear_due_date_after_immediate_reset
-            ):
-                self._reschedule_chore_due(chore_id)
 
             if reset_targets and is_rotation_mode:
                 rotation_signal_payload = self._advance_rotation(
@@ -1677,8 +1684,18 @@ class ChoreManager(BaseManager):
             "pending_claim_action": pending_claim_action,
         }
 
-    def _apply_reset_action(self, context: ResetApplyContext) -> None:
-        """Apply reset side effects for a single assignee/chore pair."""
+    def _apply_reset_action(
+        self,
+        context: ResetApplyContext,
+        *,
+        persist: bool = True,
+    ) -> dict[str, Any] | None:
+        """Apply reset side effects for a single assignee/chore pair.
+
+        Returns:
+            Rotation signal payload when rotation advanced (emit after persist
+            when persist=False), else None.
+        """
         assignee_id = context["assignee_id"]
         chore_id = context["chore_id"]
         decision = context["decision"]
@@ -1686,26 +1703,28 @@ class ChoreManager(BaseManager):
         allow_reschedule = context.get("allow_reschedule", True)
         clear_due_date = context.get("clear_due_date", False)
 
+        # Reschedule/clear the due date BEFORE the state transition so no
+        # observer can see a cleared claim paired with the previous cycle's
+        # due date (FSM P5 would derive a transient overdue — midnight flash).
         if clear_due_date:
             self._clear_due_date_after_reset(
                 chore_id,
                 assignee_id if allow_reschedule else None,
             )
+        elif (
+            allow_reschedule
+            and decision == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
+        ):
+            self._reschedule_chore_due(chore_id, reschedule_assignee_id)
 
-        self._transition_chore_state(
+        return self._transition_chore_state(
             assignee_id,
             chore_id,
             const.CHORE_STATE_PENDING,
             reset_approval_period=True,
             clear_ownership=True,
+            persist=persist,
         )
-
-        if (
-            not clear_due_date
-            and allow_reschedule
-            and decision == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
-        ):
-            self._reschedule_chore_due(chore_id, reschedule_assignee_id)
 
     def _clear_due_date_after_reset(
         self,
@@ -1754,17 +1773,25 @@ class ChoreManager(BaseManager):
         persist: bool,
         reset_count: int,
         rotation_payloads: list[dict[str, Any]] | None,
+        reset_events: set[tuple[str, str, str]] | None = None,
     ) -> None:
-        """Finalize reset batch with persist/update and deferred signal emit."""
+        """Finalize reset batch: single persist, then all deferred signals."""
         if not persist or reset_count <= 0:
             return
 
         self._coordinator._persist()
         self._coordinator.async_set_updated_data(self._coordinator._data)
+        self._flush_overdue_resolution_signals()
 
-        if rotation_payloads:
-            for payload in rotation_payloads:
-                self.emit(const.SIGNAL_SUFFIX_CHORE_ROTATION_ADVANCED, **payload)
+        for payload in rotation_payloads or []:
+            self.emit(const.SIGNAL_SUFFIX_CHORE_ROTATION_ADVANCED, **payload)
+        for assignee_id, chore_id, chore_name in sorted(reset_events or set()):
+            self.emit(
+                const.SIGNAL_SUFFIX_CHORE_STATUS_RESET,
+                user_id=assignee_id,
+                chore_id=chore_id,
+                chore_name=chore_name,
+            )
 
     @staticmethod
     def _decide_reset_action(context: ResetContext) -> ResetDecision:
@@ -2246,15 +2273,15 @@ class ChoreManager(BaseManager):
 
         # === BATCH PERSIST (Phase 1) ===
         # Write once after all changes (O(n) → O(1) disk writes)
+        # Signals emit only AFTER persist (Persist→Emit pattern); with
+        # persist=False they queue for the caller's post-persist flush
         if persist and marked_count > 0:
             self._coordinator._persist()
             self._coordinator.async_set_updated_data(self._coordinator._data)
-
-        # === BATCH EMIT SIGNALS (Phase 1) ===
-        # Emit signals AFTER persist to comply with Persist→Emit pattern
-        # StatisticsManager._on_chore_overdue handles cache refresh and entity notification
-        for signal_data in signals_to_emit:
-            self.emit(const.SIGNAL_SUFFIX_CHORE_OVERDUE, **signal_data)
+            for signal_data in signals_to_emit:
+                self.emit(const.SIGNAL_SUFFIX_CHORE_OVERDUE, **signal_data)
+        elif not persist:
+            self._pending_overdue_signals.extend(signals_to_emit)
 
     def _process_due_window(self, entries: list[ChoreTimeEntry]) -> None:
         """Process due window entries and emit signals.
@@ -2387,12 +2414,12 @@ class ChoreManager(BaseManager):
         reset_pairs: set[tuple[str, str]] = set()
         rotation_payloads: list[dict[str, Any]] = []
         approval_signal_plans: list[ApprovalSignalPlan] = []
+        reset_events: set[tuple[str, str, str]] = set()
 
         # Process SHARED/SHARED_FIRST chores
         for entry in scan.get(const.CHORE_SCAN_RESULT_APPROVAL_RESET_SHARED, []):
             chore_id = entry["chore_id"]
             chore_info = entry["chore_info"]
-            should_reschedule_shared = False
             shared_plans: list[BoundaryResetPlan] = []
 
             # Reset all assigned assignees
@@ -2443,22 +2470,29 @@ class ChoreManager(BaseManager):
                     if (plan.assignee_id, plan.chore_id) in applied_pairs:
                         plan.assignee_state = const.CHORE_STATE_APPROVED
 
+            # Reschedule BEFORE transitions (same invariant as _apply_reset_action)
+            should_reschedule_shared = any(
+                not plan.should_clear_due_date
+                and not plan.allow_reschedule
+                and plan.effective_decision
+                == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
+                for plan in shared_plans
+            )
+            if should_reschedule_shared:
+                self._reschedule_chore_due(chore_id)
+
             for plan in shared_plans:
-                reset_applied, should_reschedule = self._execute_boundary_reset_plan(
+                reset_applied = self._execute_boundary_reset_plan(
                     plan,
                     rotation_payloads,
+                    persist=persist,
+                    reset_events=reset_events,
                 )
                 if not reset_applied:
                     continue
 
-                if should_reschedule:
-                    should_reschedule_shared = True
-
                 reset_count += 1
                 reset_pairs.add((plan.assignee_id, plan.chore_id))
-
-            if should_reschedule_shared:
-                self._reschedule_chore_due(chore_id)
 
         # Process INDEPENDENT chores
         for entry in scan.get(const.CHORE_SCAN_RESULT_APPROVAL_RESET_INDEPENDENT, []):
@@ -2507,9 +2541,11 @@ class ChoreManager(BaseManager):
                     if (plan.assignee_id, plan.chore_id) in applied_pairs:
                         plan.assignee_state = const.CHORE_STATE_APPROVED
 
-                reset_applied, _ = self._execute_boundary_reset_plan(
+                reset_applied = self._execute_boundary_reset_plan(
                     plan,
                     rotation_payloads,
+                    persist=persist,
+                    reset_events=reset_events,
                 )
 
                 if not reset_applied:
@@ -2525,12 +2561,19 @@ class ChoreManager(BaseManager):
                 reset_count,
             )
 
-        self._finalize_reset_batch(
-            persist=persist,
-            reset_count=reset_count,
-            rotation_payloads=rotation_payloads,
-        )
-        self._emit_approval_signal_plans(approval_signal_plans)
+        if persist:
+            self._finalize_reset_batch(
+                persist=persist,
+                reset_count=reset_count,
+                rotation_payloads=rotation_payloads,
+                reset_events=reset_events,
+            )
+            self._emit_approval_signal_plans(approval_signal_plans)
+        else:
+            # Caller owns the persist; queue all signals for post-persist emit
+            self._queue_boundary_signals(
+                rotation_payloads, reset_events, approval_signal_plans
+            )
 
         return reset_count, reset_pairs
 
@@ -2715,8 +2758,15 @@ class ChoreManager(BaseManager):
         self,
         plan: BoundaryResetPlan,
         rotation_payloads: list[dict[str, Any]],
-    ) -> tuple[bool, bool]:
-        """Execute boundary reset side effects for a prepared plan."""
+        *,
+        persist: bool = True,
+        reset_events: set[tuple[str, str, str]] | None = None,
+    ) -> bool:
+        """Execute boundary reset side effects for a prepared plan.
+
+        Returns:
+            True if the reset was applied.
+        """
         assignee_id = plan.assignee_id
         chore_id = plan.chore_id
         chore_info = plan.chore_info
@@ -2770,7 +2820,7 @@ class ChoreManager(BaseManager):
                 if rotation_payload:
                     rotation_payloads.append(rotation_payload)
 
-        self._apply_reset_action(
+        rotation_payload = self._apply_reset_action(
             {
                 "assignee_id": assignee_id,
                 "chore_id": chore_id,
@@ -2778,15 +2828,20 @@ class ChoreManager(BaseManager):
                 "reschedule_assignee_id": plan.reschedule_assignee_id,
                 "allow_reschedule": plan.allow_reschedule,
                 "clear_due_date": plan.should_clear_due_date,
-            }
+            },
+            persist=persist,
         )
-
-        should_reschedule_shared = (
-            not plan.should_clear_due_date
-            and not plan.allow_reschedule
-            and effective_decision == const.CHORE_RESET_DECISION_RESET_AND_RESCHEDULE
-        )
-        return True, should_reschedule_shared
+        if rotation_payload is not None:
+            rotation_payloads.append(rotation_payload)
+        if reset_events is not None:
+            reset_events.add(
+                (
+                    assignee_id,
+                    chore_id,
+                    str(chore_info.get(const.DATA_CHORE_NAME, "")),
+                )
+            )
+        return True
 
     def _resolve_approval_effective_date_iso(
         self,
@@ -4876,6 +4931,44 @@ class ChoreManager(BaseManager):
                 **signal_data,
             )
 
+    def _queue_boundary_signals(
+        self,
+        rotation_payloads: list[dict[str, Any]],
+        reset_events: set[tuple[str, str, str]],
+        approval_signal_plans: list[ApprovalSignalPlan],
+    ) -> None:
+        """Queue boundary signals for emission after the caller's persist."""
+        self._pending_boundary_rotation_payloads.extend(rotation_payloads)
+        self._pending_boundary_reset_events.update(reset_events)
+        self._pending_boundary_approval_plans.extend(approval_signal_plans)
+
+    def _flush_pending_boundary_signals(self) -> None:
+        """Emit queued boundary signals. MUST be called after persist."""
+        rotation_payloads = self._pending_boundary_rotation_payloads
+        reset_events = self._pending_boundary_reset_events
+        approval_plans = self._pending_boundary_approval_plans
+        self._pending_boundary_rotation_payloads = []
+        self._pending_boundary_reset_events = set()
+        self._pending_boundary_approval_plans = []
+
+        for payload in rotation_payloads:
+            self.emit(const.SIGNAL_SUFFIX_CHORE_ROTATION_ADVANCED, **payload)
+        for assignee_id, chore_id, chore_name in sorted(reset_events):
+            self.emit(
+                const.SIGNAL_SUFFIX_CHORE_STATUS_RESET,
+                user_id=assignee_id,
+                chore_id=chore_id,
+                chore_name=chore_name,
+            )
+        self._emit_approval_signal_plans(approval_plans)
+
+        # Overdue signals deferred by _process_overdue(persist=False) share
+        # this post-persist flush point
+        overdue_signals = self._pending_overdue_signals
+        self._pending_overdue_signals = []
+        for signal_data in overdue_signals:
+            self.emit(const.SIGNAL_SUFFIX_CHORE_OVERDUE, **signal_data)
+
     def _transition_chore_state(
         self,
         assignee_id: str,
@@ -4886,7 +4979,7 @@ class ChoreManager(BaseManager):
         clear_ownership: bool = False,
         emit: bool = True,
         persist: bool = True,
-    ) -> None:
+    ) -> dict[str, Any] | None:
         """Master method for chore state transitions.
 
         This is THE single source of truth for changing a chore's state.
@@ -4903,6 +4996,11 @@ class ChoreManager(BaseManager):
             clear_ownership: If True, clears claimed_by and completed_by (for fresh cycle)
             emit: If True (default), emits CHORE_STATUS_RESET signal when → PENDING
             persist: If True (default), persists and updates coordinator data
+
+        Returns:
+            Rotation-advanced signal payload when rotation advanced, else None.
+            With persist=True the payload is emitted internally; with
+            persist=False the caller MUST emit it after its own persist.
         """
         # Phase 4 Guard Rail: Track modification
         self._track_state_modification(assignee_id, chore_id)
@@ -4911,7 +5009,7 @@ class ChoreManager(BaseManager):
         chore_info = self._coordinator.chores_data.get(chore_id)
 
         if not assignee_info or not chore_info:
-            return
+            return None
 
         # Landlord duty: Ensure periods structures exist before statistics writes
         self._ensure_assignee_structures(assignee_id, chore_id)
@@ -5029,6 +5127,8 @@ class ChoreManager(BaseManager):
                 )
 
             self._coordinator.async_set_updated_data(self._coordinator._data)
+
+        return rotation_signal_payload
 
     def _validate_assignee_and_chore(self, assignee_id: str, chore_id: str) -> None:
         """Validate assignee and chore exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ asyncio_default_fixture_loop_scope = "function"
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
 [tool.ruff]
-required-version = "==0.15.16"
+required-version = "==0.16.3"
 target-version = "py313"
 line-length = 88
 

--- a/tests/AGENT_TESTING_USAGE_GUIDE.md
+++ b/tests/AGENT_TESTING_USAGE_GUIDE.md
@@ -186,7 +186,9 @@ await hass.services.async_call("button", "press", {"entity_id": button_id})  # �
 
 # Solution: Add user context
 context = Context(user_id=mock_hass_users["approver1"].id)
-await hass.services.async_call("button", "press", {"entity_id": button_id}, context=context)  # ✅ Correct
+await hass.services.async_call(
+    "button", "press", {"entity_id": button_id}, context=context
+)  # ✅ Correct
 ```
 
 ### Troubleshooting Steps (3-Attempt Rule)

--- a/tests/AGENT_TEST_CREATION_INSTRUCTIONS.md
+++ b/tests/AGENT_TEST_CREATION_INSTRUCTIONS.md
@@ -168,25 +168,33 @@ result = await hass.config_entries.options.async_configure(
 ```python
 from tests.helpers import (
     # Setup
-    setup_from_yaml, SetupResult,
-
+    setup_from_yaml,
+    SetupResult,
     # Constants - Chore states
-    CHORE_STATE_PENDING, CHORE_STATE_CLAIMED, CHORE_STATE_APPROVED,
-    CHORE_STATE_COMPLETED_BY_OTHER, CHORE_STATE_OVERDUE,
-
+    CHORE_STATE_PENDING,
+    CHORE_STATE_CLAIMED,
+    CHORE_STATE_APPROVED,
+    CHORE_STATE_COMPLETED_BY_OTHER,
+    CHORE_STATE_OVERDUE,
     # Constants - Sensor attributes
-    ATTR_CHORE_CLAIM_BUTTON_ENTITY_ID, ATTR_CHORE_APPROVE_BUTTON_ENTITY_ID,
-    ATTR_GLOBAL_STATE, ATTR_CAN_CLAIM, ATTR_CAN_APPROVE, ATTR_DUE_DATE,
-
+    ATTR_CHORE_CLAIM_BUTTON_ENTITY_ID,
+    ATTR_CHORE_APPROVE_BUTTON_ENTITY_ID,
+    ATTR_GLOBAL_STATE,
+    ATTR_CAN_CLAIM,
+    ATTR_CAN_APPROVE,
+    ATTR_DUE_DATE,
     # Constants - Completion criteria
-    COMPLETION_CRITERIA_INDEPENDENT, COMPLETION_CRITERIA_SHARED,
+    COMPLETION_CRITERIA_INDEPENDENT,
+    COMPLETION_CRITERIA_SHARED,
     COMPLETION_CRITERIA_SHARED_FIRST,
-
     # Constants - Data keys
-    DATA_KID_CHORE_DATA, DATA_KID_CHORE_DATA_STATE, DATA_KID_POINTS,
-
+    DATA_KID_CHORE_DATA,
+    DATA_KID_CHORE_DATA_STATE,
+    DATA_KID_POINTS,
     # Workflows
-    get_dashboard_helper, find_chore, get_chore_buttons,
+    get_dashboard_helper,
+    find_chore,
+    get_chore_buttons,
 )
 ```
 
@@ -207,6 +215,7 @@ Modern tests load scenarios from YAML files and run through the full config flow
 ```python
 from tests.helpers.setup import setup_from_yaml, SetupResult
 
+
 @pytest.fixture
 async def scenario_minimal(
     hass: HomeAssistant,
@@ -223,15 +232,17 @@ async def scenario_minimal(
 ### SetupResult provides:
 
 ```python
-result = await setup_from_yaml(hass, mock_hass_users, "tests/scenarios/scenario_minimal.yaml")
+result = await setup_from_yaml(
+    hass, mock_hass_users, "tests/scenarios/scenario_minimal.yaml"
+)
 
 # Access coordinator directly
 coordinator = result.coordinator
 
 # Get internal IDs by name
-assignee_id = result.assignee_ids["Zoë"]           # UUID for Zoë
+assignee_id = result.assignee_ids["Zoë"]  # UUID for Zoë
 chore_id = result.chore_ids["Make bed"]  # UUID for Make bed chore
-approver_id = result.approver_ids["Mom"]     # UUID for Mom
+approver_id = result.approver_ids["Mom"]  # UUID for Mom
 
 # Config entry
 config_entry = result.config_entry
@@ -256,11 +267,15 @@ config_entry = result.config_entry
 ```python
 # Test as a assignee - can verify assignees CANNOT approve their own chores
 assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
-await hass.services.async_call("button", "press", {"entity_id": claim_btn}, context=assignee_context)
+await hass.services.async_call(
+    "button", "press", {"entity_id": claim_btn}, context=assignee_context
+)
 
 # Test as a approver - can verify approvers CAN approve chores
 approver_context = Context(user_id=mock_hass_users["approver1"].id)
-await hass.services.async_call("button", "press", {"entity_id": approve_btn}, context=approver_context)
+await hass.services.async_call(
+    "button", "press", {"entity_id": approve_btn}, context=approver_context
+)
 ```
 
 **Service calls ALWAYS run as admin**:
@@ -274,7 +289,9 @@ await hass.services.async_call("assigneeschores", "approve_chore", {...})
 
 ```python
 # ❌ FORBIDDEN for workflow tests - bypasses everything
-coordinator.claim_chore(assignee_id, chore_id, "Zoë")  # No user context, no button, no security
+coordinator.claim_chore(
+    assignee_id, chore_id, "Zoë"
+)  # No user context, no button, no security
 ```
 
 ### Approach A: Button Press with User Context (REQUIRED for workflow tests)
@@ -283,6 +300,7 @@ coordinator.claim_chore(assignee_id, chore_id, "Zoë")  # No user context, no bu
 
 ```python
 from homeassistant.core import Context
+
 
 async def test_claim_via_button(hass, scenario_minimal, mock_hass_users):
     # Get dashboard helper - the single source of truth for entity IDs
@@ -300,9 +318,11 @@ async def test_claim_via_button(hass, scenario_minimal, mock_hass_users):
     # Press button with user context (simulates real user action)
     assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
     await hass.services.async_call(
-        "button", "press",
+        "button",
+        "press",
         {"entity_id": claim_button_eid},
-        blocking=True, context=assignee_context,
+        blocking=True,
+        context=assignee_context,
     )
     await hass.async_block_till_done()
 
@@ -327,7 +347,8 @@ When a button entity doesn't exist for an action, use defined services from `ser
 async def test_approve_via_service(hass, scenario_minimal):
     # Service calls always run as admin - cannot test authorization
     await hass.services.async_call(
-        "assigneeschores", "approve_chore",
+        "assigneeschores",
+        "approve_chore",
         {
             "config_entry_id": scenario_minimal.entry.entry_id,
             "chore_name": "Make bed",
@@ -415,9 +436,11 @@ claim_button_eid = chore_state.attributes[ATTR_CHORE_CLAIM_BUTTON_ENTITY_ID]
 # Press button WITH user context to test real user flow
 assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
 await hass.services.async_call(
-    "button", "press",
+    "button",
+    "press",
     {"entity_id": claim_button_eid},
-    blocking=True, context=assignee_context,
+    blocking=True,
+    context=assignee_context,
 )
 ```
 
@@ -426,8 +449,13 @@ await hass.services.async_call(
 ```python
 # Service calls are acceptable but cannot test authorization
 await hass.services.async_call(
-    "assigneeschores", "approve_chore",
-    {"config_entry_id": entry.entry_id, "chore_name": "Make bed", "assignee_name": "Zoë"},
+    "assigneeschores",
+    "approve_chore",
+    {
+        "config_entry_id": entry.entry_id,
+        "chore_name": "Make bed",
+        "assignee_name": "Zoë",
+    },
     blocking=True,
 )
 ```
@@ -450,9 +478,7 @@ chore_info[const.DATA_CHORE_PER_KID_APPLICABLE_DAYS] = {
 }
 
 # ✅ PROPER APPROACH - Goes through flow
-result = await hass.config_entries.options.async_configure(
-    flow_id, user_input={...}
-)
+result = await hass.config_entries.options.async_configure(flow_id, user_input={...})
 ```
 
 **Why this matters:**
@@ -488,8 +514,8 @@ helper_attrs = helper_state.attributes
 # Chores (sensor entity IDs)
 chores_list = helper_attrs.get("chores", [])
 for chore in chores_list:
-    chore_eid = chore["eid"]        # sensor.kc_zoe_chore_status_make_bed
-    chore_name = chore["name"]      # "Make bed"
+    chore_eid = chore["eid"]  # sensor.kc_zoe_chore_status_make_bed
+    chore_name = chore["name"]  # "Make bed"
     chore_status = chore["status"]  # "pending", "claimed", "approved"
     can_claim = chore["can_claim"]  # True/False
     can_approve = chore["can_approve"]
@@ -544,17 +570,21 @@ from homeassistant.core import Context
 # Assignee claims chore
 assignee_context = Context(user_id=mock_hass_users["assignee1"].id)
 await hass.services.async_call(
-    "button", "press",
+    "button",
+    "press",
     {"entity_id": claim_button_eid},
-    blocking=True, context=assignee_context,
+    blocking=True,
+    context=assignee_context,
 )
 
 # Approver approves chore
 approver_context = Context(user_id=mock_hass_users["approver1"].id)
 await hass.services.async_call(
-    "button", "press",
+    "button",
+    "press",
     {"entity_id": approve_button_eid},
-    blocking=True, context=approver_context,
+    blocking=True,
+    context=approver_context,
 )
 ```
 
@@ -647,8 +677,12 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from tests.helpers import (
-    CHORE_STATE_PENDING, CHORE_STATE_CLAIMED, CHORE_STATE_APPROVED,
-    DATA_KID_CHORE_DATA, DATA_KID_CHORE_DATA_STATE, DATA_KID_POINTS,
+    CHORE_STATE_PENDING,
+    CHORE_STATE_CLAIMED,
+    CHORE_STATE_APPROVED,
+    DATA_KID_CHORE_DATA,
+    DATA_KID_CHORE_DATA_STATE,
+    DATA_KID_POINTS,
 )
 from tests.helpers.setup import setup_from_yaml, SetupResult
 
@@ -660,7 +694,8 @@ async def scenario_minimal(
 ) -> SetupResult:
     """Load minimal scenario."""
     return await setup_from_yaml(
-        hass, mock_hass_users,
+        hass,
+        mock_hass_users,
         "tests/scenarios/scenario_minimal.yaml",
     )
 
@@ -687,16 +722,26 @@ class TestChoreWorkflow:
         assignee_id = scenario_minimal.assignee_ids["Zoë"]
         chore_id = scenario_minimal.chore_ids["Make bed"]  # 5 points
 
-        initial_points = coordinator.assignees_data[assignee_id].get(DATA_KID_POINTS, 0.0)
+        initial_points = coordinator.assignees_data[assignee_id].get(
+            DATA_KID_POINTS, 0.0
+        )
 
-        with patch.object(coordinator.notification_manager, "notify_assignee", new=AsyncMock()):
+        with patch.object(
+            coordinator.notification_manager, "notify_assignee", new=AsyncMock()
+        ):
             # Claim
             coordinator.claim_chore(assignee_id, chore_id, "Zoë")
-            assert get_assignee_chore_state(coordinator, assignee_id, chore_id) == CHORE_STATE_CLAIMED
+            assert (
+                get_assignee_chore_state(coordinator, assignee_id, chore_id)
+                == CHORE_STATE_CLAIMED
+            )
 
             # Approve
             coordinator.approve_chore("Mom", assignee_id, chore_id)
-            assert get_assignee_chore_state(coordinator, assignee_id, chore_id) == CHORE_STATE_APPROVED
+            assert (
+                get_assignee_chore_state(coordinator, assignee_id, chore_id)
+                == CHORE_STATE_APPROVED
+            )
 
         # Verify points
         final_points = coordinator.assignees_data[assignee_id].get(DATA_KID_POINTS, 0.0)
@@ -746,8 +791,10 @@ from homeassistant.core import HomeAssistant
 
 from tests.helpers import (
     # Import needed constants and helpers
-    CHORE_STATE_PENDING, CHORE_STATE_CLAIMED,
-    setup_from_yaml, SetupResult,
+    CHORE_STATE_PENDING,
+    CHORE_STATE_CLAIMED,
+    setup_from_yaml,
+    SetupResult,
 )
 
 
@@ -758,7 +805,8 @@ async def scenario_for_feature(
 ) -> SetupResult:
     """Load scenario optimized for this feature."""
     return await setup_from_yaml(
-        hass, mock_hass_users,
+        hass,
+        mock_hass_users,
         "tests/scenarios/scenario_minimal.yaml",  # Choose appropriate scenario
     )
 

--- a/tests/SERVICE_TESTING_PATTERNS.md
+++ b/tests/SERVICE_TESTING_PATTERNS.md
@@ -36,7 +36,7 @@ async def test_create_reward_with_valid_data(hass, scenario_full):
         SERVICE_CREATE_REWARD,
         {
             "reward_name": "Test Reward",  # Must match SERVICE_FIELD_REWARD_NAME value
-            "reward_cost": 100.0,          # Must match SERVICE_FIELD_REWARD_COST value
+            "reward_cost": 100.0,  # Must match SERVICE_FIELD_REWARD_COST value
             "reward_description": "Test",  # Must match SERVICE_FIELD_REWARD_DESCRIPTION value
         },
         blocking=True,
@@ -62,7 +62,7 @@ async def test_create_reward_rejects_wrong_fields(hass, scenario_full):
             SERVICE_CREATE_REWARD,
             {
                 "name": "Test Reward",  # ❌ Wrong - schema expects "reward_name"
-                "cost": 100.0,          # ❌ Wrong - schema expects "reward_cost"
+                "cost": 100.0,  # ❌ Wrong - schema expects "reward_cost"
             },
             blocking=True,
         )
@@ -192,7 +192,7 @@ response = await hass.services.async_call(
     SERVICE_CREATE_REWARD,
     {
         SERVICE_FIELD_REWARD_NAME: "Test",  # ✅ Used constant
-        SERVICE_FIELD_REWARD_COST: 100.0,   # ✅ Used constant
+        SERVICE_FIELD_REWARD_COST: 100.0,  # ✅ Used constant
     },
     blocking=True,
     return_response=True,
@@ -227,8 +227,8 @@ async def test_create_reward_literal_field_names(hass, scenario_full):
         DOMAIN,
         SERVICE_CREATE_REWARD,
         {
-            "reward_name": "Literal Test",    # From services.yaml docs
-            "reward_cost": 100.0,             # From services.yaml docs
+            "reward_name": "Literal Test",  # From services.yaml docs
+            "reward_cost": 100.0,  # From services.yaml docs
             "reward_description": "Testing",  # From services.yaml docs
         },
         blocking=True,
@@ -290,7 +290,7 @@ class TestCreateRewardSchemaValidation:
                 "create_reward",
                 {
                     "name": "Test",  # Old field name
-                    "cost": 75.0,    # Old field name
+                    "cost": 75.0,  # Old field name
                 },
                 blocking=True,
             )

--- a/tests/scenarios/scenario_primary_standby.yaml
+++ b/tests/scenarios/scenario_primary_standby.yaml
@@ -91,3 +91,16 @@ chores:
     recurring_frequency: "daily"
     auto_approve: false
     standby_claim_mode: "anytime"
+
+  # ==========================================================================
+  # PRIMARY-STANDBY: anytime + closed claim window (Issue #271)
+  # Window lock fields are injected in-test (setup helper does not map them)
+  # ==========================================================================
+  - name: "Window Chore (anytime)"
+    assigned_to: ["Zoë", "Max!"]
+    points: 12.0
+    icon: "mdi:window-maximize"
+    completion_criteria: "rotation_primary_standby"
+    recurring_frequency: "daily"
+    auto_approve: false
+    standby_claim_mode: "anytime"

--- a/tests/test_rotation_primary_standby.py
+++ b/tests/test_rotation_primary_standby.py
@@ -24,6 +24,7 @@ from custom_components.choreops.utils.dt_utils import dt_now_utc
 # Import test constants from helpers (not from const.py - Rule 0)
 from tests.helpers.constants import (
     CHORE_CLAIM_MODE_BLOCKED_STANDBY,
+    CHORE_CLAIM_MODE_BLOCKED_WAITING_WINDOW,
     CHORE_CLAIM_MODE_CLAIMABLE,
     CHORE_CLAIM_MODE_STANDBY_AVAILABLE,
     CHORE_STATE_APPROVED,
@@ -598,3 +599,75 @@ async def test_multi_standby_rotates_when_primary_paused(
         assert (
             get_chore_state_from_sensor(hass, slug, chore_name) == CHORE_STATE_STANDBY
         )
+
+
+# =============================================================================
+# T12 — Issue #271: closed claim window blocks standby (anytime)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_closed_claim_window_blocks_standby_anytime(
+    hass: HomeAssistant,
+    scenario_primary_standby: SetupResult,
+    mock_hass_users: dict[str, Any],
+) -> None:
+    """Standby with anytime must be blocked while the claim window is closed.
+
+    Issue #271: the standby branch of the FSM returned before the waiting
+    check, so a standby with standby_claim_mode=anytime could claim a
+    primary-standby chore before the due window opened. The window gate must
+    outrank standby_claim_mode eligibility.
+    """
+    await hass.async_block_till_done()
+
+    chore_name = "Window Chore (anytime)"
+    coordinator = scenario_primary_standby.coordinator
+    chore_id = scenario_primary_standby.chore_ids[chore_name]
+
+    # Inject window-lock fields (setup helper does not map these YAML keys)
+    chore_info = coordinator.chores_data.get(chore_id, {})
+    chore_info["due_date"] = (dt_now_utc() + timedelta(hours=3)).isoformat()
+    chore_info["due_window_offset"] = "1h"
+    chore_info["chore_claim_lock_until_window"] = True
+    await coordinator.chore_manager._on_periodic_update(now_utc=dt_now_utc())
+    await hass.async_block_till_done()
+
+    # Primary sees waiting (window not open)
+    assert get_chore_state_from_sensor(hass, "zoe", chore_name) == CHORE_STATE_WAITING
+
+    # Standby keeps the standby display state but is blocked
+    max_attrs = get_chore_attributes_from_sensor(hass, "max", chore_name)
+    assert get_chore_state_from_sensor(hass, "max", chore_name) == CHORE_STATE_STANDBY
+    assert max_attrs.get("can_claim") is False
+    assert max_attrs.get("claim_mode") == CHORE_CLAIM_MODE_BLOCKED_WAITING_WINDOW
+    assert max_attrs.get("available_at") is not None
+
+    # Claim attempt is rejected at the service level
+    assignee_context = Context(user_id=mock_hass_users["assignee2"].id)
+    claim_result = await claim_chore(hass, "max", chore_name, context=assignee_context)
+    await hass.async_block_till_done()
+    assert claim_result.success is False, "Standby claim must be rejected pre-window"
+    assert get_chore_state_from_sensor(hass, "max", chore_name) == CHORE_STATE_STANDBY
+
+    # Open the window: due in 30m with a 1h offset → window opened 30m ago
+    chore_info = coordinator.chores_data.get(chore_id, {})
+    chore_info["due_date"] = (dt_now_utc() + timedelta(minutes=30)).isoformat()
+    await coordinator.chore_manager._on_periodic_update(now_utc=dt_now_utc())
+    await hass.async_block_till_done()
+
+    # Primary is now due; standby anytime is claimable again
+    assert get_chore_state_from_sensor(hass, "zoe", chore_name) == CHORE_STATE_DUE
+    max_attrs_after = get_chore_attributes_from_sensor(hass, "max", chore_name)
+    assert max_attrs_after.get("can_claim") is True
+    assert max_attrs_after.get("claim_mode") == CHORE_CLAIM_MODE_STANDBY_AVAILABLE
+
+    claim_result_after = await claim_chore(
+        hass, "max", chore_name, context=assignee_context
+    )
+    await hass.async_block_till_done()
+    assert claim_result_after.success, (
+        f"Standby should be able to claim after window opens: "
+        f"{claim_result_after.error}"
+    )
+    assert get_chore_state_from_sensor(hass, "max", chore_name) == CHORE_STATE_CLAIMED

--- a/tests/test_workflow_chores.py
+++ b/tests/test_workflow_chores.py
@@ -2775,3 +2775,310 @@ class TestEnhancedFrequencyWorkflows:
         assert max_chore is not None
         assert zoe_chore["state"] == const.CHORE_STATE_DUE
         assert max_chore["state"] == const.CHORE_STATE_WAITING
+
+
+# =============================================================================
+# MIDNIGHT RESET FLASH REGRESSION (boundary reset publish ordering)
+# =============================================================================
+
+
+class TestMidnightResetFlash:
+    """Boundary resets must never publish a transient overdue state.
+
+    Regression coverage for the midnight overdue→pending flash: the reset
+    leaf previously persisted/published after clearing the claim but before
+    rescheduling the due date, letting FSM P5 derive overdue from the stale
+    due date for one publish.
+    """
+
+    def _track_sensor_states(
+        self,
+        hass: HomeAssistant,
+        eid: str,
+        states: list[str],
+    ) -> Any:
+        """Record sensor state changes into the provided list."""
+        from homeassistant.helpers.event import async_track_state_change_event
+
+        def _record(event: Any) -> None:
+            new_state = event.data.get("new_state")
+            if new_state is not None:
+                states.append(str(new_state.state))
+
+        return async_track_state_change_event(hass, [eid], _record)
+
+    def _get_chore_eid(self, hass: HomeAssistant, chore_name: str) -> str:
+        """Resolve the chore status sensor entity ID via the dashboard helper."""
+        dashboard = get_dashboard_helper(hass, "zoe")
+        chore = find_chore(dashboard, chore_name)
+        assert chore is not None, f"Chore not found in dashboard: {chore_name}"
+        return str(chore["eid"])
+
+    @pytest.mark.asyncio
+    async def test_midnight_reset_auto_approve_pending_no_overdue_flash(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+        mock_hass_users: dict[str, Any],
+    ) -> None:
+        """Midnight reset of a claimed chore must never publish overdue."""
+        from custom_components.choreops import const
+
+        coordinator = scenario_minimal.coordinator
+        chore_name = "Make bed"
+        chore_id = scenario_minimal.chore_ids[chore_name]
+        assignee_id = scenario_minimal.assignee_ids["Zoë"]
+
+        chore_info = coordinator.chores_data.get(chore_id, {})
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+            const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+        )
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_PENDING_CLAIM_ACTION] = (
+            const.APPROVAL_RESET_PENDING_CLAIM_AUTO_APPROVE
+        )
+        chore_info[const.DATA_CHORE_DUE_DATE] = (
+            dt_now_utc() - timedelta(hours=1)
+        ).isoformat()
+        chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {
+            assignee_id: (dt_now_utc() - timedelta(hours=1)).isoformat()
+        }
+
+        await claim_chore(
+            hass,
+            "zoe",
+            chore_name,
+            Context(user_id=mock_hass_users["assignee1"].id),
+        )
+        await hass.async_block_till_done()
+        assert (
+            get_chore_state_from_sensor(hass, "zoe", chore_name) == CHORE_STATE_CLAIMED
+        )
+
+        states: list[str] = []
+        eid = self._get_chore_eid(hass, chore_name)
+        remove = self._track_sensor_states(hass, eid, states)
+        try:
+            await coordinator.chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+            await hass.async_block_till_done()
+        finally:
+            remove()
+
+        assert states[-1] == CHORE_STATE_PENDING
+        assert CHORE_STATE_OVERDUE not in states, (
+            f"Transient overdue published during midnight reset: {states}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_midnight_reset_preapproved_no_overdue_flash(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+        mock_hass_users: dict[str, Any],
+    ) -> None:
+        """Midnight reset of an approved chore must never publish overdue."""
+        from custom_components.choreops import const
+
+        coordinator = scenario_minimal.coordinator
+        chore_name = "Make bed"
+        chore_id = scenario_minimal.chore_ids[chore_name]
+        assignee_id = scenario_minimal.assignee_ids["Zoë"]
+
+        chore_info = coordinator.chores_data.get(chore_id, {})
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+            const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+        )
+        chore_info[const.DATA_CHORE_DUE_DATE] = (
+            dt_now_utc() - timedelta(hours=1)
+        ).isoformat()
+        chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {
+            assignee_id: (dt_now_utc() - timedelta(hours=1)).isoformat()
+        }
+
+        await claim_chore(
+            hass,
+            "zoe",
+            chore_name,
+            Context(user_id=mock_hass_users["assignee1"].id),
+        )
+        await hass.async_block_till_done()
+        await approve_chore(
+            hass,
+            "zoe",
+            chore_name,
+            Context(user_id=mock_hass_users["approver1"].id),
+        )
+        await hass.async_block_till_done()
+
+        states: list[str] = []
+        eid = self._get_chore_eid(hass, chore_name)
+        remove = self._track_sensor_states(hass, eid, states)
+        try:
+            await coordinator.chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+            await hass.async_block_till_done()
+        finally:
+            remove()
+
+        assert states[-1] == CHORE_STATE_PENDING
+        assert CHORE_STATE_OVERDUE not in states, (
+            f"Transient overdue published during midnight reset: {states}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_midnight_reset_hold_pending_stays_claimed(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+        mock_hass_users: dict[str, Any],
+    ) -> None:
+        """hold_pending keeps the claim through the midnight rollover."""
+        from custom_components.choreops import const
+
+        coordinator = scenario_minimal.coordinator
+        chore_name = "Make bed"
+        chore_id = scenario_minimal.chore_ids[chore_name]
+        assignee_id = scenario_minimal.assignee_ids["Zoë"]
+
+        chore_info = coordinator.chores_data.get(chore_id, {})
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+            const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+        )
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_PENDING_CLAIM_ACTION] = (
+            const.APPROVAL_RESET_PENDING_CLAIM_HOLD
+        )
+        chore_info[const.DATA_CHORE_DUE_DATE] = (
+            dt_now_utc() - timedelta(hours=1)
+        ).isoformat()
+        chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {
+            assignee_id: (dt_now_utc() - timedelta(hours=1)).isoformat()
+        }
+
+        await claim_chore(
+            hass,
+            "zoe",
+            chore_name,
+            Context(user_id=mock_hass_users["assignee1"].id),
+        )
+        await hass.async_block_till_done()
+
+        await coordinator.chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+        await hass.async_block_till_done()
+
+        assert (
+            get_chore_state_from_sensor(hass, "zoe", chore_name) == CHORE_STATE_CLAIMED
+        )
+
+    @pytest.mark.asyncio
+    async def test_midnight_rollover_single_persist_per_pass(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+        mock_hass_users: dict[str, Any],
+    ) -> None:
+        """One rollover pass with N resets performs exactly one persist."""
+        from custom_components.choreops import const
+
+        coordinator = scenario_minimal.coordinator
+        assignee_id = scenario_minimal.assignee_ids["Zoë"]
+
+        for chore_name in ("Make bed", "Brush teeth"):
+            chore_id = scenario_minimal.chore_ids[chore_name]
+            chore_info = coordinator.chores_data.get(chore_id, {})
+            chore_info[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+                const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+            )
+            chore_info[const.DATA_CHORE_DUE_DATE] = (
+                dt_now_utc() - timedelta(hours=1)
+            ).isoformat()
+            chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {
+                assignee_id: (dt_now_utc() - timedelta(hours=1)).isoformat()
+            }
+
+        await claim_chore(
+            hass,
+            "zoe",
+            "Make bed",
+            Context(user_id=mock_hass_users["assignee1"].id),
+        )
+        await hass.async_block_till_done()
+
+        persist_calls = 0
+        pipeline_persists = 0
+        original_persist = coordinator._persist
+
+        def _counting_persist() -> None:
+            nonlocal persist_calls, pipeline_persists
+            persist_calls += 1
+            import traceback
+
+            stack_names = [frame.name for frame in traceback.extract_stack()]
+            # Listener persists run eagerly inside the signal flush; the
+            # pipeline's own persist is the direct rollover finally-block call
+            if "_flush_pending_boundary_signals" not in stack_names:
+                pipeline_persists += 1
+            original_persist()
+
+        with patch.object(coordinator, "_persist", _counting_persist):
+            await coordinator.chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+            await hass.async_block_till_done()
+
+        assert pipeline_persists == 1, (
+            f"Expected exactly 1 pipeline persist per rollover pass, "
+            f"got {pipeline_persists}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_midnight_reset_signals_emit_after_settle(
+        self,
+        hass: HomeAssistant,
+        scenario_minimal: SetupResult,
+        mock_hass_users: dict[str, Any],
+    ) -> None:
+        """Reset signals arrive only when the sensor already shows pending."""
+        from custom_components.choreops import const
+
+        coordinator = scenario_minimal.coordinator
+        chore_name = "Make bed"
+        chore_id = scenario_minimal.chore_ids[chore_name]
+        assignee_id = scenario_minimal.assignee_ids["Zoë"]
+
+        chore_info = coordinator.chores_data.get(chore_id, {})
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_TYPE] = (
+            const.APPROVAL_RESET_AT_MIDNIGHT_ONCE
+        )
+        chore_info[const.DATA_CHORE_APPROVAL_RESET_PENDING_CLAIM_ACTION] = (
+            const.APPROVAL_RESET_PENDING_CLAIM_AUTO_APPROVE
+        )
+        chore_info[const.DATA_CHORE_DUE_DATE] = (
+            dt_now_utc() - timedelta(hours=1)
+        ).isoformat()
+        chore_info[const.DATA_CHORE_PER_ASSIGNEE_DUE_DATES] = {
+            assignee_id: (dt_now_utc() - timedelta(hours=1)).isoformat()
+        }
+
+        await claim_chore(
+            hass,
+            "zoe",
+            chore_name,
+            Context(user_id=mock_hass_users["assignee1"].id),
+        )
+        await hass.async_block_till_done()
+
+        observed: list[tuple[str, str]] = []
+        eid = self._get_chore_eid(hass, chore_name)
+
+        def _on_reset(payload: dict[str, Any]) -> None:
+            state = hass.states.get(eid)
+            observed.append(("reset", str(state.state) if state else "missing"))
+
+        coordinator.chore_manager.listen(
+            const.SIGNAL_SUFFIX_CHORE_STATUS_RESET, _on_reset
+        )
+
+        await coordinator.chore_manager._on_midnight_rollover(now_utc=dt_now_utc())
+        await hass.async_block_till_done()
+
+        assert observed, "Expected at least one reset signal"
+        for _, state_at_signal in observed:
+            assert state_at_signal == CHORE_STATE_PENDING, (
+                f"Reset signal observed while sensor showed {state_at_signal}"
+            )


### PR DESCRIPTION
## Summary

- Standby assignees in `rotation_primary_standby` chores could claim while the claim window was still closed (`standby_claim_mode: anytime` outranked the window gate), and dashboards showed the chore as actionable instead of greyed out. The FSM standby branch now applies the claim-window gate before standby eligibility, so a closed window blocks standbys regardless of claim mode.
- At the midnight approval reset, chores with pending claims (auto-approve-pending) or pre-approved completions briefly published `overdue` and then `pending` in the same second. The reset leaf persisted/published after clearing the claim but before rescheduling the due date, letting FSM P5 derive overdue from the stale due date. The due date is now always advanced before the state transition, and the deferred persist/signal batching contract is completed so each rollover pass performs exactly one persist with all signals emitted after it.

## Linked issue

- Closes #271
- Related: #234 (the previously-dropped midnight reset/rotation signals are the best candidate for the un-reproducible stale-rotation reports; this PR restores their emission on the deferred path)

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [x] Correct release-note label is applied for `.github/release.yml` categorization (`bug`)
- [x] Excluded triage or status labels have been removed before merge (none applied)
- [x] PR title is suitable for generated release notes

## Change type

- [x] Bug fix

## Scope

- [x] Integration logic/state

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/`
- [x] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards` (not needed: v1 dashboards already grey out on `can_claim === false` and map `blocked_waiting_window` to the Waiting label; standby group routing keys on the unchanged `standby` state)

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- [x] `./utils/quick_lint.sh --fix`
- [x] Targeted suite with rationale: `pytest tests/test_workflow_chores.py tests/test_rotation_primary_standby.py tests/test_chore_engine.py` (203 passed) — these files exercise the reset/approval/standby FSM paths this PR changes; full suite to run before release per maintainer workflow
- [x] `mypy --config-file mypy_quick.ini --explicit-package-bases custom_components/choreops` (zero errors)

## Documentation impact

- [x] No documentation updates needed

## Release notes

- [x] Release notes needed (summarize user-visible changes below)

- Release note summary: Standby users in primary-standby chores are now correctly blocked (greyed out) while the claim window is closed, even with "anytime" standby claiming. Fixed a midnight reset glitch where chores briefly showed as overdue before settling to pending.

## Breaking changes

- [x] No breaking changes

### Behavioral notes (non-breaking)

- With the standby fix, `on_overdue`/`manual_only` standbys show the "Waiting" status label (with unlock time) while the claim window is closed, instead of "Standby" — the temporal gate is the active blocker. State, group placement, and grey-out are unchanged.
- With the reset fix, a midnight reset whose new claim window is already open settles to `due` rather than `pending` (correct per FSM).
- Midnight rotation/reset signals now emit on the deferred path where they were previously dropped; consumers will see events they were missing.