### PR TITLE
ci(l10n): add enable_mt input to translation sync workflow

### DIFF
--- a/.github/workflows/translation-sync-manual.yaml
+++ b/.github/workflows/translation-sync-manual.yaml
@@ -24,6 +24,11 @@ on:
         required: true
         type: string
         default: main
+      enable_mt:
+        description: "Trigger machine translation (MT) pre-translate step"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -92,8 +97,9 @@ jobs:
 
       # STEP 2: Trigger Google Translate (MT) via Crowdin CLI
       # This auto translate service has a cost associated with it, so it may be stopped or disabled in the future.
+      # Disable via workflow_dispatch input enable_mt=false to sync human translations only.
       - name: Trigger Google Translate
-        if: steps.crowdin_preflight.outputs.run_crowdin == 'true'
+        if: steps.crowdin_preflight.outputs.run_crowdin == 'true' && inputs.enable_mt
         run: |
           npm install -g @crowdin/cli
           crowdin pre-translate \


### PR DESCRIPTION
## Summary

Adds an `enable_mt` workflow_dispatch input (default `true`) to the translation sync workflow.

## Why

The npm-published `@crowdin/cli` dropped the `--method` flag, which breaks the machine-translation (MT) pre-translate step for **all** translation sync runs in both repos. Setting `enable_mt=false` skips the MT step so human translations from Crowdin can still be synced. MT remains enabled by default and can be used again once MT token budget is available.

Same fix already merged in ChoreOps-Dashboards (#51).

## Validation

- Workflow YAML validated locally
- Identical change merged and verified working in ChoreOps-Dashboards (no-MT sync run succeeded and produced a translation PR)