### PR TITLE
fix(dashboard): repair preference coercion, override precedence, and recurring grouping

### DIFF
--- a/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-essential-v1.md
@@ -46,17 +46,13 @@
   - Allowed: `true`, `false`.
 
 - `pref_include_daily_recurring_in_today` (default: `true`)
-  - Keeps recurring daily chores in today groups.
+  - Keeps no-due-date recurring daily chores in today groups.
   - When `false`, those chores move to “other” grouping logic.
+  - Dated chores, overdue chores, and label-grouped chores are unaffected.
   - Allowed: `true`, `false`.
 
 - `pref_use_this_week_grouping` (default: `true`)
   - Shows a dedicated due-this-week group.
-  - Allowed: `true`, `false`.
-
-- `pref_include_weekly_recurring_in_this_week` (default: `true`)
-  - Keeps recurring weekly chores in this-week group.
-  - When `false`, those chores move to “other” grouping logic.
   - Allowed: `true`, `false`.
 
 ### Exclude Filters

--- a/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
@@ -59,7 +59,8 @@
 
 - `pref_exclude_blocked` (default: `false`)
   - Hides blocked-result chores.
-  - Adds `completed_by_other`, `not_my_turn`, and `missed` to the effective exclusion list.
+  - Adds `completed_by_other`, `not_my_turn`, `paused`, `missed`, and `standby` to the effective exclusion list.
+  - Claimable standbys (`can_claim`) are still shown; only standbys unavailable for claim are hidden.
 
 - `pref_exclude_states` (default: `[]`)
   - Excludes chores by state.

--- a/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-lite-v1.md
@@ -46,13 +46,11 @@
   - Allowed: `off`, `today`, `today_morning`.
 
 - `pref_include_daily_recurring_in_today` (default: `true`)
-  - Keeps recurring daily chores in today groups.
+  - Keeps no-due-date recurring daily chores in today groups.
+  - Dated chores, overdue chores, and label-grouped chores are unaffected.
 
 - `pref_use_this_week_grouping` (default: `true`)
   - Shows a due-this-week group.
-
-- `pref_include_weekly_recurring_in_this_week` (default: `true`)
-  - Keeps recurring weekly chores in the this-week group.
 
 ### Exclude Filters
 

--- a/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
@@ -93,7 +93,8 @@
 
 - `pref_exclude_blocked` (default: `false`)
   - Hides blocked-result chores.
-  - If set to `true`, `completed_by_other`, `not_my_turn`, and `missed` are automatically added to `pref_exclude_states` when missing.
+  - If set to `true`, `completed_by_other`, `not_my_turn`, `paused`, `missed`, and `standby` are automatically added to `pref_exclude_states` when missing.
+  - Claimable standbys (`can_claim`) are still shown; only standbys unavailable for claim are hidden.
   - Allowed: `true`, `false`.
 
 - `pref_exclude_states` (default: `[]`)

--- a/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-chores-standard-v1.md
@@ -75,17 +75,13 @@
   - Allowed: `off`, `today`, `today_morning`.
 
 - `pref_include_daily_recurring_in_today` (default: `true`)
-  - Keeps recurring daily chores in today groups.
+  - Keeps no-due-date recurring daily chores in today groups.
   - When `false`, those chores move to “other” grouping logic.
+  - Dated chores, overdue chores, and label-grouped chores are unaffected.
   - Allowed: `true`, `false`.
 
 - `pref_use_this_week_grouping` (default: `true`)
   - Shows a dedicated due-this-week group.
-  - Allowed: `true`, `false`.
-
-- `pref_include_weekly_recurring_in_this_week` (default: `true`)
-  - Keeps recurring weekly chores in this-week group.
-  - When `false`, those chores move to “other” grouping logic.
   - Allowed: `true`, `false`.
 
 ### Exclude Filters

--- a/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
@@ -86,17 +86,13 @@ Recommended ranges:
   - Allowed: `off`, `today`, `today_morning`.
 
 - `pref_include_daily_recurring_in_today` (default: `true`)
-  - Keeps recurring daily chores in today groups.
+  - Keeps no-due-date recurring daily chores in today groups.
   - When `false`, those chores move to “other” grouping logic.
+  - Dated chores, overdue chores, and label-grouped chores are unaffected.
   - Allowed: `true`, `false`.
 
 - `pref_use_this_week_grouping` (default: `true`)
   - Shows a dedicated due-this-week group.
-  - Allowed: `true`, `false`.
-
-- `pref_include_weekly_recurring_in_this_week` (default: `true`)
-  - Keeps recurring weekly chores in this-week group.
-  - When `false`, those chores move to “other” grouping logic.
   - Allowed: `true`, `false`.
 
 - `pref_exclude_completed` (default: `false`)

--- a/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-gamification-premier-v1.md
@@ -102,7 +102,8 @@ Recommended ranges:
 
 - `pref_exclude_blocked` (default: `false`)
   - Hides blocked-result chores.
-  - If set to `true`, `completed_by_other`, `not_my_turn`, and `missed` are automatically added to `pref_exclude_states` when missing.
+  - If set to `true`, `completed_by_other`, `not_my_turn`, `paused`, `missed`, and `standby` are automatically added to `pref_exclude_states` when missing.
+  - Claimable standbys (`can_claim`) are still shown; only standbys unavailable for claim are hidden.
   - Allowed: `true`, `false`.
 
 - `pref_exclude_states` (default: `[]`)
@@ -139,7 +140,8 @@ Recommended ranges:
 
 - `pref_exclude_blocked` (default: `false`)
   - Hides blocked-result chores.
-  - If set to `true`, `completed_by_other`, `not_my_turn`, and `missed` are automatically added to `pref_exclude_states` when missing.
+  - If set to `true`, `completed_by_other`, `not_my_turn`, `paused`, `missed`, and `standby` are automatically added to `pref_exclude_states` when missing.
+  - Claimable standbys (`can_claim`) are still shown; only standbys unavailable for claim are hidden.
   - Allowed: `true`, `false`.
 
 - `pref_exclude_states` (default: `[]`)

--- a/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
+++ b/custom_components/choreops/dashboards/preferences/user-kidschores-classic-v1.md
@@ -30,13 +30,11 @@
   - Show dedicated due-today groups.
   - Allowed: `true`, `false`.
 - `pref_include_daily_recurring_in_today` (default: `true`)
-  - Keep recurring daily chores in today group.
+  - Keep no-due-date recurring daily chores in today group.
+  - Dated chores, overdue chores, and label-grouped chores are unaffected.
   - Allowed: `true`, `false`.
 - `pref_use_this_week_grouping` (default: `true`)
   - Show dedicated due-this-week group.
-  - Allowed: `true`, `false`.
-- `pref_include_weekly_recurring_in_this_week` (default: `true`)
-  - Keep recurring weekly chores in this-week group.
   - Allowed: `true`, `false`.
 
 ### Exclude Filters

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
@@ -69,25 +69,7 @@
   {%- endif -%}
 {%- endfor -%}
 {%- set pref_exclude_group_list = ns_valid_exclude_groups.items -%}
-{%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
-  {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
-{%- endif -%}
 {%- set pref_exclude_blocked = (pref_exclude_blocked | default('false') | string | lower) == 'true' -%}
-{%- if pref_exclude_blocked and 'completed_by_other' not in pref_exclude_states -%}
-  {%- set pref_exclude_states = pref_exclude_states + ['completed_by_other'] -%}
-{%- endif -%}
-{%- if pref_exclude_blocked and 'not_my_turn' not in pref_exclude_states -%}
-  {%- set pref_exclude_states = pref_exclude_states + ['not_my_turn'] -%}
-{%- endif -%}
-{%- if pref_exclude_blocked and 'missed' not in pref_exclude_states -%}
-  {%- set pref_exclude_states = pref_exclude_states + ['missed'] -%}
-{%- endif -%}
-{%- if pref_exclude_blocked and 'paused' not in pref_exclude_states -%}
-  {%- set pref_exclude_states = pref_exclude_states + ['paused'] -%}
-{%- endif -%}
-{%- if pref_exclude_blocked and 'standby' not in pref_exclude_states -%}
-  {%- set pref_exclude_states = pref_exclude_states + ['standby'] -%}
-{%- endif -%}
 {%- set pref_use_label_grouping = (pref_use_label_grouping | default('false') | string | lower) == 'true' -%}
 {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable and pref_exclude_label_list is not string else [] -%}
 {%- set pref_exclude_label_list = pref_exclude_label_list | map('lower') | list -%}
@@ -261,6 +243,12 @@
   {%- endif -%}
   {%- if exclude_blocked_effective and 'missed' not in effective_exclude_states -%}
     {%- set effective_exclude_states = effective_exclude_states + ['missed'] -%}
+  {%- endif -%}
+  {%- if exclude_blocked_effective and 'paused' not in effective_exclude_states -%}
+    {%- set effective_exclude_states = effective_exclude_states + ['paused'] -%}
+  {%- endif -%}
+  {%- if exclude_blocked_effective and 'standby' not in effective_exclude_states -%}
+    {%- set effective_exclude_states = effective_exclude_states + ['standby'] -%}
   {%- endif -%}
   {%- set chore_row_template_name = 'chore_row_kids_v1' if effective_row_variant == 'kids' else 'chore_row_v1' -%}
   {%- set integration_entry_id = state_attr(dashboard_helper, 'integration_entry_id') -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
@@ -51,7 +51,6 @@
 {%- endif -%}
 {%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default(true, true) | string | lower) == 'true' -%}
 {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default(true, true) | string | lower) == 'true' -%}
-{%- set pref_include_weekly_recurring_in_this_week = (pref_include_weekly_recurring_in_this_week | default(true, true) | string | lower) == 'true' -%}
 {%- set pref_use_standby_grouping = (pref_use_standby_grouping | default(true) | string | lower) == 'true' -%}
 {%- set pref_exclude_completed = (pref_exclude_completed | default(false, true) | string | lower) == 'true' -%}
 {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable and pref_exclude_states is not string else [] -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/context_v1.yaml
@@ -42,20 +42,20 @@
     {%- set pref_column_count_kids = 1 -%}
   {%- endif -%}
 {%- endif -%}
-{%- set pref_use_overdue_grouping = (pref_use_overdue_grouping | default(true, true) | string | lower) == 'true' -%}
-{%- set pref_use_today_grouping = (pref_use_today_grouping | default(true, true) | string | lower) == 'true' -%}
-{%- set pref_use_today_am_grouping = (pref_use_today_am_grouping | default(true, true) | string | lower) == 'true' -%}
+{%- set pref_use_overdue_grouping = (pref_use_overdue_grouping | default('true') | string | lower) == 'true' -%}
+{%- set pref_use_today_grouping = (pref_use_today_grouping | default('true') | string | lower) == 'true' -%}
+{%- set pref_use_today_am_grouping = (pref_use_today_am_grouping | default('true') | string | lower) == 'true' -%}
 {%- set pref_today_grouping_mode = (pref_today_grouping_mode | default('', true) | string | lower) -%}
 {%- if pref_today_grouping_mode not in ['off', 'today', 'today_morning'] -%}
   {%- set pref_today_grouping_mode = 'today_morning' if pref_use_today_am_grouping else 'today' if pref_use_today_grouping else 'off' -%}
 {%- endif -%}
-{%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default(true, true) | string | lower) == 'true' -%}
-{%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default(true, true) | string | lower) == 'true' -%}
+{%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default('true') | string | lower) == 'true' -%}
+{%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
 {%- set pref_use_standby_grouping = (pref_use_standby_grouping | default(true) | string | lower) == 'true' -%}
-{%- set pref_exclude_completed = (pref_exclude_completed | default(false, true) | string | lower) == 'true' -%}
+{%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
 {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable and pref_exclude_states is not string else [] -%}
 {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
-{%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+{%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default('false') | string | lower) == 'true' -%}
 {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
 {%- if pref_max_due_date_days < 0 -%}
   {%- set pref_max_due_date_days = 0 -%}
@@ -72,7 +72,7 @@
 {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
   {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
 {%- endif -%}
-{%- set pref_exclude_blocked = (pref_exclude_blocked | default(false, true) | string | lower) == 'true' -%}
+{%- set pref_exclude_blocked = (pref_exclude_blocked | default('false') | string | lower) == 'true' -%}
 {%- if pref_exclude_blocked and 'completed_by_other' not in pref_exclude_states -%}
   {%- set pref_exclude_states = pref_exclude_states + ['completed_by_other'] -%}
 {%- endif -%}
@@ -88,7 +88,7 @@
 {%- if pref_exclude_blocked and 'standby' not in pref_exclude_states -%}
   {%- set pref_exclude_states = pref_exclude_states + ['standby'] -%}
 {%- endif -%}
-{%- set pref_use_label_grouping = (pref_use_label_grouping | default(false, true) | string | lower) == 'true' -%}
+{%- set pref_use_label_grouping = (pref_use_label_grouping | default('false') | string | lower) == 'true' -%}
 {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable and pref_exclude_label_list is not string else [] -%}
 {%- set pref_exclude_label_list = pref_exclude_label_list | map('lower') | list -%}
 {%- set pref_include_label_list = pref_include_label_list if pref_include_label_list is iterable and pref_include_label_list is not string else [] -%}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
@@ -75,8 +75,8 @@
 				{%- set ns.standby_buttons = ns.standby_buttons + [chore_sensor_id] -%}
 
 			{#-- Step 5: Handle recurring filters BEFORE primary_group logic (override primary_group assignment) --#}
-			{#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
-			{%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
+			{#-- Daily-recurring chores in the today bucket (dated or dateless) move to other when disabled --#}
+			{%- elif chore_primary_group == 'today' and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
 				{%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
 
 			{#-- Step 6: Categorize by primary_group (time-based) --#}

--- a/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
+++ b/custom_components/choreops/dashboards/templates/shared/chore_engine/prepare_groups_v1.yaml
@@ -75,12 +75,8 @@
 				{%- set ns.standby_buttons = ns.standby_buttons + [chore_sensor_id] -%}
 
 			{#-- Step 5: Handle recurring filters BEFORE primary_group logic (override primary_group assignment) --#}
-			{#-- If a chore is in 'today' group without specific date, it's daily recurring --#}
-			{%- elif chore_primary_group == 'today' and not pref_include_daily_recurring_in_today -%}
-				{%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
-
-			{#-- If a chore is in 'this_week' group without specific date, it's weekly recurring --#}
-			{%- elif chore_primary_group == 'this_week' and not pref_include_weekly_recurring_in_this_week -%}
+			{#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
+			{%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
 				{%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
 
 			{#-- Step 6: Categorize by primary_group (time-based) --#}

--- a/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
@@ -420,8 +420,8 @@ views:
                             {%- set ns.standby_buttons = ns.standby_buttons + [chore_sensor_id] -%}
 
                           {#-- Step 5: Handle recurring filters BEFORE primary_group logic (override primary_group assignment) --#}
-                          {#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
-                          {%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
+                          {#-- Daily-recurring chores in the today bucket (dated or dateless) move to other when disabled --#}
+                          {%- elif chore_primary_group == 'today' and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
                             {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
 
                           {#-- Step 6: Categorize by primary_group (time-based) --#}

--- a/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
@@ -274,18 +274,18 @@ views:
 
                   {#-- Type coercion for preferences --#}
                   {%- set pref_column_count = pref_column_count | int(default=2) -%}
-                  {%- set pref_use_overdue_grouping = pref_use_overdue_grouping | default(true, true) -%}
-                  {%- set pref_use_today_grouping = pref_use_today_grouping | default(true, true) -%}
-                  {%- set pref_include_daily_recurring_in_today = pref_include_daily_recurring_in_today | default(true, true) -%}
-                  {%- set pref_use_this_week_grouping = pref_use_this_week_grouping | default(true, true) -%}
+                  {%- set pref_use_overdue_grouping = (pref_use_overdue_grouping | default('true') | string | lower) == 'true' -%}
+                  {%- set pref_use_today_grouping = (pref_use_today_grouping | default('true') | string | lower) == 'true' -%}
+                  {%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default('true') | string | lower) == 'true' -%}
+                  {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
 
-                  {%- set pref_exclude_completed = pref_exclude_completed | default(false, true) -%}
+                  {%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
                   {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable else [] -%}
                   {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
                   {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
                     {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
                   {%- endif -%}
-                  {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+                  {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default('false') | string | lower) == 'true' -%}
                   {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
                   {%- if pref_max_due_date_days < 0 -%}
                     {%- set pref_max_due_date_days = 0 -%}
@@ -299,7 +299,7 @@ views:
                     {%- endif -%}
                   {%- endfor -%}
                   {%- set pref_exclude_group_list = ns_group_filter.valid -%}
-                  {%- set pref_use_label_grouping = pref_use_label_grouping | default(false, true) -%}
+                  {%- set pref_use_label_grouping = (pref_use_label_grouping | default('false') | string | lower) == 'true' -%}
                   {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable else [] -%}
                   {%- set pref_include_label_list = pref_include_label_list if pref_include_label_list is iterable else [] -%}
                   {%- set pref_include_group_list = pref_include_group_list if pref_include_group_list is iterable and pref_include_group_list is not string else [] -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-essential-v1.yaml
@@ -218,8 +218,6 @@ views:
 
                   {%- set pref_use_this_week_grouping = true -%}  {#-- Allowed: true, false --#}
 
-                  {%- set pref_include_weekly_recurring_in_this_week = true -%}  {#-- Allowed: true, false --#}
-
                   {%- set pref_use_standby_grouping = true -%}  {#-- Allowed: true, false --#}
 
 
@@ -280,7 +278,7 @@ views:
                   {%- set pref_use_today_grouping = pref_use_today_grouping | default(true, true) -%}
                   {%- set pref_include_daily_recurring_in_today = pref_include_daily_recurring_in_today | default(true, true) -%}
                   {%- set pref_use_this_week_grouping = pref_use_this_week_grouping | default(true, true) -%}
-                  {%- set pref_include_weekly_recurring_in_this_week = pref_include_weekly_recurring_in_this_week | default(true, true) -%}
+
                   {%- set pref_exclude_completed = pref_exclude_completed | default(false, true) -%}
                   {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable else [] -%}
                   {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
@@ -422,12 +420,8 @@ views:
                             {%- set ns.standby_buttons = ns.standby_buttons + [chore_sensor_id] -%}
 
                           {#-- Step 5: Handle recurring filters BEFORE primary_group logic (override primary_group assignment) --#}
-                          {#-- If a chore is in 'today' group without specific date, it's daily recurring --#}
-                          {%- elif chore_primary_group == 'today' and not pref_include_daily_recurring_in_today -%}
-                            {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
-
-                          {#-- If a chore is in 'this_week' group without specific date, it's weekly recurring --#}
-                          {%- elif chore_primary_group == 'this_week' and not pref_include_weekly_recurring_in_this_week -%}
+                          {#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
+                          {%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
                             {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
 
                           {#-- Step 6: Categorize by primary_group (time-based) --#}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -201,12 +201,12 @@ views:
 
 
                     {#-- Type coercion for preferences --#}
-                    {%- set pref_use_overdue_grouping = pref_use_overdue_grouping | default(true, true) -%}
+                    {%- set pref_use_overdue_grouping = (pref_use_overdue_grouping | default('true') | string | lower) == 'true' -%}
                     {%- set pref_today_grouping_mode = pref_today_grouping_mode | default('today_morning', true) -%}
-                    {%- set pref_include_daily_recurring_in_today = pref_include_daily_recurring_in_today | default(true, true) -%}
-                    {%- set pref_use_this_week_grouping = pref_use_this_week_grouping | default(true, true) -%}
-                    {%- set pref_exclude_completed = pref_exclude_completed | default(false, true) -%}
-                    {%- set pref_exclude_blocked = pref_exclude_blocked | default(false, true) -%}
+                    {%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default('true') | string | lower) == 'true' -%}
+                    {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
+                    {%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
+                    {%- set pref_exclude_blocked = (pref_exclude_blocked | default('false') | string | lower) == 'true' -%}
                     {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable else [] -%}
                     {%- set pref_exclude_states = pref_exclude_states | map('lower') | list -%}
                     {%- if pref_exclude_completed and 'completed' not in pref_exclude_states -%}
@@ -219,7 +219,7 @@ views:
                         {%- endif -%}
                       {%- endfor -%}
                     {%- endif -%}
-                    {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+                    {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default('false') | string | lower) == 'true' -%}
                     {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
                     {%- if pref_max_due_date_days < 0 -%}
                       {%- set pref_max_due_date_days = 0 -%}
@@ -233,7 +233,7 @@ views:
                       {%- endif -%}
                     {%- endfor -%}
                     {%- set pref_exclude_group_list = ns_group_filter.valid -%}
-                    {%- set pref_use_label_grouping = pref_use_label_grouping | default(false, true) -%}
+                    {%- set pref_use_label_grouping = (pref_use_label_grouping | default('false') | string | lower) == 'true' -%}
                     {%- set pref_exclude_label_list = pref_exclude_label_list if pref_exclude_label_list is iterable else [] -%}
                     {%- set pref_include_label_list = pref_include_label_list if pref_include_label_list is iterable else [] -%}
                     {%- set pref_include_group_list = pref_include_group_list if pref_include_group_list is iterable and pref_include_group_list is not string else [] -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -164,8 +164,6 @@ views:
 
                     {%- set pref_use_this_week_grouping = true -%}  {#-- Allowed: true, false --#}
 
-                    {%- set pref_include_weekly_recurring_in_this_week = true -%}  {#-- Allowed: true, false --#}
-
 
                     {#-- ── Exclude Filters ──────────────────────────────────────────────── --#}
 
@@ -207,7 +205,6 @@ views:
                     {%- set pref_today_grouping_mode = pref_today_grouping_mode | default('today_morning', true) -%}
                     {%- set pref_include_daily_recurring_in_today = pref_include_daily_recurring_in_today | default(true, true) -%}
                     {%- set pref_use_this_week_grouping = pref_use_this_week_grouping | default(true, true) -%}
-                    {%- set pref_include_weekly_recurring_in_this_week = pref_include_weekly_recurring_in_this_week | default(true, true) -%}
                     {%- set pref_exclude_completed = pref_exclude_completed | default(false, true) -%}
                     {%- set pref_exclude_blocked = pref_exclude_blocked | default(false, true) -%}
                     {%- set pref_exclude_states = pref_exclude_states if pref_exclude_states is iterable else [] -%}
@@ -338,10 +335,8 @@ views:
                               {%- set ns.visible_count = ns.visible_count + 1 -%}
                             {%- elif pref_use_label_grouping and (chore_labels | default([], true) | list | length > 0) -%}
                               {%- set ns.label_group_candidates = ns.label_group_candidates + [{'eid': chore_sensor_id, 'labels': chore_labels}] -%}
-                            {%- elif chore_primary_group == 'today' and not pref_include_daily_recurring_in_today -%}
-                              {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
-                              {%- set ns.visible_count = ns.visible_count + 1 -%}
-                            {%- elif chore_primary_group == 'this_week' and not pref_include_weekly_recurring_in_this_week -%}
+                            {#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
+                            {%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
                               {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
                               {%- set ns.visible_count = ns.visible_count + 1 -%}
                             {%- elif chore_primary_group == 'today' and pref_today_grouping_mode == 'today_morning' and chore_is_today_am == true -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -213,7 +213,7 @@ views:
                       {%- set pref_exclude_states = pref_exclude_states + ['completed'] -%}
                     {%- endif -%}
                     {%- if pref_exclude_blocked -%}
-                      {%- for blocked_state in ['completed_by_other', 'not_my_turn', 'paused', 'missed'] -%}
+                      {%- for blocked_state in ['completed_by_other', 'not_my_turn', 'paused', 'missed', 'standby'] -%}
                         {%- if blocked_state not in pref_exclude_states -%}
                           {%- set pref_exclude_states = pref_exclude_states + [blocked_state] -%}
                         {%- endif -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-lite-v1.yaml
@@ -335,8 +335,8 @@ views:
                               {%- set ns.visible_count = ns.visible_count + 1 -%}
                             {%- elif pref_use_label_grouping and (chore_labels | default([], true) | list | length > 0) -%}
                               {%- set ns.label_group_candidates = ns.label_group_candidates + [{'eid': chore_sensor_id, 'labels': chore_labels}] -%}
-                            {#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
-                            {%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
+                            {#-- Daily-recurring chores in the today bucket (dated or dateless) move to other when disabled --#}
+                            {%- elif chore_primary_group == 'today' and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
                               {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
                               {%- set ns.visible_count = ns.visible_count + 1 -%}
                             {%- elif chore_primary_group == 'today' and pref_today_grouping_mode == 'today_morning' and chore_is_today_am == true -%}

--- a/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-chores-standard-v1.yaml
@@ -264,8 +264,6 @@ views:
 
                   {%- set pref_use_this_week_grouping = true -%}  {#-- Allowed: true, false --#}
 
-                  {%- set pref_include_weekly_recurring_in_this_week = true -%}  {#-- Allowed: true, false --#}
-
                   {%- set pref_use_standby_grouping = true -%}  {#-- Allowed: true, false --#}
 
 

--- a/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-gamification-premier-v1.yaml
@@ -261,8 +261,6 @@ views:
 
                   {%- set pref_use_this_week_grouping = true -%}  {#-- Allowed: true, false --#}
 
-                  {%- set pref_include_weekly_recurring_in_this_week = true -%}  {#-- Allowed: true, false --#}
-
                   {%- set pref_use_standby_grouping = true -%}  {#-- Allowed: true, false --#}
 
 

--- a/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
@@ -206,7 +206,7 @@ views:
                   {%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default('true') | string | lower) == 'true' -%}
                   {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
                   {%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
-                  {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
+                  {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default('false') | string | lower) == 'true' -%}
                   {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
                   {%- if pref_max_due_date_days < 0 -%}
                     {%- set pref_max_due_date_days = 0 -%}

--- a/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
@@ -332,8 +332,8 @@ views:
                             {%- set ns.label_group_candidates = ns.label_group_candidates + [{'eid': chore_sensor_id, 'labels': chore_labels}] -%}
 
                           {#-- Step 5: Handle recurring filters BEFORE primary_group logic (override primary_group assignment) --#}
-                          {#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
-                          {%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
+                          {#-- Daily-recurring chores in the today bucket (dated or dateless) move to other when disabled --#}
+                          {%- elif chore_primary_group == 'today' and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
                             {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
 
                           {#-- Step 6: Categorize by primary_group (time-based) --#}

--- a/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
+++ b/custom_components/choreops/dashboards/templates/user-kidschores-classic-v1.yaml
@@ -167,8 +167,6 @@ views:
 
                   {%- set pref_use_this_week_grouping = true -%}  {#-- Allowed: true, false --#}
 
-                  {%- set pref_include_weekly_recurring_in_this_week = true -%}  {#-- Allowed: true, false --#}
-
 
                   {#-- ── Exclude Filters ──────────────────────────────────────────────── --#}
 
@@ -207,7 +205,6 @@ views:
                   {%- set pref_use_today_grouping = (pref_use_today_grouping | default('true') | string | lower) == 'true' -%}
                   {%- set pref_include_daily_recurring_in_today = (pref_include_daily_recurring_in_today | default('true') | string | lower) == 'true' -%}
                   {%- set pref_use_this_week_grouping = (pref_use_this_week_grouping | default('true') | string | lower) == 'true' -%}
-                  {%- set pref_include_weekly_recurring_in_this_week = (pref_include_weekly_recurring_in_this_week | default('true') | string | lower) == 'true' -%}
                   {%- set pref_exclude_completed = (pref_exclude_completed | default('false') | string | lower) == 'true' -%}
                   {%- set pref_exclude_nonrecurring_no_due_date = (pref_exclude_nonrecurring_no_due_date | default(false, true) | string | lower) == 'true' -%}
                   {%- set pref_max_due_date_days = pref_max_due_date_days | int(default=0) -%}
@@ -335,12 +332,8 @@ views:
                             {%- set ns.label_group_candidates = ns.label_group_candidates + [{'eid': chore_sensor_id, 'labels': chore_labels}] -%}
 
                           {#-- Step 5: Handle recurring filters BEFORE primary_group logic (override primary_group assignment) --#}
-                          {#-- If a chore is in 'today' group without specific date, it's daily recurring --#}
-                          {%- elif chore_primary_group == 'today' and not pref_include_daily_recurring_in_today -%}
-                            {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
-
-                          {#-- If a chore is in 'this_week' group without specific date, it's weekly recurring --#}
-                          {%- elif chore_primary_group == 'this_week' and not pref_include_weekly_recurring_in_this_week -%}
+                          {#-- Only no-due-date daily chores can land in 'today' without a date (weekly requires a due date) --#}
+                          {%- elif chore_primary_group == 'today' and chore_due_date in [none, 'unknown', 'unavailable'] and chore_recurring_frequency == 'daily' and not pref_include_daily_recurring_in_today -%}
                             {%- set ns.other_buttons = ns.other_buttons + [chore_sensor_id] -%}
 
                           {#-- Step 6: Categorize by primary_group (time-based) --#}

--- a/tests/test_chore_manager.py
+++ b/tests/test_chore_manager.py
@@ -637,6 +637,7 @@ class TestResetExecutor:
             const.CHORE_STATE_PENDING,
             reset_approval_period=True,
             clear_ownership=True,
+            persist=True,
         )
         chore_manager._reschedule_chore_due.assert_called_once_with(
             "chore-1", "assignee-1"
@@ -897,7 +898,8 @@ class TestResetExecutor:
                 "reschedule_assignee_id": "assignee-1",
                 "allow_reschedule": True,
                 "clear_due_date": False,
-            }
+            },
+            persist=True,
         )
 
     @pytest.mark.asyncio

--- a/tests/test_dashboard_recurring_grouping_contract.py
+++ b/tests/test_dashboard_recurring_grouping_contract.py
@@ -6,11 +6,10 @@ from pathlib import Path
 
 TEMPLATES_ROOT = Path("custom_components/choreops/dashboards/templates")
 
-# Step 5 daily-recurring discriminator: only no-due-date daily chores may be
-# relocated when pref_include_daily_recurring_in_today is false.
+# Step 5 daily-recurring filter: all daily chores in the today bucket (dated
+# or dateless) are relocated when pref_include_daily_recurring_in_today is false.
 DAILY_DISCRIMINATOR = (
     "chore_primary_group == 'today' and "
-    "chore_due_date in [none, 'unknown', 'unavailable'] and "
     "chore_recurring_frequency == 'daily' and "
     "not pref_include_daily_recurring_in_today"
 )
@@ -31,16 +30,16 @@ def _read_template(name: str) -> str:
     return (TEMPLATES_ROOT / name).read_text(encoding="utf-8")
 
 
-def test_shared_prepare_groups_gates_daily_filter_on_no_due_date() -> None:
-    """Shared chore engine relocates only no-due-date daily chores."""
+def test_shared_prepare_groups_gates_daily_filter_on_frequency() -> None:
+    """Shared chore engine relocates daily chores from the today bucket."""
     content = _read_template("shared/chore_engine/prepare_groups_v1.yaml")
 
     assert DAILY_DISCRIMINATOR in content
     assert REMOVED_WEEKLY_PREF not in content
 
 
-def test_inline_templates_gate_daily_filter_on_no_due_date() -> None:
-    """Inline grouping templates relocate only no-due-date daily chores."""
+def test_inline_templates_gate_daily_filter_on_frequency() -> None:
+    """Inline grouping templates relocate daily chores from the today bucket."""
     for template_name in INLINE_STEP5_TEMPLATES:
         content = _read_template(template_name)
         assert DAILY_DISCRIMINATOR in content, template_name

--- a/tests/test_dashboard_recurring_grouping_contract.py
+++ b/tests/test_dashboard_recurring_grouping_contract.py
@@ -1,0 +1,75 @@
+"""Contract tests for dashboard recurring-filter grouping (issue #272)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TEMPLATES_ROOT = Path("custom_components/choreops/dashboards/templates")
+
+# Step 5 daily-recurring discriminator: only no-due-date daily chores may be
+# relocated when pref_include_daily_recurring_in_today is false.
+DAILY_DISCRIMINATOR = (
+    "chore_primary_group == 'today' and "
+    "chore_due_date in [none, 'unknown', 'unavailable'] and "
+    "chore_recurring_frequency == 'daily' and "
+    "not pref_include_daily_recurring_in_today"
+)
+
+# Removed in favor of pref_exclude_group_list: no chore can be in 'this_week'
+# without a due date, so a weekly-recurring filter can never match.
+REMOVED_WEEKLY_PREF = "pref_include_weekly_recurring_in_this_week"
+
+INLINE_STEP5_TEMPLATES = (
+    "user-chores-essential-v1.yaml",
+    "user-chores-lite-v1.yaml",
+    "user-kidschores-classic-v1.yaml",
+)
+
+
+def _read_template(name: str) -> str:
+    """Read a vendored dashboard template file."""
+    return (TEMPLATES_ROOT / name).read_text(encoding="utf-8")
+
+
+def test_shared_prepare_groups_gates_daily_filter_on_no_due_date() -> None:
+    """Shared chore engine relocates only no-due-date daily chores."""
+    content = _read_template("shared/chore_engine/prepare_groups_v1.yaml")
+
+    assert DAILY_DISCRIMINATOR in content
+    assert REMOVED_WEEKLY_PREF not in content
+
+
+def test_inline_templates_gate_daily_filter_on_no_due_date() -> None:
+    """Inline grouping templates relocate only no-due-date daily chores."""
+    for template_name in INLINE_STEP5_TEMPLATES:
+        content = _read_template(template_name)
+        assert DAILY_DISCRIMINATOR in content, template_name
+        assert REMOVED_WEEKLY_PREF not in content, template_name
+
+
+def test_weekly_pref_removed_from_all_templates_and_defaults() -> None:
+    """Weekly recurring pref is fully removed from templates and coercion."""
+    for template_name in (
+        "user-chores-essential-v1.yaml",
+        "user-chores-lite-v1.yaml",
+        "user-chores-standard-v1.yaml",
+        "user-gamification-premier-v1.yaml",
+        "user-kidschores-classic-v1.yaml",
+        "shared/chore_engine/context_v1.yaml",
+    ):
+        assert REMOVED_WEEKLY_PREF not in _read_template(template_name), template_name
+
+
+def test_weekly_pref_removed_from_preference_docs() -> None:
+    """Preference docs drop the weekly pref and clarify daily pref scope."""
+    for doc_name in (
+        "user-chores-essential-v1.md",
+        "user-chores-lite-v1.md",
+        "user-chores-standard-v1.md",
+        "user-gamification-premier-v1.md",
+        "user-kidschores-classic-v1.md",
+    ):
+        doc_path = Path("custom_components/choreops/dashboards/preferences") / doc_name
+        content = doc_path.read_text(encoding="utf-8")
+        assert REMOVED_WEEKLY_PREF not in content, doc_name
+        assert "no-due-date recurring daily chores" in content, doc_name

--- a/tests/test_dashboard_recurring_grouping_contract.py
+++ b/tests/test_dashboard_recurring_grouping_contract.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 TEMPLATES_ROOT = Path("custom_components/choreops/dashboards/templates")
+PREFERENCES_ROOT = Path("custom_components/choreops/dashboards/preferences")
 
 # Step 5 daily-recurring filter: all daily chores in the today bucket (dated
 # or dateless) are relocated when pref_include_daily_recurring_in_today is false.
@@ -22,6 +24,17 @@ INLINE_STEP5_TEMPLATES = (
     "user-chores-essential-v1.yaml",
     "user-chores-lite-v1.yaml",
     "user-kidschores-classic-v1.yaml",
+)
+
+# Templates whose pref coercions must use the string-default pattern.
+# Jinja's default(x, true) boolean flag replaces FALSY values, so a
+# user-set false would be silently reset to the default. The string
+# default only substitutes for undefined inputs.
+COERCION_TEMPLATES = (
+    "user-chores-essential-v1.yaml",
+    "user-chores-lite-v1.yaml",
+    "user-kidschores-classic-v1.yaml",
+    "shared/chore_engine/context_v1.yaml",
 )
 
 
@@ -71,4 +84,39 @@ def test_weekly_pref_removed_from_preference_docs() -> None:
         doc_path = Path("custom_components/choreops/dashboards/preferences") / doc_name
         content = doc_path.read_text(encoding="utf-8")
         assert REMOVED_WEEKLY_PREF not in content, doc_name
-        assert "no-due-date recurring daily chores" in content, doc_name
+        assert "recurring daily chores" in content, doc_name
+
+
+def test_pref_coercions_use_string_default_pattern() -> None:
+    """YAML pref coercions preserve user-set false values."""
+    boolean_default = re.compile(r"pref_\w+ \| default\((?:true|false), true\)")
+    for template_name in COERCION_TEMPLATES:
+        content = _read_template(template_name)
+        assert not boolean_default.search(content), (
+            f"{template_name} uses boolean-default coercion which resets "
+            "user-set false values"
+        )
+
+
+def test_daily_pref_coercion_preserves_false() -> None:
+    """The daily pref coercion chain keeps a user-set false intact."""
+    import jinja2
+
+    env = jinja2.Environment()
+    for template_name in COERCION_TEMPLATES:
+        content = _read_template(template_name)
+        match = re.search(
+            r"set pref_include_daily_recurring_in_today = "
+            r"\(pref_include_daily_recurring_in_today ([^%]+?)\) == 'true' -%}",
+            content,
+        )
+        assert match, template_name
+        chain = f"(pref_include_daily_recurring_in_today {match.group(1)}) == 'true'"
+        rendered_false = env.from_string(
+            "{%- set pref_include_daily_recurring_in_today = false -%}"
+            f"{{%- set pref_include_daily_recurring_in_today = {chain} -%}}"
+            "{{ pref_include_daily_recurring_in_today }}"
+        ).render()
+        assert rendered_false == "False", (
+            f"{template_name} coercion resets user-set false to {rendered_false}"
+        )

--- a/tests/test_optional_select_field.py
+++ b/tests/test_optional_select_field.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from probatio import to_field_list
 import pytest
-import voluptuous_serialize
 
 from custom_components.choreops import const
 from custom_components.choreops.helpers.flow_helpers import build_user_schema
@@ -44,11 +44,10 @@ class TestOptionalSelectFieldValidation:
                 assignees_dict=assignees_dict,
             )
 
-        # This is what HA does to send schema to frontend
+        # This is what HA does to send schema to the frontend
+        # (homeassistant/helpers/data_entry_flow.py uses probatio.to_field_list)
         try:
-            serialized = voluptuous_serialize.convert(
-                schema, custom_serializer=cv.custom_serializer
-            )
+            serialized = to_field_list(schema, custom_serializer=cv.custom_serializer)
             assert serialized is not None, "Schema should serialize"
             assert len(serialized) > 0, "Schema should have fields"
         except Exception as e:


### PR DESCRIPTION
## Summary

Fixes three interacting dashboard preference bugs surfaced by #272 (originally in discussion #269) , where `pref_include_daily_recurring_in_today: false` had no effect. The reported pref was blocked by two deeper defects (coercion and override precedence); fixing those exposed a third (the grouping condition itself). Also removes a vestigial preference and includes two pre-existing test-suite fixes discovered during validation.

### Root causes fixed (in causal order)

**1. Boolean pref coercion silently reset user-set `false` values (the actual #272 blocker)**

Jinja's `default(x, true)` boolean flag replaces *falsy* values, not just undefined ones. The pref coercion chains used `(pref | default(true, true) | string | lower) == 'true'`, so a user-set `false` was replaced by `true` before any logic saw it — boolean prefs could never be disabled via YAML, in any version.

- Converted 24 YAML-pref coercion sites (`context_v1`, essential, lite, classic) to the string-default pattern `(pref | default('true') | string | lower) == 'true'`, which only substitutes for undefined inputs
- Runtime sensor reads (`gamification_enabled` etc.) intentionally untouched — their falsy-guard for missing attributes is correct
- Settings-panel toggle round-trip verified unaffected; reset-to-default buttons now behave correctly for false-default prefs

**2. Pref-level state baking defeated the ui_control toggles**

The shared engine appended `completed` and the blocked states to `pref_exclude_states` at the pref level, *before* the per-user ui_control override was resolved. With `pref_exclude_completed: true` in YAML, the toggle button flipped its label and stored the override correctly, but the exclusion list still contained `completed` — completed chores could never be shown.

- Removed the pref-level baking; the effective-level block (which respects the ui_control override) is now the single source of truth
- Extended the effective block to cover `paused` and `standby` from `exclude_blocked_effective` (previously pref-level only)
- Lite/essential keep their pref-level baking — they have no ui_control override system, so it is correct there

**3. The daily-recurring grouping filter over-fired**

With `pref_include_daily_recurring_in_today: false`, the Step 5 filter matched `primary_group == 'today'` alone, relocating every Today-bucket chore (dated chores due today, chores inside their due window, AM chores) into Later — not just daily-recurring chores.

- Step 5 now requires `chore_recurring_frequency == 'daily'` (frequency-based, matching the preference docs, which have no due-date qualifier). Dated daily chores are relocated too — they carry scheduler-populated per-assignee due dates, so a due-date-based gate would be a near-no-op
- Overdue chores are unaffected (Step 3 precedence), and the filter is not redundant with `pref_exclude_group_list` because it is frequency-based

**Removed: `pref_include_weekly_recurring_in_this_week`**

Since v1.0.1 (`84d1e75`), the integration requires a due date for every frequency except `none` and `daily`, and `_calculate_primary_group` no longer routes no-due-date weekly chores to `this_week`. The pref's documented behavior became impossible — no chore can be in `this_week` without a due date. Its only possible effect was hiding the entire Due This Week bucket, which `pref_exclude_group_list: ['this_week']` already covers. Users who set the pref in their YAML are unaffected; unknown preferences are ignored.

**Consistency: `pref_exclude_blocked` state list**

- Lite's blocked list now includes `standby`, matching the shared engine (standard/premier)
- Preference docs list the full state set (`completed_by_other`, `not_my_turn`, `paused`, `missed`, `standby`) and document the carve-out: claimable standbys (`can_claim`) are still shown; only standbys unavailable for claim are hidden

### Changes

**Dashboard assets** (synced from ccpk1/ChoreOps-Dashboards#50 — canonical source):
- `shared/chore_engine/context_v1.yaml` — string-default coercions, pref-level baking removed, effective-level block extended
- `shared/chore_engine/prepare_groups_v1.yaml` + 3 inline templates — frequency-based daily filter, weekly branch removed
- All 5 preference docs — weekly pref removed, daily pref scope clarified, blocked-state list and carve-out documented

**New tests** (`tests/test_dashboard_recurring_grouping_contract.py`):
- Shared engine and all 3 inline templates gate the daily filter on the daily-frequency check
- Weekly pref fully removed from templates and preference docs
- No `pref_*` coercion uses the boolean-default pattern
- The daily pref coercion chain preserves a user-set `false` (executed through Jinja)

**Pre-existing test fixes** (unrelated to #272, discovered during full-suite validation — separable commits for easy cherry-pick):
- `test: add persist=True to reset executor mock assertions` — PR #275 added the `persist` flag to `_apply_reset_action` and its call site; two exact-call mock assertions lagged
- `test: serialize flow schema via probatio to_field_list` — HA 2026.9 (home-assistant/core#175128) migrated flow schema serialization to probatio; `voluptuous_serialize.convert` now leaks a foreign `UNSUPPORTED` sentinel that crashes `len()` on new HA

## Behavior changes for release notes

- Dashboard YAML boolean preferences now respect explicit `false` values; previously some were silently ignored
- `pref_include_daily_recurring_in_today: false` now relocates all daily-recurring chores (including dated ones) from Today to Later; overdue chores remain in the Overdue group
- `pref_include_weekly_recurring_in_this_week` is removed (dead preference; use `pref_exclude_group_list: ['this_week']` to hide the Due This Week bucket)
- `pref_exclude_blocked` consistently includes `standby` across templates; claimable standbys remain visible
- Settings-panel toggles now correctly override `pref_exclude_completed` / `pref_exclude_blocked` set to `true` in YAML

## Linked issue

- Closes #272

## Main merge automation checks

- [x] PR body uses a closing keyword when applicable (`Closes #...`)
- [ ] Correct release-note label is applied for `.github/release.yml` categorization — needs `bug` label (maintainer to apply)
- [ ] Excluded triage or status labels have been removed before merge — `needs-triage` on #272 should be removed when this merges
- [x] PR title is suitable for generated release notes

## Change type

- [x] Bug fix
- [ ] Enhancement
- [ ] Refactor
- [ ] Documentation

## Scope

- [x] Dashboard/template behavior
- [ ] Integration logic/state
- [ ] Services/automations
- [x] Documentation/wiki — preference docs updated

## Dashboard source boundary

- [x] This PR does not introduce manual source edits under `custom_components/choreops/dashboards/` — all changes are byte-identical syncs from ChoreOps-Dashboards (parity check passed)
- [x] If dashboard source changes are needed, a corresponding PR is opened in `ccpk1/ChoreOps-Dashboards` — #50 (merged)

## Standards references

- [Architecture](../docs/ARCHITECTURE.md)
- [Development standards](../docs/DEVELOPMENT_STANDARDS.md)
- [Quality reference](../docs/QUALITY_REFERENCE.md)
- [Technical troubleshooting wiki](https://github.com/ccpk1/choreops/wiki/Technical:-Troubleshooting)

## Validation

- Full suite: **2033 passed**, 3 skipped, 0 failures
- `./utils/quick_lint.sh --fix`: all architectural boundaries validated
- Mypy (`--explicit-package-bases`): zero errors in 55 source files
- Dashboard asset parity check: passed (against merged dashboards `main`)
- Contract tests: 6 passed, including a Jinja-executed coercion-preservation test
- Manual verification in HA dev instance: `pref_include_daily_recurring_in_today: false` relocates daily chores to Later (overdue stay in Overdue); `pref_exclude_completed: true` + toggle now shows/hides completed chores correctly; `pref_exclude_blocked` carve-out verified for claimable standbys
